### PR TITLE
Need spaces in Emacs style encoding comment

### DIFF
--- a/git/compat.py
+++ b/git/compat.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # config.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/test/test_base.py
+++ b/git/test/test_base.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # test_base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/test/test_docs.py
+++ b/git/test/test_docs.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # test_git.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # test_git.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/test/test_index.py
+++ b/git/test/test_index.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # test_index.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -1,4 +1,4 @@
-#-*-coding:utf-8-*-
+# -*- coding: utf-8 -*-
 # test_repo.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #


### PR DESCRIPTION
Although it's hard to see, PEP-0263 does have ws delimiting the 'coding' string.
This commit will fix the root cause of (at least) one bug: https://lists.fedoraproject.org/archives/list/eclipse-sig@lists.fedoraproject.org/thread/5XQ5JRHG6DPPMGRDU7TA2AO4EYS2H7AG/