### PR TITLE
Add an output_strip kwarg to Git.execute

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -19,7 +19,7 @@ from subprocess import (
 
 execute_kwargs = ('istream', 'with_keep_cwd', 'with_extended_output',
 				  'with_exceptions', 'as_process', 
-				  'output_stream' )
+				  'output_stream', 'output_strip' )
 
 __all__ = ('Git', )
 
@@ -267,6 +267,7 @@ class Git(LazyMixin):
 				with_exceptions=True,
 				as_process=False, 
 				output_stream=None, 
+				output_strip=True,
 				**subprocess_kwargs
 				):
 		"""Handles executing the command on the shell and consumes and returns
@@ -308,6 +309,11 @@ class Git(LazyMixin):
 			always be created with a pipe due to issues with subprocess.
 			This merely is a workaround as data will be copied from the 
 			output pipe to the given output stream directly.
+			
+		:param output_strip:
+			Strip the last line of the output if it is empty (default). Stripping should
+			be disabled whenever it is important that the output is not modified in any
+			way. For example when retrieving patch files using git-diff.
 			
 		:param subprocess_kwargs:
 			Keyword arguments to be passed to subprocess.Popen. Please note that 
@@ -359,7 +365,7 @@ class Git(LazyMixin):
 			if output_stream is None:
 				stdout_value, stderr_value = proc.communicate() 
 				# strip trailing "\n"
-				if stdout_value.endswith("\n"):
+				if stdout_value.endswith("\n") and output_strip:
 					stdout_value = stdout_value[:-1]
 				if stderr_value.endswith("\n"):
 					stderr_value = stderr_value[:-1]

--- a/git/test/test_cmd.py
+++ b/git/test/test_cmd.py
@@ -108,3 +108,25 @@ class TestGit(TestBase):
 		finally:
 			type(self.git).GIT_PYTHON_GIT_EXECUTABLE = prev_cmd
 		#END undo adjustment
+		
+	def test_output_strip(self):
+		import subprocess as sp
+		hexsha = "b2339455342180c7cc1e9bba3e9f181f7baa5167"
+
+		# Verify that a trailing newline is stripped from the output of a git
+		# command.
+		content = self.git.cat_file('blob', hexsha)
+		g = self.git.hash_object(istream=sp.PIPE, as_process=True, stdin=True)
+		g.stdin.write(content)
+		g.stdin.close()
+		newsha = g.stdout.readline().strip()
+		self.assertNotEquals(newsha, hexsha)
+
+		# Verify that output of a git command which ends with an empty
+		# line is not modified when the output_strip flag is cleared.
+		content = self.git.cat_file('blob', hexsha, output_strip=False)
+		g = self.git.hash_object(istream=sp.PIPE, as_process=True, stdin=True)
+		g.stdin.write(content)
+		g.stdin.close()
+		newsha = g.stdout.readline().strip()
+		self.assertEquals(newsha, hexsha)


### PR DESCRIPTION
Strip the last line of the output if it is empty (default). Stripping should be disabled whenever it is important that the output is not modified in any way. For example when retrieving patch files using git-diff.
