### PR TITLE
Partial fix to issue #142

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -521,7 +521,7 @@ class Remote(LazyMixin, Iterable):
         fetch_info_lines = list()
         seen_refs = set()
         for line in digest_process_messages(proc.stderr, progress):
-            if line.startswith('From') or line.startswith('remote: Total'):
+            if line.startswith('From') or line.startswith('remote: Total') or line.startswith('POST'):
                 continue
             elif line.startswith('warning:'):
                 print >> sys.stderr, line


### PR DESCRIPTION
Introduces a new, different error:

```
Traceback (most recent call last):
  File "test.py", line 188, in test_simple_conflict
    commit2 = bizarro.repo.save_working_file(*args2)
  File "/Users/migurski/Sites/tmp/CMS/bizarro/repo.py", line 77, in save_working_file
    clone.remotes.origin.push(clone.active_branch.name)
  File "/Users/migurski/Sites/tmp/CMS/venv-cms/lib/python2.7/site-packages/git/repo/base.py", line 551, in active_branch
    return self.head.reference
  File "/Users/migurski/Sites/tmp/CMS/venv-cms/lib/python2.7/site-packages/git/refs/symbolic.py", line 244, in _get_reference
    raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
TypeError: HEAD is a detached symbolic reference as it points to '320ac0ab2ed85f0e65ad734e2a72863a526db5be'
```
