### PR TITLE
Remove requires in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(name = "GitPython",
 	  package_data = {'git.test' : ['fixtures/*']},
 	  package_dir = {'git':'git'},
 	  license = "BSD License",
-	  requires=('gitdb (>=0.5.1)',),
 	  install_requires='gitdb >= 0.5.1',
 	  zip_safe=False,
 	  long_description = """\


### PR DESCRIPTION
The requires line in setup.py causes problems when uploading the package. The requires option is no longer used when using pip and distribute.
