### PR TITLE
Fix broken worktree path with submodules on Windows

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -293,7 +293,8 @@ class Submodule(util.IndexObject, Iterable, Traversable):
         fp.close()
 
         writer = GitConfigParser(os.path.join(module_abspath, 'config'), read_only=False, merge_includes=False)
-        writer.set_value('core', 'worktree', os.path.relpath(working_tree_dir, start=module_abspath))
+        writer.set_value('core', 'worktree',
+                         to_native_path_linux(os.path.relpath(working_tree_dir, start=module_abspath)))
         writer.release()
 
     #{ Edit Interface


### PR DESCRIPTION
On Windows, `repo.create_submodule(...)` failed because git didn't recognize the worktree path set in `.git/modules/sub/config` (`fatal: bad config file line 6 in ./config`). This resulted in the following traceback:

```
Traceback (most recent call last):
  File "F:\Dokumente\Coding\python\PyGitUp\tests\test_submodules.py", line 42, in setup
    repo.create_submodule('sub', 'sub', master_path)
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\repo\base.py", line 295, in create_submodule
    return Submodule.add(self, *args, **kwargs)
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\objects\submodule\base.py", line 417, in add
    sm.binsha = mrepo.head.commit.binsha
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\refs\symbolic.py", line 182, in _get_commit
    obj = self._get_object()
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\refs\symbolic.py", line 175, in _get_object
    return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\objects\base.py", line 65, in new_from_sha
    oinfo = repo.odb.info(sha1)
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\db.py", line 40, in info
    hexsha, typename, size = self._git.get_object_header(bin_to_hex(sha))
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\cmd.py", line 866, in get_object_header
    return self.__get_object_header(cmd, ref)
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\cmd.py", line 855, in __get_object_header
    return self._parse_object_header(cmd.stdout.readline())
  File "F:\Dokumente\Coding\python\.virtualenv\PyGitUp\lib\site-packages\git\cmd.py", line 817, in _parse_object_header
    raise ValueError("SHA could not be resolved, git returned: %r" % (header_line.strip()))
ValueError: SHA could not be resolved, git returned: ''
```

This PR makes `_write_git_file_and_module_config` convert the worktree path to the linux format (forward slashes) which git recognizes.