### PR TITLE
Fixes #457: 'TypeError: decode() takes no keyword arguments' on Python 2.6

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.6 - Fixes
 =============
 
-* ...
+* Fix: TypeError about passing keyword argument to string decode() on
+  Python 2.6.
 
 2.0.5 - Fixes
 =============

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -501,14 +501,14 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
 
         try:
             self.author, self.authored_date, self.author_tz_offset = \
-                parse_actor_and_date(author_line.decode(self.encoding, errors='replace'))
+                parse_actor_and_date(author_line.decode(self.encoding, 'replace'))
         except UnicodeDecodeError:
             log.error("Failed to decode author line '%s' using encoding %s", author_line, self.encoding,
                       exc_info=True)
 
         try:
             self.committer, self.committed_date, self.committer_tz_offset = \
-                parse_actor_and_date(committer_line.decode(self.encoding, errors='replace'))
+                parse_actor_and_date(committer_line.decode(self.encoding, 'replace'))
         except UnicodeDecodeError:
             log.error("Failed to decode committer line '%s' using encoding %s", committer_line, self.encoding,
                       exc_info=True)
@@ -518,7 +518,7 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
         # The end of our message stream is marked with a newline that we strip
         self.message = stream.read()
         try:
-            self.message = self.message.decode(self.encoding, errors='replace')
+            self.message = self.message.decode(self.encoding, 'replace')
         except UnicodeDecodeError:
             log.error("Failed to decode message '%s' using encoding %s", self.message, self.encoding, exc_info=True)
         # END exception handling


### PR DESCRIPTION
This PR addresses issue #457.

Ready to be merged. Please review and merge.