### PR TITLE
Fix bug in diff parser output

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -5,6 +5,8 @@ Changelog
 2.0.4 - Fixes
 =============
 
+* Fix: non-ASCII paths are now properly decoded and returned in
+  ``.diff()`` output
 * Fix: `RemoteProgress` will now strip the ', ' prefix or suffix from messages.
 * API: Remote.[fetch|push|pull](...) methods now allow the ``progress`` argument to
   be a callable. This saves you from creating a custom type with usually just one

--- a/git/test/fixtures/diff_patch_unsafe_paths
+++ b/git/test/fixtures/diff_patch_unsafe_paths
@@ -61,6 +61,13 @@ index 0000000000000000000000000000000000000000..eaf5f7510320b6a327fb308379de2f94
 +++ "b/path/¯\\_(ツ)_|¯"
 @@ -0,0 +1 @@
 +dummy content
+diff --git "a/path/\360\237\222\251.txt" "b/path/\360\237\222\251.txt"
+new file mode 100644
+index 0000000000000000000000000000000000000000..eaf5f7510320b6a327fb308379de2f94d8859a54
+--- /dev/null
++++ "b/path/\360\237\222\251.txt"
+@@ -0,0 +1 @@
++dummy content
 diff --git a/a/with spaces b/b/with some spaces
 similarity index 100%
 rename from a/with spaces

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -161,16 +161,17 @@ class TestDiff(TestBase):
         self.assertEqual(res[6].b_path, u'path/with spaces')
         self.assertEqual(res[7].b_path, u'path/with-question-mark?')
         self.assertEqual(res[8].b_path, u'path/¯\\_(ツ)_|¯')
+        self.assertEqual(res[9].b_path, u'path/💩.txt')
 
         # The "Moves"
         # NOTE: The path prefixes a/ and b/ here are legit!  We're actually
         # verifying that it's not "a/a/" that shows up, see the fixture data.
-        self.assertEqual(res[9].a_path, u'a/with spaces')       # NOTE: path a/ here legit!
-        self.assertEqual(res[9].b_path, u'b/with some spaces')  # NOTE: path b/ here legit!
-        self.assertEqual(res[10].a_path, u'a/ending in a space ')
-        self.assertEqual(res[10].b_path, u'b/ending with space ')
-        self.assertEqual(res[11].a_path, u'a/"with-quotes"')
-        self.assertEqual(res[11].b_path, u'b/"with even more quotes"')
+        self.assertEqual(res[10].a_path, u'a/with spaces')       # NOTE: path a/ here legit!
+        self.assertEqual(res[10].b_path, u'b/with some spaces')  # NOTE: path b/ here legit!
+        self.assertEqual(res[11].a_path, u'a/ending in a space ')
+        self.assertEqual(res[11].b_path, u'b/ending with space ')
+        self.assertEqual(res[12].a_path, u'a/"with-quotes"')
+        self.assertEqual(res[12].b_path, u'b/"with even more quotes"')
 
     def test_diff_patch_format(self):
         # test all of the 'old' format diffs for completness - it should at least


### PR DESCRIPTION
The diff `--patch` output parser was missing some edge case where Git would encode non-ASCII chars in path names as octals, but these weren't decoded properly.

    \360\237\222\251.txt

Decoded via utf-8, that will return:

    💩.txt
