### PR TITLE
git-daemon test fixes

### DIFF
--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -200,7 +200,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
             temp_dir = osp(_mktemp())
             # On windows, this will fail ... we deal with failures anyway and default to telling the user to do it
             try:
-                gd = Git().daemon(temp_dir, enable='receive-pack', as_process=True)
+                gd = Git().daemon(temp_dir, enable='receive-pack', listen='127.0.0.1', as_process=True)
                 # yes, I know ... fortunately, this is always going to work if sleep time is just large enough
                 time.sleep(0.5)
             except Exception:

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -18,10 +18,11 @@ from git.compat import string_types
 osp = os.path.dirname
 
 GIT_REPO = os.environ.get("GIT_PYTHON_TEST_GIT_REPO_BASE", osp(osp(osp(osp(__file__)))))
+GIT_DAEMON_PORT = os.environ.get("GIT_PYTHON_TEST_GIT_DAEMON_PORT", "9418")
 
 __all__ = (
     'fixture_path', 'fixture', 'absolute_project_path', 'StringProcessAdapter',
-    'with_rw_repo', 'with_rw_and_rw_remote_repo', 'TestBase', 'TestCase', 'GIT_REPO'
+    'with_rw_repo', 'with_rw_and_rw_remote_repo', 'TestBase', 'TestCase', 'GIT_REPO', 'GIT_DAEMON_PORT'
 )
 
 #{ Routines
@@ -193,14 +194,15 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
             # by the user, not by us
             d_remote = Remote.create(rw_repo, "daemon_origin", remote_repo_dir)
             d_remote.fetch()
-            remote_repo_url = "git://localhost%s" % remote_repo_dir
+            remote_repo_url = "git://localhost:%s%s" % (GIT_DAEMON_PORT, remote_repo_dir)
 
             d_remote.config_writer.set('url', remote_repo_url)
 
             temp_dir = osp(_mktemp())
             # On windows, this will fail ... we deal with failures anyway and default to telling the user to do it
             try:
-                gd = Git().daemon(temp_dir, enable='receive-pack', listen='127.0.0.1', as_process=True)
+                gd = Git().daemon(temp_dir, enable='receive-pack', listen='127.0.0.1', port=GIT_DAEMON_PORT,
+                                  as_process=True)
                 # yes, I know ... fortunately, this is always going to work if sleep time is just large enough
                 time.sleep(0.5)
             except Exception:
@@ -223,6 +225,8 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
                     raise AssertionError(msg)
                 else:
                     msg = 'Please start a git-daemon to run this test, execute: git daemon --enable=receive-pack "%s"'
+                    msg += 'You can also run the daemon on a different port by passing --port=<port>'
+                    msg += 'and setting the environment variable GIT_PYTHON_TEST_GIT_DAEMON_PORT to <port>'
                     msg %= temp_dir
                     raise AssertionError(msg)
                 # END make assertion

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -8,7 +8,8 @@ from git.test.lib import (
     TestBase,
     with_rw_repo,
     with_rw_and_rw_remote_repo,
-    fixture
+    fixture,
+    GIT_DAEMON_PORT
 )
 from git import (
     RemoteProgress,
@@ -250,7 +251,7 @@ class TestRemote(TestBase):
         # must clone with a local path for the repo implementation not to freak out
         # as it wants local paths only ( which I can understand )
         other_repo = remote_repo.clone(other_repo_dir, shared=False)
-        remote_repo_url = "git://localhost%s" % remote_repo.git_dir
+        remote_repo_url = "git://localhost:%s%s" % (GIT_DAEMON_PORT, remote_repo.git_dir)
 
         # put origin to git-url
         other_origin = other_repo.remotes.origin


### PR DESCRIPTION
We are building packages in a sandbox that restricts network access somewhat.

Here are a couple of changes I made that should be generally useful.

a) make the git-daemon bind to localhost instead of 0.0.0.0 (aka all interfaces), as there's no reason it should be accessible from the outside
b) make the listen port configurable via an environment variable, in case it is already taken.