### PR TITLE
Fix typo in untracked_files

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -535,7 +535,7 @@ class Repo(object):
         for line in proc.stdout:
             if not line.startswith(prefix):
                 continue
-            filename = line[len(preffix):].rstrip('\n')
+            filename = line[len(prefix):].rstrip('\n')
             # Special characters are escaped
             if filename[0] == filename[-1] == '"':
                 filename = filename[1:-1].decode('string_escape')


### PR DESCRIPTION
Fixed a typo which caused a crash in the untracked_files command.
