### PR TITLE
Fix GitPython on systems with language != english

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -337,12 +337,15 @@ class Git(LazyMixin):
 		  cwd=self._working_dir
 		  
 		# Start the process
+		env = os.environ.copy()
+		env['LANG'] = 'C'
 		proc = Popen(command,
 						cwd=cwd,
 						stdin=istream,
 						stderr=PIPE,
 						stdout=PIPE,
 						close_fds=(os.name=='posix'),# unsupported on linux
+						env=env,
 						**subprocess_kwargs
 						)
 		if as_process:


### PR DESCRIPTION
Currently GitPython only works on systems with language set to English. If the language is set to any other it fails silently.

This pull request provides a simple fix by settings the environment variable LANG to "C" for subprocess calls to the git executable.
