### PR TITLE
Make sure os is not even partly destroyed

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -287,7 +287,7 @@ class Git(LazyMixin):
                 return
 
             # can be that nothing really exists anymore ...
-            if os is None:
+            if os is None or os.kill is None:
                 return
 
             # try to kill it


### PR DESCRIPTION
I had problems with errors like:
Exception TypeError: "'NoneType' object is not callable" in > ignored

After much digging I found, that os.kill is None in this case while os still exists. No clue how Python managed to get this state, but my change fixes the problem.