### PR TITLE
Handle indented comments in git config files (issue #17)

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -205,13 +205,14 @@ class GitConfigParser(cp.RawConfigParser, object):
 		optname = None
 		lineno = 0
 		e = None								  # None, or an exception
+		comment_re = re.compile('^\s*[#;]')
 		while True:
 			line = fp.readline()
 			if not line:
 				break
 			lineno = lineno + 1
 			# comment or blank line?
-			if line.strip() == '' or line[0] in '#;':
+			if line.strip() == '' or comment_re.match(line):
 				continue
 			if line.split(None, 1)[0].lower() == 'rem' and line[0] in "rR":
 				# no leading whitespace


### PR DESCRIPTION
It's perfectly valid for a git config file to contain comments inside
sections, e.g.:

```
[core]
    # This is a shared repository
    sharedRepository = true
```

The git tools all parse this fine while GitPython was choking on it.
