### PR TITLE
gic {init,clone} --separate-git-dir is supported only since 1.7.5

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -137,7 +137,7 @@ class Submodule(util.IndexObject, Iterable, Traversable):
 
     @classmethod
     def _need_gitfile_submodules(cls, git):
-        return git.version_info[:3] >= (1, 7, 0)
+        return git.version_info[:3] >= (1, 7, 5)
 
     def __eq__(self, other):
         """Compare with another submodule"""


### PR DESCRIPTION
Without this commit the update() function of a submodule does not work
in CentOS 6.