### PR TITLE
Store path attribute on Diff object

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -168,11 +168,13 @@ class Diff(object):
 
         a_mode is None
         a_blob is None
+        a_path is None
 
     ``Deleted File``::
 
         b_mode is None
         b_blob is None
+        b_path is None
 
     ``Working Tree Blobs``
 
@@ -200,8 +202,8 @@ class Diff(object):
     NULL_HEX_SHA = "0" * 40
     NULL_BIN_SHA = b"\0" * 20
 
-    __slots__ = ("a_blob", "b_blob", "a_mode", "b_mode", "new_file", "deleted_file",
-                 "rename_from", "rename_to", "diff")
+    __slots__ = ("a_blob", "b_blob", "a_mode", "b_mode", "a_path", "b_path",
+                 "new_file", "deleted_file", "rename_from", "rename_to", "diff")
 
     def __init__(self, repo, a_path, b_path, a_blob_id, b_blob_id, a_mode,
                  b_mode, new_file, deleted_file, rename_from,
@@ -209,6 +211,9 @@ class Diff(object):
 
         self.a_mode = a_mode
         self.b_mode = b_mode
+
+        self.a_path = a_path
+        self.b_path = b_path
 
         if self.a_mode:
             self.a_mode = mode_str_to_int(self.a_mode)


### PR DESCRIPTION
If a file in a commit contains no changes (for example, if only the
file mode is changed) there will be no blob attached.  This is
usually where the filename is stored, so without it, the calling
context can not tell what file was changed.  Instead, always
store a_path and b_path on the Diff object so that information
is available.