### PR TITLE
Fix typo in tutorial

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -146,9 +146,9 @@ Index Objects are objects that can be put into git's index. These objects are tr
     ''
     hct.trees[0].path   # the first subdirectory has one though
     'dir'
-    htc.mode            # trees have the mode of a linux directory
+    oct(htc.mode)       # trees have the mode of a linux directory
     040000
-    '%o' % htc.blobs[0].mode    # blobs have a specific mode though comparable to a standard linux fs
+    oct(htc.blobs[0].mode)    # blobs have a specific mode though comparable to a standard linux fs
     100644
     
 Access blob data (or any object data) directly or using streams::


### PR DESCRIPTION
I fixed typo and wrong representation of tree mode in tutorial.
`htc` is a obvious typo of `hct` and `hct.mode` is an octal value, so it must be 16384, not 040000 without `oct()`.

( Thanks to @Kroisse - https://github.com/gitpython-developers/GitPython/pull/115/files#pullrequestreviewcomment-5469388 )
