### PR TITLE
GitRunCommand exception can store stdout output too.

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -380,7 +380,10 @@ class Git(LazyMixin):
         # END handle debug printing
 
         if with_exceptions and status != 0:
-            raise GitCommandError(command, status, stderr_value)
+            if with_extended_output:
+                raise GitCommandError(command, status, stderr_value, stdout_value)
+            else:
+                raise GitCommandError(command, status, stderr_value)
 
         # Allow access to the command's status code
         if with_extended_output:

--- a/git/exc.py
+++ b/git/exc.py
@@ -17,14 +17,18 @@ class NoSuchPathError(OSError):
 
 class GitCommandError(Exception):
     """ Thrown if execution of the git command fails with non-zero status code. """
-    def __init__(self, command, status, stderr=None):
+    def __init__(self, command, status, stderr=None, stdout=None):
         self.stderr = stderr
+        self.stdout = stdout
         self.status = status
         self.command = command
         
     def __str__(self):
-        return ("'%s' returned exit status %i: %s" %
-                    (' '.join(str(i) for i in self.command), self.status, self.stderr))
+        ret = "'%s' returned exit status %i: %s" % \
+              (' '.join(str(i) for i in self.command), self.status, self.stderr)
+        if self.stdout is not None:
+            ret += "\nstdout: %s" % self.stdout
+        return ret
 
 
 class CheckoutError( Exception ):


### PR DESCRIPTION
Some git commands, like git merge outputs their problems onto stdout,
instead of stderr, which will be thrown away by the current setup. This
change allows the GitPython commands to store the stdout's value too,
in case of error.
