### PR TITLE
Fixes on cmd.py (fd leak and signal exception)

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -87,6 +87,8 @@ class Git(LazyMixin):
 			# try to kill it
 			try:
 				os.kill(self.proc.pid, 2)	# interrupt signal
+			except OSError:
+			    pass # ignore error when process already died
 			except AttributeError:
 				# try windows 
 				# for some reason, providing None for stdout/stderr still prints something. This is why 


### PR DESCRIPTION
Hello,

I found some problems on cmd.py and tried to write fixes.
Please consider to merge.
### Fix fd leak on git cmd.

Currently if command is called with as_proces=True, pipes for the
command will not be closed.

cb68f36c9a2cd18a38e2b2c4630fd2131bfa3879 makes sure to close command file descriptors.
### Ignore signal exception on AutoInterrupt destructor.

When command run as subprocess, AutoInterrupt will kill the
process on destructor. However, if process already finished,
it raise OSError exception.

f467834059bb1297df97df4e03149cd2b48b81e3 fix just ignore OSError on os.kill.
