### PR TITLE
Replace GIT_SSH with GIT_SSH_COMMAND for SSH key management.

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -331,12 +331,11 @@ You can easily access configuration information for a remote by accessing option
     :start-after: # [26-test_references_and_objects]
     :end-before: # ![26-test_references_and_objects]
 
-You can also specify per-call custom environments using a new context manager on the Git command
+You can also specify per-call custom environments using a new context manager on the Git command, e.g. for using a specific SSH key.
 
-.. literalinclude:: ../../git/test/test_docs.py
-    :language: python
-    :start-after: # [32-test_references_and_objects]
-    :end-before: # ![32-test_references_and_objects]    
+    ssh_cmd = 'ssh -i id_deployment_key'
+    with repo.git.custom_environment(GIT_SSH_COMMAND=ssh_cmd):
+        repo.remotes.origin.fetch()
     
 Submodule Handling
 ******************

--- a/git/test/test_docs.py
+++ b/git/test/test_docs.py
@@ -437,15 +437,6 @@ class Tutorials(TestBase):
         git.for_each_ref()                              # '-' becomes '_' when calling it
         # ![31-test_references_and_objects]
 
-        # [32-test_references_and_objects]
-        ssh_executable = os.path.join(rw_dir, 'my_ssh_executable.sh')
-        with repo.git.custom_environment(GIT_SSH=ssh_executable):
-            # Note that we don't actually make the call here, as our test-setup doesn't permit it to
-            # succeed.
-            # It will in your case :)
-            repo.remotes.origin.fetch
-        # ![32-test_references_and_objects]
-
     def test_submodules(self):
         # [1-test_submodules]
         repo = self.rorepo


### PR DESCRIPTION
Also move untestable documentation out of test.

Related: #234, #242