### PR TITLE
Support repeated kwargs

### DIFF
--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -70,6 +70,10 @@ class TestGit(TestBase):
         assert_equal(["--max-count"], self.git.transform_kwargs(**{'max_count': True}))
         assert_equal(["--max-count=5"], self.git.transform_kwargs(**{'max_count': 5}))
 
+        # Multiple args are supported by using lists/tuples
+        assert_equal(["-L", "1-3", "-L", "12-18"], self.git.transform_kwargs(**{'L': ('1-3', '12-18')}))
+        assert_equal(["-C", "-C"], self.git.transform_kwargs(**{'C': [True, True]}))
+
         # order is undefined
         res = self.git.transform_kwargs(**{'s': True, 't': True})
         assert ['-s', '-t'] == res or ['-t', '-s'] == res


### PR DESCRIPTION
Some Git command line options are allowed to be repeated multiple times. Examples of this are the -C flag which may occur more than once to "strengthen" its effect, or the -L flag on Git blames, to select
multiple blocks of lines to blame.

    $ git diff -C -C HEAD~1 HEAD
    $ git blame -L 1-3 -L 12-18 HEAD -- somefile.py

This patch supports passing a list/tuple as the value part for kwargs, so that the generated Git command contain the repeated options.