### PR TITLE
Fixing issue #186: 'tuple index out of range' issue when uploading to private Pypi repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(name="GitPython",
       package_data={'git.test': ['fixtures/*']},
       package_dir={'git': 'git'},
       license="BSD License",
-      requires=('gitdb (>=0.5.1)',),
+      requires=['gitdb (>=0.5.1)',],
       install_requires='gitdb >= 0.5.1',
       zip_safe=False,
       long_description = """\


### PR DESCRIPTION
Fixing 'tuple index out of range' issue with distutils/command/upload.py (v2.7.7): the 'requires' field tuple should be a list(https://github.com/gitpython-developers/GitPython/issues/186)
