### PR TITLE
Copy environment for subprocess execution

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -341,8 +341,10 @@ class Git(LazyMixin):
           cwd = self._working_dir
 
         # Start the process
+        env = os.environ.copy()
+        env["LC_MESSAGES"] = "C"
         proc = Popen(command,
-                        env={"LC_MESSAGES": "C"},
+                        env=env,
                         cwd=cwd,
                         stdin=istream,
                         stderr=PIPE,

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -5,6 +5,7 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
 import os
+import mock
 from git.test.lib import (TestBase,
                             patch,
                             raises,
@@ -128,3 +129,8 @@ class TestGit(TestBase):
 
     def test_change_to_transform_kwargs_does_not_break_command_options(self):
         self.git.log(n=1)
+
+    def test_env_vars_passed_to_git(self):
+        editor = 'non_existant_editor'
+        with mock.patch.dict('os.environ', {'GIT_EDITOR': editor}):
+            assert self.git.var("GIT_EDITOR") == editor


### PR DESCRIPTION
fixes #207 by ensuring the os.environ is copied before overriding LC_MESSAGES, in a similar manner to master.

Git utilizes multiple environment variables to control various
behaviours. Make sure to set LC_MESSAGES on a copy of the environment
instead of discarding any variables that may be set by the user or
default shell environment such as EDITOR.

Add test to assert that when overriding GIT_EDITOR via os.environ that
the modified value will be picked up by and git commands called.
