### PR TITLE
Allowed remotes to have no refs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,5 +14,6 @@ Contributors are:
 -Sebastian Thiel <byronimo _at_ gmail.com>
 -Jonathan Chu <jonathan.chu _at_ me.com>
 -Vincent Driessen <me _at_ nvie.com>
+-Phil Elson <pelson _dot_ pub _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/remote.py
+++ b/git/remote.py
@@ -511,7 +511,6 @@ class Remote(LazyMixin, Iterable):
             remote.refs.master # yields RemoteReference('/refs/remotes/origin/master')"""
         out_refs = IterableList(RemoteReference._id_attribute_, "%s/" % self.name)
         out_refs.extend(RemoteReference.list_items(self.repo, remote=self.name))
-        assert out_refs, "Remote %s did not have any references" % self.name
         return out_refs
 
     @property

--- a/git/test/test_refs.py
+++ b/git/test/test_refs.py
@@ -320,8 +320,8 @@ class TestRefs(TestBase):
         assert remote_refs_so_far
 
         for remote in remotes:
-            # remotes without references throw
-            self.failUnlessRaises(AssertionError, getattr, remote, 'refs')
+            # remotes without references should produce an empty list
+            self.assertEqual(remote.refs, [])
         # END for each remote
 
         # change where the active head points to


### PR DESCRIPTION
It makes sense to be able to write ``for ref in repo.remotes.upstream.refs`` without having to guard against an AssertionError.

Also relates to a comment from @Byron in https://github.com/gitpython-developers/GitPython/issues/480#issuecomment-228543784.