### PR TITLE
Fixed 'path not defined' error when referencing remote_name of non-remote branch

### DIFF
--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -18,7 +18,7 @@ def require_remote_ref_path(func):
 	"""A decorator raising a TypeError if we are not a valid remote, based on the path"""
 	def wrapper(self, *args):
 		if not self.path.startswith(self._remote_common_path_default + "/"):
-			raise ValueError("ref path does not point to a remote reference: %s" % path)
+			raise ValueError("ref path does not point to a remote reference: %s" % self.path)
 		return func(self, *args)
 	#END wrapper
 	wrapper.__name__ = func.__name__


### PR DESCRIPTION
The 'path' variable is an attribute of self
