### PR TITLE
While parsing errors, also detecting lines starting with "error:"

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -555,7 +555,7 @@ class Remote(LazyMixin, Iterable):
             line = line.decode(defenc)
             line = line.rstrip()
             for pline in progress_handler(line):
-                if line.startswith('fatal:'):
+                if line.startswith('fatal:') or line.startswith('error:'):
                     raise GitCommandError(("Error when fetching: %s" % line,), 2)
                 # END handle special messages
                 for cmd in cmds:


### PR DESCRIPTION
Rigth now only the word "fatal:" is being checked but there are also errors that start with "error:", for example:

$ git pull origin master
From github.host.com/mycompany/repo
 * branch            master     -> FETCH_HEAD
Updating 49d7506..7de461c
error: Your local changes to the following files would be overwritten by merge:
	mydir/myfile.txt
Please, commit your changes or stash them before you can merge.
Aborting
