### PR TITLE
Add isremote method to refs

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -368,6 +368,10 @@ class SymbolicReference(object):
 			In that case, it will be faster than the ``log()`` method"""
 		return RefLog.entry_at(RefLog.path(self), index)
 
+        def isremote(self):
+                """:return: (boolean) Is the reference to a remote branch"""
+                return self.path.startswith(self._remote_common_path_default + "/")
+
 	@classmethod
 	def to_full_path(cls, path):
 		"""


### PR DESCRIPTION
Adds an easy interface to determine if a reference is a remote reference or a local reference
