### PR TITLE
test_fetch_info error, FETCH_HEAD uses tabs

### DIFF
--- a/git/test/db/cmd/test_base.py
+++ b/git/test/db/cmd/test_base.py
@@ -37,7 +37,7 @@ class TestBase(RepoBase):
 
     def test_fetch_info(self):
         # assure we can handle remote-tracking branches
-        fetch_info_line_fmt = "c437ee5deb8d00cf02f03720693e4c802e99f390 not-for-merge   %s '0.3' of git://github.com/gitpython-developers/GitPython"
+        fetch_info_line_fmt = "c437ee5deb8d00cf02f03720693e4c802e99f390\tnot-for-merge\t%s '0.3' of git://github.com/gitpython-developers/GitPython"
         remote_info_line_fmt = "* [new branch]      nomatter     -> %s"
         fi = CmdFetchInfo._from_line(self.rorepo,
                                      remote_info_line_fmt % "local/master",


### PR DESCRIPTION
A small fix for test_base.py nose tests, the fetch_info_line_fmt was missing
the required tabs.
