### PR TITLE
Fix order of operators before executing the git command

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -13,6 +13,8 @@ import threading
 import errno
 import mmap
 
+from collections import OrderedDict
+
 from contextlib import contextmanager
 import signal
 from subprocess import (
@@ -783,6 +785,7 @@ class Git(LazyMixin):
     def transform_kwargs(self, split_single_char_options=True, **kwargs):
         """Transforms Python style kwargs into git command line options."""
         args = list()
+        kwargs = OrderedDict(sorted(kwargs.items(), key=lambda x: x[0]))
         for k, v in kwargs.items():
             if isinstance(v, (list, tuple)):
                 for value in v:


### PR DESCRIPTION
Hello,

For a tool I'm writing [git-repo](https://github.com/guyzmo/git-repo), I was working with a mockup of subprocess to run regression tests for commands issued through GitPython. I've written a process similar to the VCR or Betamax libraries to define expected command calls passed through Popen. [Here](https://github.com/guyzmo/git-repo/blob/master/tests/helpers.py#L207-L209) is where I setup the mockup, and [here](https://github.com/guyzmo/git-repo/blob/master/tests/helpers.py#L295-L311) is a place where I use it.

It was working great, up until recently when I've introduced the `--progress` support. Then I've been hitting an issue where the same code would fail inconsistently between calls. Cf the [travis reports](https://travis-ci.org/guyzmo/git-repo/builds/129130635).

With a fair bit of debugging, I found out the issue is that because GitPython relies on the `kwargs` construct to pass around optional arguments, the order of argument will depend on the order of the items within the dict. As when I introduced progress support, `opt_arg` contains `'-v'` and `'--progress'` now, the order depending on both `hash('-v')` and `hash('--progress')`. So this request for merging is intended to fix that issue by simply ordering optional arguments by their name before passing the command to subprocess.