### PR TITLE
Ensure consistent output from git command

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -316,6 +316,9 @@ class Git(LazyMixin):
             if ouput_stream is True, the stdout value will be your output stream:
             * output_stream if extended_output = False
             * tuple(int(status), output_stream, str(stderr)) if extended_output = True
+
+            Note git is executed with LC_MESSAGES="C" to ensure consitent
+            output regardless of system language.
             
         :raise GitCommandError:
         
@@ -333,6 +336,7 @@ class Git(LazyMixin):
           
         # Start the process
         proc = Popen(command,
+                        env={"LC_MESSAGES": "C"},
                         cwd=cwd,
                         stdin=istream,
                         stderr=PIPE,


### PR DESCRIPTION
The git command output can vary by language which would cause assertions
errors when parsing the output.

On POSIX system the language used by git can be adjusted by LC_MESSAGES.
The special language 'C' is guaranteed to be always available and is
whatever default the software has been written in (usually english, the
case for git).

Thus passing LC_MESSAGES to Popen will ensure we receive from git a
consistent output regardless of the user preference.

Addresses #153
