### PR TITLE
Fix another bug found by Fedora users, indented config sections.  Newer RawConfigParser handles them fine, as does git config.

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -216,6 +216,11 @@ class GitConfigParser(cp.RawConfigParser, object):
 			if line.split(None, 1)[0].lower() == 'rem' and line[0] in "rR":
 				# no leading whitespace
 				continue
+                        # continuation line?
+                        if line[0].isspace() and cursect is not None and optname:
+                            value = line.strip()
+                            if value:
+                                cursect[optname] = "%s\n%s" % (cursect[optname], value)
 			else:
 				# is it a section header?
 				mo = self.SECTCRE.match(line)


### PR DESCRIPTION
This brings over some new code from RawConfigParser that handles lines
that start with spaces but are also sections themselves, eg:

[color]
    ui = auto
  [color "branch"]

Previously this would cause a traceback.
(https://bugzilla.redhat.com/show_bug.cgi?id=706218)
