### PR TITLE
fix(cmd): fixed deadlock when stderr buffer overflow

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -310,11 +310,11 @@ class Git(LazyMixin):
             """Wait for the process and return its status code.
 
             :raise GitCommandError: if the return status is not 0"""
-            status = self.proc.wait()
-            if status != 0:
-                raise GitCommandError(self.args, status, self.proc.stderr.read())
+            stderr_value = self.proc.communicate()[1]
+            if self.proc.returncode != 0:
+                raise GitCommandError(self.args, status, stderr_value)
             # END status handling
-            return status
+            return self.proc.returncode
     # END auto interrupt
 
     class CatFileContentStream(object):


### PR DESCRIPTION
Fixed deadlock when using stderr=PIPE in Popen and Git generates enough
output to a pipe such that it blocks waiting for the OS pipe buffer to
accept more data (see https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait)