### PR TITLE
Always add '--' to git reset

### DIFF
--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -55,7 +55,6 @@ class HEAD(SymbolicReference):
 
         :return: self"""
         mode = "--soft"
-        add_arg = None
         if index:
             mode = "--mixed"
 
@@ -73,12 +72,8 @@ class HEAD(SymbolicReference):
 
         # END working tree handling
 
-        if paths:
-            add_arg = "--"
-        # END nicely separate paths from rest
-
         try:
-            self.repo.git.reset(mode, commit, add_arg, paths, **kwargs)
+            self.repo.git.reset(mode, commit, '--', paths, **kwargs)
         except GitCommandError as e:
             # git nowadays may use 1 as status to indicate there are still unstaged
             # modifications after the reset


### PR DESCRIPTION
If a git repo has the misfortune to have a file with the name "HEAD"
at the root level of the repo, git will return an error because it
is unsure whether the file or ref is meant:

    File "/usr/local/lib/python2.7/dist-packages/git/refs/head.py", line 81, in reset
      self.repo.git.reset(mode, commit, add_arg, paths, **kwargs)
    File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 440, in <lambda>
      return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
    File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 834, in _call_process
      return self.execute(make_call(), **_kwargs)
    File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 627, in execute
      raise GitCommandError(command, status, stderr_value)
  GitCommandError: 'git reset --hard HEAD' returned with exit code 128
  stderr: 'fatal: ambiguous argument 'HEAD': both revision and filename
  Use '--' to separate filenames from revisions'

Implement its suggested fix by always passing '--' as an argument to
"git reset".  It is fine to pass it with no file specifiers afterwords.
In that case, git knows that "HEAD" is always meant as the ref.