### PR TITLE
test & fix for mangled tagger names

### DIFF
--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -58,7 +58,7 @@ class TagObject(base.Object):
 			
 			self.tag = lines[2][4:]	 # tag <tag name>
 			
-			tagger_info = lines[3][7:]# tagger <actor> <date>
+			tagger_info = lines[3]# tagger <actor> <date>
 			self.tagger, self.tagged_date, self.tagger_tz_offset = parse_actor_and_date(tagger_info)
 			
 			# line 4 empty - it could mark the beginning of the next header

--- a/git/test/test_refs.py
+++ b/git/test/test_refs.py
@@ -49,6 +49,16 @@ class TestRefs(TestBase):
 		# END for tag in repo-tags
 		assert tag_object_refs
 		assert isinstance(self.rorepo.tags['0.1.5'], TagReference)
+
+
+	def test_tags_author(self):
+		tag = self.rorepo.tags[0]
+		tagobj = tag.tag
+		assert isinstance( tagobj.tagger, Actor )
+		tagger_name = tagobj.tagger.name
+		assert tagger_name == 'Michael Trier'
+
+
 		
 	def test_tags(self):
 		# tag refs can point to tag objects or to commits


### PR DESCRIPTION
I've found and fixed an issue where the tagger names where not parsed correctly.

The root cause was that the 'tagger' prefix was stripped before passed on to the parse_actor_and_date function, so the first name of the author was consumed by the RE instead. I've changed the code to pass the whole line to the parse_actor_and_date function, as it is done in git/objects/commit.py and it fixes the issue.
