### PR TITLE
BF: run commit hook with repo.working_dir as cwd

### DIFF
--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -72,6 +72,7 @@ def run_commit_hook(name, index):
                            env=env,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,
+                           cwd=index.repo.working_dir,
                            close_fds=(os.name == 'posix'))
     stdout, stderr = cmd.communicate()
     cmd.stdout.close()


### PR DESCRIPTION
Otherwise commit hook might rightfully fail, as happens if
repository is e.g. git-annex repository.  See e.g. now failing

https://travis-ci.org/datalad/datalad/builds/49802394\#L1590
which seems to pass tests nicely with patch as this.

P.S. I am still unclear WTF this doesn't fail for me locally where I do run recent GitPython now... 