### PR TITLE
Make sure .read() and friends always return bytes

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -355,7 +355,7 @@ class Git(LazyMixin):
         def read(self, size=-1):
             bytes_left = self._size - self._nbr
             if bytes_left == 0:
-                return ''
+                return b''
             if size > -1:
                 # assure we don't try to read past our limit
                 size = min(bytes_left, size)
@@ -374,7 +374,7 @@ class Git(LazyMixin):
 
         def readline(self, size=-1):
             if self._nbr == self._size:
-                return ''
+                return b''
 
             # clamp size to lowest allowed value
             bytes_left = self._size - self._nbr

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -454,7 +454,7 @@ class TestRepo(TestBase):
         assert s.readline() == l1
         assert s.readline() == l2
         assert s.readline() == l3
-        assert s.readline() == ''
+        assert s.readline() == b''
         assert s._stream.tell() == len(d)
 
         # readline limit
@@ -465,13 +465,13 @@ class TestRepo(TestBase):
         # readline on tiny section
         s = mktiny()
         assert s.readline() == l1p
-        assert s.readline() == ''
+        assert s.readline() == b''
         assert s._stream.tell() == ts + 1
 
         # read no limit
         s = mkfull()
         assert s.read() == d[:-1]
-        assert s.read() == ''
+        assert s.read() == b''
         assert s._stream.tell() == len(d)
 
         # read limit


### PR DESCRIPTION
This had tripped me up when consuming from `.read(4096)` in a streaming fashion. All chunks will return bytes except the last one (the empty string), which is a unicode string in Python 3.

This fixes that to always return bytes, in both Python 2 and 3.
