### PR TITLE
Split lines by new line characters

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -682,10 +682,12 @@ class Repo(object):
         data = self.git.blame(rev, '--', file, p=True, incremental=True, stdout_as_string=False, **kwargs)
         commits = dict()
 
-        stream = iter(data.splitlines())
+        stream = iter(data.split(b'\n'))
         while True:
             line = next(stream)  # when exhausted, casues a StopIteration, terminating this function
-
+            if line.strip() == '':
+                # Skip over empty lines
+                continue
             hexsha, orig_lineno, lineno, num_lines = line.split()
             lineno = int(lineno)
             num_lines = int(num_lines)

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -685,7 +685,7 @@ class Repo(object):
         stream = iter(data.split(b'\n'))
         while True:
             line = next(stream)  # when exhausted, casues a StopIteration, terminating this function
-            if line.strip() == '':
+            if line.strip() == '' or line.strip() == b'':
                 # Skip over empty lines
                 continue
             hexsha, orig_lineno, lineno, num_lines = line.split()

--- a/git/test/fixtures/blame_incremental
+++ b/git/test/fixtures/blame_incremental
@@ -7,7 +7,7 @@ committer Sebastian Thiel
 committer-mail <byronimo@gmail.com>
 committer-time 1270634931
 committer-tz +0200
-summary Used this release for a first beta of the 0.2 branch of development
+summary Used this release for a first beta of the 0.2 branch of development
 previous 501bf602abea7d21c3dbb409b435976e92033145 AUTHORS
 filename AUTHORS
 82b8902e033430000481eb355733cd7065342037 14 14 1


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where there could be special characters in the commit message, causing the line splits to be improperly detected when parsing the blame metadata.

This commit opts to split lines by the new line character instead of letting `splitlines()` do this. This helps catch the issue when there are special characters in the line, particular the commit summary section.

#### How should this be manually tested?
`git/test/test_repo.py` has been modified to catch this edge case. Please do run all tests or this one test in particular.