### PR TITLE
Added NullHandlers to all loggers to prevent "No handler" messages

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -44,6 +44,7 @@ execute_kwargs = ('istream', 'with_keep_cwd', 'with_extended_output',
                   'output_stream')
 
 log = logging.getLogger('git.cmd')
+log.addHandler(logging.NullHandler())
 
 __all__ = ('Git', )
 

--- a/git/config.py
+++ b/git/config.py
@@ -32,6 +32,7 @@ __all__ = ('GitConfigParser', 'SectionConstraint')
 
 
 log = logging.getLogger('git.config')
+log.addHandler(logging.NullHandler())
 
 
 class MetaParserBuilder(abc.ABCMeta):

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -34,6 +34,7 @@ from io import BytesIO
 import logging
 
 log = logging.getLogger('git.objects.commit')
+log.addHandler(logging.NullHandler())
 
 __all__ = ('Commit', )
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -43,6 +43,7 @@ __all__ = ["Submodule", "UpdateProgress"]
 
 
 log = logging.getLogger('git.objects.submodule.base')
+log.addHandler(logging.NullHandler())
 
 
 class UpdateProgress(RemoteProgress):

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -13,6 +13,7 @@ import logging
 __all__ = ["RootModule", "RootUpdateProgress"]
 
 log = logging.getLogger('git.objects.submodule.root')
+log.addHandler(logging.NullHandler())
 
 
 class RootUpdateProgress(UpdateProgress):


### PR DESCRIPTION
When the code is run without setting up loggers, the loggers have no
handlers for the emitted messages. The logging module displays:
`No handlers could be found for logger "git.cmd"` on the
console. By adding a NullHandler (a no-op) the message disappears,
and doesn't affect logging when other handlers are configured.