### PR TITLE
Strip the line when matching for sections

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -218,7 +218,7 @@ class GitConfigParser(cp.RawConfigParser, object):
 				continue
 			else:
 				# is it a section header?
-				mo = self.SECTCRE.match(line)
+				mo = self.SECTCRE.match(line.strip()) # strip the line to remove leading spaces
 				if mo:
 					sectname = mo.group('header')
 					if sectname in self._sections:


### PR DESCRIPTION
The SECTCRE regex does not seem to ignore leading spaces before a
section in the config and will cause a traceback.  However git itself
parses these files just fine.  Stripping the line resolves the issue.
https://bugzilla.redhat.com/show_bug.cgi?id=706218
