### PR TITLE
As the commit says, the current option regex only matches zero or one leading space, although the comments state that any number of leading spaces are allowed.

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -124,7 +124,7 @@ class GitConfigParser(cp.RawConfigParser, object):
 	#} END configuration 
 	
 	OPTCRE = re.compile(
-		r'\s?(?P<option>[^:=\s][^:=]*)'		  # very permissive, incuding leading whitespace
+		r'\s*(?P<option>[^:=\s][^:=]*)'		  # very permissive, incuding leading whitespace
 		r'\s*(?P<vi>[:=])\s*'				  # any number of space/tab,
 											  # followed by separator
 											  # (either : or =), followed


### PR DESCRIPTION
The regex comments state that any number of leading tabs or spaces
should be allowed, however the regex was only catching zero or one
space.  This allows multiple spaces.
