### PR TITLE
Implement is_ancestor

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -504,6 +504,21 @@ class Repo(object):
 
         return res
 
+    def is_ancestor(self, ancestor_rev, rev):
+        """Check if a commit  is an ancestor of another
+
+        :param ancestor_rev: Rev which should be an ancestor
+        :param rev: Rev to test against ancestor_rev
+        :return: ``True``, ancestor_rev is an accestor to rev.
+        """
+        try:
+            self.git.merge_base(ancestor_rev, rev, is_ancestor=True)
+        except GitCommandError as err:
+            if err.status == 1:
+                return False
+            raise
+        return True
+
     def _get_daemon_export(self):
         filename = join(self.git_dir, self.DAEMON_EXPORT_FILE)
         return os.path.exists(filename)

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -42,6 +42,7 @@ import os
 import sys
 import tempfile
 import shutil
+import itertools
 from io import BytesIO
 
 
@@ -765,3 +766,16 @@ class TestRepo(TestBase):
 
         # Test for no merge base - can't do as we have
         self.failUnlessRaises(GitCommandError, repo.merge_base, c1, 'ffffff')
+
+    def test_is_ancestor(self):
+        repo = self.rorepo
+        c1 = 'f6aa8d1'
+        c2 = '763ef75'
+        self.assertTrue(repo.is_ancestor(c1, c1))
+        self.assertTrue(repo.is_ancestor("master", "master"))
+        self.assertTrue(repo.is_ancestor(c1, c2))
+        self.assertTrue(repo.is_ancestor(c1, "master"))
+        self.assertFalse(repo.is_ancestor(c2, c1))
+        self.assertFalse(repo.is_ancestor("master", c1))
+        for i, j in itertools.permutations([c1, 'ffffff', ''], r=2):
+            self.assertRaises(GitCommandError, repo.is_ancestor, i, j)


### PR DESCRIPTION
Wrap `git merge-base --is-ancestor` into its own function because it acts
as a boolean check unlike base `git merge-base call`