### PR TITLE
Use proper syntax for conditional expressions.

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -609,7 +609,7 @@ class Git(LazyMixin):
                          bufsize=-1,
                          stdin=istream,
                          stderr=PIPE,
-                         stdout=with_stdout and PIPE or open(os.devnull, 'wb'),
+                         stdout=PIPE if with_stdout else open(os.devnull, 'wb'),
                          shell=self.USE_SHELL,
                          close_fds=(os.name == 'posix'),  # unsupported on windows
                          universal_newlines=universal_newlines,


### PR DESCRIPTION
Hello. :)

This change replaces abusing the "short-circuit" property of logical operations (`cond and A or B`) with dedicated conditional expression syntax (`A if cond else B`).

Just please double-check that I didn't get the `and-or` short-circuitry logic backwards or wrong in some other way! ;)