### PR TITLE
Fix `git push` hanging when stdout/stderr is big

### DIFF
--- a/git/db/cmd/base.py
+++ b/git/db/cmd/base.py
@@ -127,10 +127,11 @@ def get_push_info(repo, remotename_or_url, proc, progress):
     # we hope stdout can hold all the data, it should ...
     # read the lines manually as it will use carriage returns between the messages
     # to override the previous one. This is why we read the bytes manually
-    digest_process_messages(proc.stderr, progress)
+    stdout, stderr = proc.communicate()
+    digest_process_messages(StringIO(stderr), progress)
 
     output = IterableList('name')
-    for line in proc.stdout.readlines():
+    for line in stdout.splitlines():
         try:
             output.append(CmdPushInfo._from_line(repo, remotename_or_url, line))
         except ValueError:
@@ -139,7 +140,6 @@ def get_push_info(repo, remotename_or_url, proc, progress):
         # END exception handling
     # END for each line
 
-    finalize_process(proc)
     return output
 
 


### PR DESCRIPTION
Fixes GH-145

Sample program:

``` python
# test_git_push_hang.py
import git

repo = git.Repo('.')
remote = git.Remote(repo, 'origin')

remote.push(tags=True)
```

Without this change:

```
$ python test_git_push_hang.py
Pushing tags to remote...
(hangs indefinitely)
```

With this change:

```
$ python test_git_push_hang.py
Pushing tags to remote...
Tags pushed: 993
```

Cc: @byron, @sontek, @colinmsaunders, @willwagner, @monkeydiane

This is what seems to be causing our Doula builds to stall when git repos have a lot of tags. Hopefully this fixes that issue.
