### PR TITLE
encode name of actor to utf-8

### DIFF
--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -37,8 +37,9 @@ class RefLogEntry(tuple):
     def __repr__(self):
         """Representation of ourselves in git reflog format"""
         act = self.actor
+        name = act.name.encode('utf-8')
         time = self.time
-        return self._fmt % (self.oldhexsha, self.newhexsha, act.name, act.email,
+        return self._fmt % (self.oldhexsha, self.newhexsha, name, act.email,
                             time[0], altz_to_utctz_str(time[1]), self.message)
 
     @property


### PR DESCRIPTION
I found we cannot write log message to reflog in UTF-8 in python 2.7.5.
We can easily to reproduce this bug by executing following code to empty repository.

``` python
repo = Repo(path_to_repository)
repo.create_head('test_head', logmsg='日本語')
```

In my environment, this code will throw following error:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

I think this bug was introduced by 4a7e7a769087b1790a18d6645740b5b670f5086b and 28fdf05b1d7827744b7b70eeb1cc66d3afd38c82.

I hope this PR fix this bug.
