### PR TITLE
Feature: Make commits with custom `author_date` and `commit_date` (closes #315)

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -922,7 +922,7 @@ class IndexFile(LazyMixin, diff.Diffable, Serializable):
 
         return out
 
-    def commit(self, message, parent_commits=None, head=True, author=None, committer=None):
+    def commit(self, message, parent_commits=None, head=True, author=None, committer=None, author_date=None, commit_date=None):
         """Commit the current default index file, creating a commit object.
         For more information on the arguments, see tree.commit.
 
@@ -932,7 +932,8 @@ class IndexFile(LazyMixin, diff.Diffable, Serializable):
         run_commit_hook('pre-commit', self)
         tree = self.write_tree()
         rval = Commit.create_from_tree(self.repo, tree, message, parent_commits,
-                                       head, author=author, committer=committer)
+                                       head, author=author, committer=committer,
+                                       author_date=author_date, commit_date=commit_date)
         run_commit_hook('post-commit', self)
         return rval
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -922,7 +922,8 @@ class IndexFile(LazyMixin, diff.Diffable, Serializable):
 
         return out
 
-    def commit(self, message, parent_commits=None, head=True, author=None, committer=None, author_date=None, commit_date=None):
+    def commit(self, message, parent_commits=None, head=True, author=None,
+               committer=None, author_date=None, commit_date=None):
         """Commit the current default index file, creating a commit object.
         For more information on the arguments, see tree.commit.
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -266,7 +266,8 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
             finalize_process(proc_or_stream)
 
     @classmethod
-    def create_from_tree(cls, repo, tree, message, parent_commits=None, head=False, author=None, committer=None):
+    def create_from_tree(cls, repo, tree, message, parent_commits=None, head=False, author=None, committer=None,
+                         author_date=None, commit_date=None):
         """Commit the given tree, creating a commit object.
 
         :param repo: Repo object the commit should be part of
@@ -288,6 +289,8 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
             configuration is used to obtain this value.
         :param committer: The name of the committer, optional. If unset, the
             repository configuration is used to obtain this value.
+        :param author_date: The timestamp for the author field
+        :param commit_date: The timestamp for the committer field
 
         :return: Commit object representing the new commit
 
@@ -327,14 +330,18 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
         offset = altzone
 
         author_date_str = env.get(cls.env_author_date, '')
-        if author_date_str:
+        if author_date:
+            author_time, author_offset = parse_date(author_date)
+        elif author_date_str:
             author_time, author_offset = parse_date(author_date_str)
         else:
             author_time, author_offset = unix_time, offset
         # END set author time
 
         committer_date_str = env.get(cls.env_committer_date, '')
-        if committer_date_str:
+        if commit_date:
+            committer_time, committer_offset = parse_date(commit_date)
+        elif committer_date_str:
             committer_time, committer_offset = parse_date(committer_date_str)
         else:
             committer_time, committer_offset = unix_time, offset

--- a/git/test/test_index.py
+++ b/git/test/test_index.py
@@ -470,6 +470,17 @@ class TestIndex(TestBase):
         assert cur_head.commit == commit_actor
         assert cur_head.log()[-1].actor == my_committer
 
+        # commit with author_date and commit_date
+        cur_commit = cur_head.commit
+        commit_message = u"commit with dates by Avinash Sajjanshetty"
+
+        new_commit = index.commit(commit_message, author_date="2006-04-07T22:13:13", commit_date="2005-04-07T22:13:13")
+        assert cur_commit != new_commit
+        print(new_commit.authored_date, new_commit.committed_date)
+        assert new_commit.message == commit_message
+        assert new_commit.authored_date == 1144447993
+        assert new_commit.committed_date == 1112911993
+
         # same index, no parents
         commit_message = "index without parents"
         commit_no_parents = index.commit(commit_message, parent_commits=list(), head=True)


### PR DESCRIPTION
As title says, now you can send custom datetime to the commit:

```
import git
...
repo = git.Repo.init(repo_path)
repo.index.add(['some_file'])
repo.index.commit(message, authored_date=commit_date, committed_date=commit_date)
```