### PR TITLE
Include 'timeout' parameter in Git execute

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -576,6 +576,8 @@ class Git(LazyMixin):
 
         if sys.platform == 'win32':
             cmd_not_found_exception = WindowsError
+            if timeout:
+                raise GitCommandError('"timeout" feature is not supported on Windows.')
         else:
             if sys.version_info[0] > 2:
                 cmd_not_found_exception = FileNotFoundError  # NOQA # this is defined, but flake8 doesn't know

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -537,7 +537,11 @@ class Git(LazyMixin):
             To specify a timeout in seconds for the git command, after which the process
             should be killed. This will have no effect if as_process is set to True. It is
             set to None by default and will let the process run until the timeout is
-            explicitly specified.
+            explicitly specified. This feature is not supported on Windows. It's also worth
+            noting that kill_after_timeout uses SIGKILL, which can have negative side
+            effects on a repository. For example, stale locks in case of git gc could
+            render the repository incapable of accepting changes until the lock is manually
+            removed.
 
         :return:
             * str(output) if extended_output = False (Default)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -618,7 +618,10 @@ class Git(LazyMixin):
             try:
                 os.kill(pid, SIGKILL)
                 for child_pid in child_pids:
-                    os.kill(child_pid, SIGKILL)
+                    try:
+                        os.kill(child_pid, SIGKILL)
+                    except OSError:
+                        pass
                 kill_check.set()    # tell the main routine that the process was killed
             except OSError:
                 # It is possible that the process gets completed in the duration after timeout


### PR DESCRIPTION
This feature enables to set a timeout while executing a git
command. After this timeout is over, the process will be killed.
If not explicitly specified, the default functionality will not
be affected.
