### PR TITLE
care tilde in include.path config

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -386,7 +386,7 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
             # We expect all paths to be normalized and absolute (and will assure that is the case)
             if self._has_includes():
                 for _, include_path in self.items('include'):
-                    if '~' in include_path:
+                    if include_path.startswith('~'):
                         include_path = os.path.expanduser(include_path)
                     if not os.path.isabs(include_path):
                         if not close_fp:

--- a/git/config.py
+++ b/git/config.py
@@ -386,6 +386,8 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
             # We expect all paths to be normalized and absolute (and will assure that is the case)
             if self._has_includes():
                 for _, include_path in self.items('include'):
+                    if '~' in include_path:
+                        include_path = os.path.expanduser(include_path)
                     if not os.path.isabs(include_path):
                         if not close_fp:
                             continue


### PR DESCRIPTION
According to the [git documentation](http://git-scm.com/docs/git-config), include.path is subject to tilde expansion.

> You can include one config file from another by setting the special include.path variable to the name of the file to be included. The included file is expanded immediately, as if its contents had been found at the location of the include directive. If the value of the include.path variable is a relative path, the path is considered to be relative to the configuration file in which the include directive was found. ***The value of include.path is subject to tilde expansion***: ~/ is expanded to the value of $HOME, and ~user/ to the specified user’s home directory. See below for examples.

So, I added to care code for tilde expansion.