### PR TITLE
Correct doc errors

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -464,7 +464,7 @@ class Repo(object):
             max_count and skip
 
         :note: to receive only commits between two named revisions, use the
-            "revA..revB" revision specifier
+            "revA...revB" revision specifier
 
         :return ``git.Commit[]``"""
         if rev is None:

--- a/git/test/test_docs.py
+++ b/git/test/test_docs.py
@@ -18,7 +18,7 @@ class Tutorials(TestBase):
         from git import Repo
         join = os.path.join
 
-        # rorepo is a a Repo instance pointing to the git-python repository.
+        # rorepo is a Repo instance pointing to the git-python repository.
         # For all you know, the first argument to Repo is a path to the repository
         # you want to work with
         repo = Repo(self.rorepo.working_tree_dir)


### PR DESCRIPTION
revA..revB &rarr; revA...revB (three instead of two dots) [base.py, line
467](https://github.com/gitpython-developers/GitPython/blob/master/git/repo/base.py#L467)

rorepo is a ~~a~~ Repo instance [test_docs.py, line
21](https://github.com/gitpython-developers/GitPython/blob/master/git/test/test_docs.py#L21)
closes #314