### PR TITLE
fix(cmd): make short options with arguments become two separate argum…

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -700,7 +700,7 @@ class Git(LazyMixin):
         finally:
             self.update_environment(**old_env)
 
-    def transform_kwargs(self, split_single_char_options=False, **kwargs):
+    def transform_kwargs(self, split_single_char_options=True, **kwargs):
         """Transforms Python style kwargs into git command line options."""
         args = list()
         for k, v in kwargs.items():

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -65,7 +65,7 @@ class TestGit(TestBase):
 
     def test_it_transforms_kwargs_into_git_command_arguments(self):
         assert_equal(["-s"], self.git.transform_kwargs(**{'s': True}))
-        assert_equal(["-s5"], self.git.transform_kwargs(**{'s': 5}))
+        assert_equal(["-s", "5"], self.git.transform_kwargs(**{'s': 5}))
 
         assert_equal(["--max-count"], self.git.transform_kwargs(**{'max_count': True}))
         assert_equal(["--max-count=5"], self.git.transform_kwargs(**{'max_count': 5}))


### PR DESCRIPTION
…ents for the executable.

So `git.Git.command(f=42)` becomes `git command -f 42` instead of `git command -f42`, which is not recognized by `git`. See #340.