### PR TITLE
Remove Byte Order Mark from git/cmd.py

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1,4 +1,4 @@
-﻿# cmd.py
+# cmd.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under


### PR DESCRIPTION
The Unicode Byte Order Mark is usually unwanted. git/cmd.py had one
inserted in 2008 by cf37099e, a commit that fix a Windows related issue
which indicate the file has most probably be edited with a text editor
that automatically insert the Byte Order Mark.

Remove the BOM from git/cmd.py

For details aboute the BOM:
    https://en.wikipedia.org/wiki/Byte_order_mark
