### PR TITLE
Added CHECKING_OUT as a logged operation

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -165,7 +165,7 @@ class RemoteProgress(object):
     Handler providing an interface to parse progress information emitted by git-push
     and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
     """
-    _num_op_codes = 8
+    _num_op_codes = 9
     BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES, CHECKING_OUT = \
         [1 << x for x in range(_num_op_codes)]
     STAGE_MASK = BEGIN | END

--- a/git/util.py
+++ b/git/util.py
@@ -166,7 +166,7 @@ class RemoteProgress(object):
     and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
     """
     _num_op_codes = 8
-    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES = \
+    BEGIN, END, COUNTING, COMPRESSING, WRITING, RECEIVING, RESOLVING, FINDING_SOURCES, CHECKING_OUT = \
         [1 << x for x in range(_num_op_codes)]
     STAGE_MASK = BEGIN | END
     OP_MASK = ~STAGE_MASK
@@ -231,6 +231,8 @@ class RemoteProgress(object):
                 op_code |= self.RESOLVING
             elif op_name == 'Finding sources':
                 op_code |= self.FINDING_SOURCES
+            elif op_name == 'Checking out files':
+                op_code |= self.CHECKING_OUT
             else:
                 # Note: On windows it can happen that partial lines are sent
                 # Hence we get something like "CompreReceiving objects", which is


### PR DESCRIPTION
As seen in #330, "Checking out files" is not covered in the operations for RemoteProgress. Here is a simple fix. I have not found where to add test for it, feel free to redirect me.

Closes #330