### PR TITLE
BF: allow for other section names which start with a string "remote"

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -445,7 +445,7 @@ class Remote(LazyMixin, Iterable):
     def iter_items(cls, repo):
         """:return: Iterator yielding Remote objects of the given repository"""
         for section in repo.config_reader("repository").sections():
-            if not section.startswith('remote'):
+            if not section.startswith('remote '):
                 continue
             lbound = section.find('"')
             rbound = section.rfind('"')


### PR DESCRIPTION
by demanding a space after a word remote, and space is explicitly described as
a delimiter in man git-config:

To begin a subsection put its name in double quotes, separated by space from the section name,

otherwise e.g.

```
  File "/usr/lib/python2.7/dist-packages/datalad/support/gitrepo.py", line 836, in get_remote_branches
    for remote in self.repo.remotes:
  File "/home/yoh/deb/gits/python-git/git/repo/base.py", line 271, in remotes
    return Remote.list_items(self)
  File "/home/yoh/deb/gits/python-git/git/util.py", line 745, in list_items
    out_list.extend(cls.iter_items(repo, *args, **kwargs))
  File "/home/yoh/deb/gits/python-git/git/remote.py", line 453, in iter_items
    raise ValueError("Remote-Section has invalid format: %r" % section)
ValueError: Remote-Section has invalid format: u'remotes'
```

More proper fix I guess could be making a helper function to split any section definition into `(section, subsection)` tuple and use it throughout the code, since I am afraid there might be similar treatment for other common subsection names 