### PR TITLE
I think I found a bug in the diff('diff-against') function regarding reversing ordering...

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -79,12 +79,12 @@ class Diffable(object):
 		if paths is not None and not isinstance(paths, (tuple,list)):
 			paths = [ paths ]
 
+		args.insert(0,self)
+		
 		if other is not None and other is not self.Index:
 			args.insert(0, other)
 		if other is self.Index:
 			args.insert(0, "--cached")
-		
-		args.insert(0,self)
 		
 		# paths is list here or None
 		if paths:


### PR DESCRIPTION
Pull this repo: https://github.com/tomrittervg/Code-Audit-Feed-Test-Cases

Now do this:
$ python

> > > import git as pygit
> > > c = pygit.Repo('github.com-tomrittervg-Code-Audit-Feed-Test-Cases.git/')
> > > x = c.commit('4aee3ae658c1320619432817d63ec7adabf0f43a')
> > > p = [i for i in x.diff('HEAD~1')][0]

That is this commit: https://github.com/tomrittervg/Code-Audit-Feed-Test-Cases/commit/4aee3ae658c1320619432817d63ec7adabf0f43a
This is the addition of a single file.

Unless I'm misunderstanding git, as well as this documentation: http://packages.python.org/GitPython/0.3.1/tutorial.html#obtaining-diff-information

   tdiff = hcommit.diff('HEAD~1')  # diff tree against previous tree

x.diff('HEAD~1') ought to give a 'new_file' commit
But it was reversing the commit.

It ran this:
  git diff 4aee3ae658c1320619432817d63ec7adabf0f43a HEAD~1 --abbrev=40 --full-index --raw
producing
  :100644 000000 5f9b998a3e2916af6671a0f8d296ad7c1fe1490d 0000000000000000000000000000000000000000 D      api-call-test.c

When it should be running this:
  git diff HEAD~1 4aee3ae658c1320619432817d63ec7adabf0f43a --abbrev=40 --full-index --raw
producing this:
  :000000 100644 0000000000000000000000000000000000000000 5f9b998a3e2916af6671a0f8d296ad7c1fe1490d A      api-call-test.c

I changed the order of arguments to get it to give a file addition.  This would also affect which diff the a_blob and b_blob in a 'M' and how a 'R' behaves... I think.
