### PR TITLE
Add stdout option to GitCommandError

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -378,7 +378,7 @@ class Git(LazyMixin):
 		# END handle debug printing
 
 		if with_exceptions and status != 0:
-			raise GitCommandError(command, status, stderr_value)
+			raise GitCommandError(command, status, stderr_value, stdout_value)
 
 		# Allow access to the command's status code
 		if with_extended_output:

--- a/git/exc.py
+++ b/git/exc.py
@@ -17,14 +17,15 @@ class NoSuchPathError(OSError):
 
 class GitCommandError(Exception):
 	""" Thrown if execution of the git command fails with non-zero status code. """
-	def __init__(self, command, status, stderr=None):
+	def __init__(self, command, status, stderr=None, stdout=None):
 		self.stderr = stderr
+		self.stdout = stdout
 		self.status = status
 		self.command = command
 		
 	def __str__(self):
 		return ("'%s' returned exit status %i: %s" %
-					(' '.join(str(i) for i in self.command), self.status, self.stderr))
+					(' '.join(str(i) for i in self.command), self.status, self.stderr, self.stdout))
 
 
 class CheckoutError( Exception ):


### PR DESCRIPTION
Add stdout option to GitCommandError to capture outputs other than to stderr. Should fix #90.
Tested with Python 2.7.
