### PR TITLE
fix(util): Handle 'Finding sources' messages in RemoteProgress

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -165,7 +165,7 @@ class RemoteProgress(object):
     and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
     """
     _num_op_codes = 7
-    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING = [1 << x for x in range(_num_op_codes)]
+    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES = [1 << x for x in range(_num_op_codes)]
     STAGE_MASK = BEGIN | END
     OP_MASK = ~STAGE_MASK
 
@@ -227,6 +227,8 @@ class RemoteProgress(object):
                 op_code |= self.RECEIVING
             elif op_name == 'Resolving deltas':
                 op_code |= self.RESOLVING
+            elif op_name == 'Finding sources':
+                op_code |= self.FINDING_SOURCES
             else:
                 # Note: On windows it can happen that partial lines are sent
                 # Hence we get something like "CompreReceiving objects", which is

--- a/git/util.py
+++ b/git/util.py
@@ -164,7 +164,7 @@ class RemoteProgress(object):
     Handler providing an interface to parse progress information emitted by git-push
     and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
     """
-    _num_op_codes = 7
+    _num_op_codes = 8
     BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES = [1 << x for x in range(_num_op_codes)]
     STAGE_MASK = BEGIN | END
     OP_MASK = ~STAGE_MASK


### PR DESCRIPTION
When running a long running operation (such as a clone on a large repo),
Git may return a message indicating that it is 'Finding sources'. Since
there is no bit field value for this message, this causes a large amount
of error messages to be emitted to stderr.

This patch fixes this by adding another bit field value for this
message, FINDING_SOURCES. Derived classes can look for this op_code and
handle it appropriately.