### PR TITLE
Support multiple refspecs in fetch.

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -583,6 +583,10 @@ class Remote(LazyMixin, Iterable):
             See also git-push(1).
             
             Taken from the git manual
+
+            Fetch supports multiple refspecs (as the
+            underlying git-fetch does) - supplying a list rather than a string
+            for 'refspec' will make use of this facility.
         :param progress: See 'push' method
         :param kwargs: Additional arguments to be passed to git-fetch
         :return:
@@ -593,7 +597,11 @@ class Remote(LazyMixin, Iterable):
             As fetch does not provide progress information to non-ttys, we cannot make 
             it available here unfortunately as in the 'push' method."""
         kwargs = add_progress(kwargs, self.repo.git, progress)
-        proc = self.repo.git.fetch(self, refspec, with_extended_output=True, as_process=True, v=True, **kwargs)
+        if isinstance(refspec, list):
+            args = refspec
+        else:
+            args = [refspec]
+        proc = self.repo.git.fetch(self, *args, with_extended_output=True, as_process=True, v=True, **kwargs)
         return self._get_fetch_info_from_stderr(proc, progress or RemoteProgress())
         
     def pull(self, refspec=None, progress=None, **kwargs):

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -199,6 +199,10 @@ class TestRemote(TestBase):
         # ... with respec and no target
         res = fetch_and_test(remote, refspec='master')
         assert len(res) == 1
+
+        # ... multiple refspecs
+        res = fetch_and_test(remote, refspec=['master', 'fred'])
+        assert len(res) == 1
         
         # add new tag reference
         rtag = TagReference.create(remote_repo, "1.0-RV_hello.there")


### PR DESCRIPTION
Git supports fetching many refs at once - support this in GitPython
too for more efficient operations when selectively mirroring
repositories.
