### PR TITLE
RF: coveralls (not used/relied on really) -> codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ git:
 install:
   - git submodule update --init --recursive
   - git fetch --tags
-  - pip install coveralls flake8 ddt sphinx
+  - pip install codecov flake8 ddt sphinx
 
   # generate some reflog as git-python tests need it (in master)
   - ./init-tests-after-clone.sh
@@ -36,4 +36,4 @@ script:
   - if [ "$TRAVIS_PYTHON_VERSION" == '3.5' ]; then cd doc && make html; fi
   -
 after_success:
-  - coveralls
+  - codecov


### PR DESCRIPTION
codecov in our (datalad, etc) experience provides a better service,
great support, and super-nice intergration with chromium and firefox
for reviewing coverage of pull requests.  In light of the
@with_rw_directory fiasco detected/fixed in #521 I would strongly
recommend to (re-)enable and use coverage reports

edit 1: I think that if you accept this PR codecov might automagically enable itself on this repo, but I could be wrong and someone with authority might need to login into codecov via github and enable

coverage as seen from my clone: https://codecov.io/gh/yarikoptic/GitPython/commit/94ca83c6b6f49bb1244569030ce7989d4e01495c
and trust me integration with browsers is great!    ha -- actually basic (since there were no reports against master -- can't show the difference)  report already appeared here (magic!)

If you want to see it in action -- install codecov browser plugin and look e.g. at https://github.com/datalad/datalad/pull/969/files 