### PR TITLE
Ignore progress lines from the git http backend that start w/ POST ...

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -520,7 +520,7 @@ class Remote(LazyMixin, Iterable):
 		# Skip some progress lines that don't provide relevant information
 		fetch_info_lines = list()
 		for line in digest_process_messages(proc.stderr, progress):
-			if line.startswith('From') or line.startswith('remote: Total'):
+			if line.startswith('From') or line.startswith('remote: Total') or line.startswitch('POST'):
 				continue
 			elif line.startswith('warning:'):
 				print >> sys.stderr, line


### PR DESCRIPTION
A better way to implement this might be to enumerate the things you do want to count, rather than skipping ones you don't. In the meantime, this fixes the error I ran into on my server.
