### PR TITLE
Update the config parser using code from python2.7

### DIFF
--- a/git/test/fixtures/git_config
+++ b/git/test/fixtures/git_config
@@ -27,3 +27,8 @@
 [branch "mainline_performance"]
 	remote = mainline
 	merge = refs/heads/master
+[filter "indent"]
+	clean = indent
+	smudge = cat
+	# A vauleless option
+	required

--- a/git/test/test_config.py
+++ b/git/test/test_config.py
@@ -77,18 +77,22 @@ class TestConfig(TestBase):
         assert r_config._is_initialized == False
         for section in r_config.sections():
             num_sections += 1
-            for option in r_config.options(section):
-                num_options += 1
-                val = r_config.get(section, option)
-                val_typed = r_config.get_value(section, option)
-                assert isinstance(val_typed, (bool, long, float, basestring))
-                assert val
-                assert "\n" not in option
-                assert "\n" not in val
+            if section != 'filter "indent"':
+                for option in r_config.options(section):
+                    num_options += 1
+                    val = r_config.get(section, option)
+                    val_typed = r_config.get_value(section, option)
+                    assert isinstance(val_typed, (bool, long, float, basestring))
+                    assert val
+                    assert "\n" not in option
+                    assert "\n" not in val
 
-                # writing must fail
-                self.failUnlessRaises(IOError, r_config.set, section, option, None)
-                self.failUnlessRaises(IOError, r_config.remove_option, section, option)
+                    # writing must fail
+                    self.failUnlessRaises(IOError, r_config.set, section, option, None)
+                    self.failUnlessRaises(IOError, r_config.remove_option, section, option)
+            else:
+                val = r_config.get(section, 'required')
+                assert val is None
             # END for each option
             self.failUnlessRaises(IOError, r_config.remove_section, section)
         # END for each section


### PR DESCRIPTION
Notably this adds support for valueless options ( e.x. the option "required" which can be added to filters which must succeed.) Most of the code comes from the "allow_no_value" kwarg support added to ConfigParser in 2.7

This was created in response to GitPython erroring out on even the most simple tasks, because we've got a required filter in the global config.
