### PR TITLE
import OrderedDict from git.odict rather than directly from collections, to pix Py2.6 compatibility

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -13,7 +13,7 @@ import threading
 import errno
 import mmap
 
-from collections import OrderedDict
+from git.odict import OrderedDict
 
 from contextlib import contextmanager
 import signal


### PR DESCRIPTION
cfr. https://github.com/gitpython-developers/GitPython/pull/431/files/89ade7bfff534ae799d7dd693b206931d5ed3d4f#r64649040

cc @Byron 

I tested this in my fork on Travis; I'm running into one failing test, but it seems unrelated to this change.
Am I missing something to make the tests pass?

```
======================================================================
ERROR: test_init_repo_object (git.test.test_docs.Tutorials)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/boegel/GitPython/git/ext/gitdb/gitdb/test/lib.py", line 87, in wrapper
    return func(self, path)
  File "/home/travis/build/boegel/GitPython/git/test/test_docs.py", line 68, in test_init_repo_object
    assert repo.refs['origin/master'] == repo.remotes.origin.refs.master  # ... remotes ...
  File "/home/travis/build/boegel/GitPython/git/util.py", line 684, in __getitem__
    raise IndexError("No item found with id %r" % (self._prefix + index))
IndexError: No item found with id 'origin/master'
```