### PR TITLE
Avoid spawning console windows when running from .pyw

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -336,6 +336,7 @@ class Git(LazyMixin):
 						stderr=PIPE,
 						stdout=PIPE,
 						close_fds=(os.name=='posix'),# unsupported on linux
+						shell=True,
 						**subprocess_kwargs
 						)
 		if as_process:


### PR DESCRIPTION
I'm developing a small background application (Windows + PyQt) to track Git repositories.

The GitPython module works great, but when called from a windowless script (.pyw) each command spawns a console window. Those windows are empty and last only a second, but I think they should not be there at all.

I saw it was using `Popen` to call the `git` executable and added a `shell=True` parameter to avoid spawning those windows.

Be aware I haven't tested this on other machines or operating systems.
