### PR TITLE
Added support for separeted git dir.

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -32,6 +32,7 @@ from gitdb.util import (
 from fun import (
 					rev_parse,
 					is_git_dir,
+					read_gitfile,
 					touch
 				)
 
@@ -110,6 +111,11 @@ class Repo(object):
 				break
 			gitpath = join(curpath, '.git')
 			if is_git_dir(gitpath):
+				self.git_dir = gitpath
+				self._working_tree_dir = curpath
+				break
+			gitpath = read_gitfile(gitpath)
+			if gitpath:
 				self.git_dir = gitpath
 				self._working_tree_dir = curpath
 				break

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -30,6 +30,17 @@ def is_git_dir(d):
 				os.readlink(headref).startswith('refs'))
 	return False
 
+def read_gitfile(f):
+	""" This is taken from the git setup.c:read_gitfile function.
+	:return gitdir path or None if gitfile is invalid."""
+	
+	if not isfile(f):
+		return None
+	line = open(f, 'r').readline().rstrip()
+	if line[0:8] != 'gitdir: ':
+		return None
+	path = os.path.realpath(line[8:])
+	return path if is_git_dir(path) else None
 
 def short_to_long(odb, hexsha):
 	""":return: long hexadecimal sha1 from the given less-than-40 byte hexsha


### PR DESCRIPTION
Git-init command supported --separate-git-dir option.
The repository initialized with this option manage the repository by using .git file instead of the .git directory.

I added support for these type repositories.
