### PR TITLE
Ignore fetch info if it starts with POST

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -534,6 +534,8 @@ class Remote(LazyMixin, Iterable):
 		# read head information 
 		fp = open(join(self.repo.git_dir, 'FETCH_HEAD'),'r')
 		fetch_head_info = fp.readlines()
+		if fetch_head_info[0].startswith('POST'):
+			fetch_head_info.pop(0)
 		fp.close()
 		
 		assert len(fetch_info_lines) == len(fetch_head_info), "len(%s) != len(%s)" % (fetch_head_info, fetch_info_lines)


### PR DESCRIPTION
I haven't gotten the tests to pass, I get:

```
  File "/home/medwards/forks/GitPython/git/test/lib/asserts.py", line 16, in <module>
    'assert_mode_755'] + tools.__all__
AttributeError: 'module' object has no attribute '__all__'
```

Where tools is from `from nose import tools`

So that's great.

I also haven't manually tested this but based on output I copied and pasted into #94 it should at least fix my part of the problem.
