### PR TITLE
Proposition to make comparisons between GitPython objects and non-GitPython objects possible.

### DIFF
--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -77,10 +77,14 @@ class Object(LazyMixin):
 		
 	def __eq__(self, other):
 		""":return: True if the objects have the same SHA1"""
+		if not hasattr(other, 'binsha'):
+			return False
 		return self.binsha == other.binsha
 		
 	def __ne__(self, other):
 		""":return: True if the objects do not have the same SHA1 """
+		if not hasattr(other, 'binsha'):
+			return True
 		return self.binsha != other.binsha
 		
 	def __hash__(self):


### PR DESCRIPTION
In order to be able to compare for instance None with a Commit, I'm suggesting that we check that 'other' has the attribute binsha before comparing. (also, see issue https://github.com/gitpython-developers/GitPython/issues/15).

Thanks.
