### PR TITLE
BF: remove a submodule with a remote without refs + misc fixes around

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -836,7 +836,7 @@ class Submodule(util.IndexObject, Iterable, Traversable):
                         num_branches_with_new_commits += len(mod.git.cherry(rref)) != 0
                     # END for each remote ref
                     # not a single remote branch contained all our commits
-                    if num_branches_with_new_commits == len(rrefs):
+                    if len(rrefs) and num_branches_with_new_commits == len(rrefs):
                         raise InvalidGitRepositoryError(
                             "Cannot delete module at %s as there are new commits" % mod.working_tree_dir)
                     # END handle new commits

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -107,6 +107,8 @@ def with_rw_directory(func):
             gc.collect()
             if not keep:
                 rmtree(path)
+    wrapper.__name__ = func.__name__
+    return wrapper
 
 
 def with_rw_repo(working_tree_ref, bare=False):

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -94,8 +94,8 @@ def with_rw_directory(func):
             try:
                 return func(self, path)
             except Exception:
-                log.info.write("Test %s.%s failed, output is at %r\n",
-                               type(self).__name__, func.__name__, path)
+                log.info("Test %s.%s failed, output is at %r\n",
+                         type(self).__name__, func.__name__, path)
                 keep = True
                 raise
         finally:


### PR DESCRIPTION
now if there is a remote without any refs (this happens e.g. with git-annex repo with special remotes), it would refuse to remove the submodule
(with 2.0.8 it also didn't work but with a different msg "AssertionError: Remote datalad did not have any references")