### PR TITLE
tox commands now have {posargs} as argument

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,15 @@
 envlist = py26,py27,flake8
 
 [testenv]
-commands = nosetests
+commands = nosetests {posargs}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
 [testenv:cover]
-commands = nosetests --with-coverage
+commands = nosetests --with-coverage {posargs}
 
 [testenv:flake8]
-commands = flake8
+commands = flake8 {posargs}
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
When invoking an environement, one might want to pass extra argument to
the command. That is done in tox by invoking an env and passing the
extra arguments after '--' which are then available as '{posargs}'.

Examples:

  # Reports flake8 error statistics
  tox -eflake8 -- --statistics

  # Only run test_util.py tests, printing a line per test:
  tox -epy27 -- --verbose  git/test/test_util.py
