### PR TITLE
Start fixing #525 Windows errors

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -59,7 +59,8 @@ __all__ = ('Git',)
 # Documentation
 ## @{
 
-def handle_process_output(process, stdout_handler, stderr_handler, finalizer, decode_streams=True):
+def handle_process_output(process, stdout_handler, stderr_handler,
+                          finalizer=None, decode_streams=True):
     """Registers for notifications to lean that process output is ready to read, and dispatches lines to
     the respective line handlers.
     This function returns once the finalizer returns
@@ -108,10 +109,13 @@ def handle_process_output(process, stdout_handler, stderr_handler, finalizer, de
         t.start()
         threads.append(t)
 
+    ## FIXME: Why Join??  Will block if `stdin` needs feeding...
+    #
     for t in threads:
         t.join()
 
-    return finalizer(process)
+    if finalizer:
+        return finalizer(process)
 
 
 def dashify(string):

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -539,6 +539,9 @@ class Git(LazyMixin):
                 cmd_not_found_exception = OSError
         # end handle
 
+        stdout_sink = (PIPE
+                       if with_stdout
+                       else getattr(subprocess, 'DEVNULL', open(os.devnull, 'wb')))
         log.debug("Popen(%s, cwd=%s, universal_newlines=%s, shell=%s)",
                   command, cwd, universal_newlines, shell)
         try:
@@ -548,9 +551,9 @@ class Git(LazyMixin):
                          bufsize=-1,
                          stdin=istream,
                          stderr=PIPE,
-                         stdout=PIPE if with_stdout else open(os.devnull, 'wb'),
+                         stdout=stdout_sink,
                          shell=shell is not None and shell or self.USE_SHELL,
-                         close_fds=(is_posix),  # unsupported on windows
+                         close_fds=is_posix,  # unsupported on windows
                          universal_newlines=universal_newlines,
                          creationflags=PROC_CREATIONFLAGS,
                          **subprocess_kwargs

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -247,7 +247,7 @@ class Git(LazyMixin):
         def __getattr__(self, attr):
             return getattr(self.proc, attr)
 
-        def wait(self, stderr=b''):
+        def wait(self, stderr=b''):  # TODO: Bad choice to mimic `proc.wait()` but with different args.
             """Wait for the process and return its status code.
 
             :param stderr: Previously read value of stderr, in case stderr is already closed.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -42,12 +42,12 @@ from .util import (
 )
 
 
-execute_kwargs = set(('istream', 'with_keep_cwd', 'with_extended_output',
+execute_kwargs = set(('istream', 'with_extended_output',
                       'with_exceptions', 'as_process', 'stdout_as_string',
                       'output_stream', 'with_stdout', 'kill_after_timeout',
                       'universal_newlines', 'shell'))
 
-log = logging.getLogger('git.cmd')
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 __all__ = ('Git',)
@@ -418,7 +418,6 @@ class Git(LazyMixin):
 
     def execute(self, command,
                 istream=None,
-                with_keep_cwd=False,
                 with_extended_output=False,
                 with_exceptions=True,
                 as_process=False,
@@ -440,11 +439,6 @@ class Git(LazyMixin):
 
         :param istream:
             Standard input filehandle passed to subprocess.Popen.
-
-        :param with_keep_cwd:
-            Whether to use the current working directory from os.getcwd().
-            The cmd otherwise uses its own working_dir that it has been initialized
-            with if possible.
 
         :param with_extended_output:
             Whether to return a (status, stdout, stderr) tuple.
@@ -518,10 +512,7 @@ class Git(LazyMixin):
             log.info(' '.join(command))
 
         # Allow the user to have the command executed in their working dir.
-        if with_keep_cwd or self._working_dir is None:
-            cwd = os.getcwd()
-        else:
-            cwd = self._working_dir
+        cwd = self._working_dir or os.getcwd()
 
         # Start the process
         env = os.environ.copy()

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -649,10 +649,7 @@ class Git(LazyMixin):
         # END handle debug printing
 
         if with_exceptions and status != 0:
-            if with_extended_output:
-                raise GitCommandError(command, status, stderr_value, stdout_value)
-            else:
-                raise GitCommandError(command, status, stderr_value)
+            raise GitCommandError(command, status, stderr_value, stdout_value)
 
         if isinstance(stdout_value, bytes) and stdout_as_string:  # could also be output_stream
             stdout_value = safe_decode(stdout_value)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -186,14 +186,18 @@ class Git(LazyMixin):
     # Override this value using `Git.USE_SHELL = True`
     USE_SHELL = False
 
-    class AutoInterrupt(object):
+    @classmethod
+    def polish_url(cls, url):
+        return url.replace("\\\\", "\\").replace("\\", "/")
 
+    class AutoInterrupt(object):
         """Kill/Interrupt the stored process instance once this instance goes out of scope. It is
         used to prevent processes piling up in case iterators stop reading.
         Besides all attributes are wired through to the contained process object.
 
         The wait method was overridden to perform automatic status code checking
         and possibly raise."""
+
         __slots__ = ("proc", "args")
 
         def __init__(self, proc, args):

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -41,6 +41,7 @@ import uuid
 from unittest.case import SkipTest
 from git.util import HIDE_WINDOWS_KNOWN_ERRORS
 from git.objects.base import IndexObject, Object
+from git.cmd import Git
 
 __all__ = ["Submodule", "UpdateProgress"]
 
@@ -393,6 +394,9 @@ class Submodule(IndexObject, Iterable, Traversable):
             # _clone_repo(cls, repo, url, path, name, **kwargs):
             mrepo = cls._clone_repo(repo, url, path, name, **kwargs)
         # END verify url
+
+        ## See #525 for ensuring git urls in config-files valid under Windows.
+        url = Git.polish_url(url)
 
         # It's important to add the URL to the parent config, to let `git submodule` know.
         # otherwise there is a '-' character in front of the submodule listing

--- a/git/remote.py
+++ b/git/remote.py
@@ -29,7 +29,7 @@ from git.util import (
     join_path,
     finalize_process
 )
-from git.cmd import handle_process_output
+from git.cmd import handle_process_output, Git
 from gitdb.util import join
 from git.compat import (defenc, force_text, is_win)
 import logging
@@ -570,7 +570,7 @@ class Remote(LazyMixin, Iterable):
         :raise GitCommandError: in case an origin with that name already exists"""
         scmd = 'add'
         kwargs['insert_kwargs_after'] = scmd
-        repo.git.remote(scmd, name, url, **kwargs)
+        repo.git.remote(scmd, name, Git.polish_url(url), **kwargs)
         return cls(repo, name)
 
     # add is an alias

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -897,7 +897,7 @@ class Repo(object):
         repo = cls(path, odbt=odbt)
         if repo.remotes:
             with repo.remotes[0].config_writer as writer:
-                writer.set_value('url', repo.remotes[0].url.replace("\\\\", "\\").replace("\\", "/"))
+                writer.set_value('url', Git.polish_url(repo.remotes[0].url))
         # END handle remote repo
         return repo
 

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -214,7 +214,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
     See working dir info in with_rw_repo
     :note: We attempt to launch our own invocation of git-daemon, which will be shutdown at the end of the test.
     """
-    from git import Git, Remote
+    from git import Git, Remote  # To avoid circular deps.
 
     assert isinstance(working_tree_ref, string_types), "Decorator requires ref name for working tree checkout"
 
@@ -250,7 +250,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
 
             base_path, rel_repo_dir = osp.split(remote_repo_dir)
 
-            remote_repo_url = "git://localhost:%s/%s" % (GIT_DAEMON_PORT, rel_repo_dir)
+            remote_repo_url = Git.polish_url("git://localhost:%s/%s" % (GIT_DAEMON_PORT, rel_repo_dir))
             with d_remote.config_writer as cw:
                 cw.set('url', remote_repo_url)
 
@@ -342,7 +342,8 @@ class TestBase(TestCase):
 
     def _small_repo_url(self):
         """:return" a path to a small, clonable repository"""
-        return osp.join(self.rorepo.working_tree_dir, 'git/ext/gitdb/gitdb/ext/smmap')
+        from git.cmd import Git
+        return Git.polish_url(osp.join(self.rorepo.working_tree_dir, 'git/ext/gitdb/gitdb/ext/smmap'))
 
     @classmethod
     def setUpClass(cls):

--- a/git/test/test_base.py
+++ b/git/test/test_base.py
@@ -110,17 +110,6 @@ class TestBase(TestBase):
         assert not rw_repo.config_reader("repository").getboolean("core", "bare")
         assert os.path.isdir(os.path.join(rw_repo.working_tree_dir, 'lib'))
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS, """
-    # FIXME: helper.wrapper fails with:
-    #     PermissionError: [WinError 5] Access is denied:
-    #     'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\
-    #     master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx'
-    # AND
-    # FIXME: git-daemon failing with:
-    #     git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
-    #       cmdline: git ls-remote daemon_origin
-    #       stderr: 'fatal: bad config line 15 in file .git/config'
-    # """)
     @with_rw_and_rw_remote_repo('0.1.6')
     def test_with_rw_remote_and_rw_repo(self, rw_repo, rw_remote_repo):
         assert not rw_repo.config_reader("repository").getboolean("core", "bare")

--- a/git/test/test_base.py
+++ b/git/test/test_base.py
@@ -41,7 +41,7 @@ class TestBase(TestBase):
     def test_base_object(self):
         # test interface of base object classes
         types = (Blob, Tree, Commit, TagObject)
-        assert len(types) == len(self.type_tuples)
+        self.assertEqual(len(types), len(self.type_tuples))
 
         s = set()
         num_objs = 0
@@ -55,12 +55,12 @@ class TestBase(TestBase):
                 item = obj_type(self.rorepo, binsha, 0, path)
             # END handle index objects
             num_objs += 1
-            assert item.hexsha == hexsha
-            assert item.type == typename
+            self.assertEqual(item.hexsha, hexsha)
+            self.assertEqual(item.type, typename)
             assert item.size
-            assert item == item
-            assert not item != item
-            assert str(item) == item.hexsha
+            self.assertEqual(item, item)
+            self.assertNotEqual(not item, item)
+            self.assertEqual(str(item), item.hexsha)
             assert repr(item)
             s.add(item)
 
@@ -78,16 +78,16 @@ class TestBase(TestBase):
 
             tmpfilename = tempfile.mktemp(suffix='test-stream')
             with open(tmpfilename, 'wb+') as tmpfile:
-                assert item == item.stream_data(tmpfile)
+                self.assertEqual(item, item.stream_data(tmpfile))
                 tmpfile.seek(0)
-                assert tmpfile.read() == data
+                self.assertEqual(tmpfile.read(), data)
             os.remove(tmpfilename)
         # END for each object type to create
 
         # each has a unique sha
-        assert len(s) == num_objs
-        assert len(s | s) == num_objs
-        assert num_index_objs == 2
+        self.assertEqual(len(s), num_objs)
+        self.assertEqual(len(s | s), num_objs)
+        self.assertEqual(num_index_objs, 2)
 
     def test_get_object_type_by_name(self):
         for tname in base.Object.TYPES:
@@ -98,7 +98,7 @@ class TestBase(TestBase):
 
     def test_object_resolution(self):
         # objects must be resolved to shas so they compare equal
-        assert self.rorepo.head.reference.object == self.rorepo.active_branch.object
+        self.assertEqual(self.rorepo.head.reference.object, self.rorepo.active_branch.object)
 
     @with_rw_repo('HEAD', bare=True)
     def test_with_bare_rw_repo(self, bare_rw_repo):
@@ -110,6 +110,7 @@ class TestBase(TestBase):
         assert not rw_repo.config_reader("repository").getboolean("core", "bare")
         assert os.path.isdir(os.path.join(rw_repo.working_tree_dir, 'lib'))
 
+    #@skipIf(HIDE_WINDOWS_FREEZE_ERRORS, "FIXME: Freezes!  sometimes...")
     @with_rw_and_rw_remote_repo('0.1.6')
     def test_with_rw_remote_and_rw_repo(self, rw_repo, rw_remote_repo):
         assert not rw_repo.config_reader("repository").getboolean("core", "bare")

--- a/git/test/test_docs.py
+++ b/git/test/test_docs.py
@@ -16,7 +16,7 @@ class Tutorials(TestBase):
         import gc
         gc.collect()
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
+    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,  ## ACTUALLY skipped by `git.submodule.base#L869`.
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "
     #         "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx")  # noqa E501
     @with_rw_directory

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -207,18 +207,15 @@ class TestGit(TestBase):
         rw_repo = Repo.init(os.path.join(rw_dir, 'repo'))
         remote = rw_repo.create_remote('ssh-origin', "ssh://git@server/foo")
 
-        # This only works if we are not evaluating git-push/pull output in a thread !
-        import select
-        if hasattr(select, 'poll'):
-            with rw_repo.git.custom_environment(GIT_SSH=path):
-                try:
-                    remote.fetch()
-                except GitCommandError as err:
-                    if sys.version_info[0] < 3 and is_darwin:
-                        self.assertIn('ssh-orig, ' in str(err))
-                        self.assertEqual(err.status, 128)
-                    else:
-                        self.assertIn('FOO', str(err))
+        with rw_repo.git.custom_environment(GIT_SSH=path):
+            try:
+                remote.fetch()
+            except GitCommandError as err:
+                if sys.version_info[0] < 3 and is_darwin:
+                    self.assertIn('ssh-orig, ' in str(err))
+                    self.assertEqual(err.status, 128)
+                else:
+                    self.assertIn('FOO', str(err))
 
     def test_handle_process_output(self):
         from git.cmd import handle_process_output

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -31,7 +31,7 @@ from git.test.lib import (
     GIT_DAEMON_PORT,
     assert_raises
 )
-from git.util import IterableList, rmtree, HIDE_WINDOWS_FREEZE_ERRORS, HIDE_WINDOWS_KNOWN_ERRORS
+from git.util import IterableList, rmtree, HIDE_WINDOWS_FREEZE_ERRORS
 import os.path as osp
 
 
@@ -90,7 +90,7 @@ class TestRemoteProgress(RemoteProgress):
             return
 
         # sometimes objects are not compressed which is okay
-        assert len(self._seen_ops) in (2, 3)
+        assert len(self._seen_ops) in (2, 3), len(self._seen_ops)
         assert self._stages_per_op
 
         # must have seen all stages
@@ -114,40 +114,42 @@ class TestRemote(TestBase):
 
     def _do_test_fetch_result(self, results, remote):
         # self._print_fetchhead(remote.repo)
-        assert len(results) > 0 and isinstance(results[0], FetchInfo)
+        self.assertGreater(len(results), 0)
+        self.assertIsInstance(results[0], FetchInfo)
         for info in results:
-            assert isinstance(info.note, string_types)
+            self.assertIsInstance(info.note, string_types)
             if isinstance(info.ref, Reference):
-                assert info.flags != 0
+                self.assertTrue(info.flags)
             # END reference type flags handling
-            assert isinstance(info.ref, (SymbolicReference, Reference))
+            self.assertIsInstance(info.ref, (SymbolicReference, Reference))
             if info.flags & (info.FORCED_UPDATE | info.FAST_FORWARD):
-                assert isinstance(info.old_commit, Commit)
+                self.assertIsInstance(info.old_commit, Commit)
             else:
-                assert info.old_commit is None
+                self.assertIsNone(info.old_commit)
             # END forced update checking
         # END for each info
 
     def _do_test_push_result(self, results, remote):
-        assert len(results) > 0 and isinstance(results[0], PushInfo)
+        self.assertGreater(len(results), 0)
+        self.assertIsInstance(results[0], PushInfo)
         for info in results:
-            assert info.flags
-            assert isinstance(info.summary, string_types)
+            self.assertTrue(info.flags)
+            self.assertIsInstance(info.summary, string_types)
             if info.old_commit is not None:
-                assert isinstance(info.old_commit, Commit)
+                self.assertIsInstance(info.old_commit, Commit)
             if info.flags & info.ERROR:
                 has_one = False
                 for bitflag in (info.REJECTED, info.REMOTE_REJECTED, info.REMOTE_FAILURE):
                     has_one |= bool(info.flags & bitflag)
                 # END for each bitflag
-                assert has_one
+                self.assertTrue(has_one)
             else:
                 # there must be a remote commit
                 if info.flags & info.DELETED == 0:
-                    assert isinstance(info.local_ref, Reference)
+                    self.assertIsInstance(info.local_ref, Reference)
                 else:
-                    assert info.local_ref is None
-                assert type(info.remote_ref) in (TagReference, RemoteReference)
+                    self.assertIsNone(info.local_ref)
+                self.assertIn(type(info.remote_ref), (TagReference, RemoteReference))
             # END error checking
         # END for each info
 
@@ -187,7 +189,7 @@ class TestRemote(TestBase):
         res = fetch_and_test(remote)
         # all up to date
         for info in res:
-            assert info.flags & info.HEAD_UPTODATE
+            self.assertTrue(info.flags & info.HEAD_UPTODATE)
 
         # rewind remote head to trigger rejection
         # index must be false as remote is a bare repo
@@ -197,18 +199,19 @@ class TestRemote(TestBase):
         res = fetch_and_test(remote)
         mkey = "%s/%s" % (remote, 'master')
         master_info = res[mkey]
-        assert master_info.flags & FetchInfo.FORCED_UPDATE and master_info.note is not None
+        self.assertTrue(master_info.flags & FetchInfo.FORCED_UPDATE)
+        self.assertIsNotNone(master_info.note)
 
         # normal fast forward - set head back to previous one
         rhead.commit = remote_commit
         res = fetch_and_test(remote)
-        assert res[mkey].flags & FetchInfo.FAST_FORWARD
+        self.assertTrue(res[mkey].flags & FetchInfo.FAST_FORWARD)
 
         # new remote branch
         new_remote_branch = Head.create(remote_repo, "new_branch")
         res = fetch_and_test(remote)
         new_branch_info = get_info(res, remote, new_remote_branch)
-        assert new_branch_info.flags & FetchInfo.NEW_HEAD
+        self.assertTrue(new_branch_info.flags & FetchInfo.NEW_HEAD)
 
         # remote branch rename ( causes creation of a new one locally )
         new_remote_branch.rename("other_branch_name")
@@ -248,14 +251,14 @@ class TestRemote(TestBase):
         tinfo = res[str(rtag)]
         self.assertIsInstance(tinfo.ref, TagReference)
         self.assertEqual(tinfo.ref.commit, rtag.commit)
-        assert tinfo.flags & tinfo.NEW_TAG
+        self.assertTrue(tinfo.flags & tinfo.NEW_TAG)
 
         # adjust tag commit
         Reference.set_object(rtag, rhead.commit.parents[0].parents[0])
         res = fetch_and_test(remote, tags=True)
         tinfo = res[str(rtag)]
         self.assertEqual(tinfo.commit, rtag.commit)
-        assert tinfo.flags & tinfo.TAG_UPDATE
+        self.assertTrue(tinfo.flags & tinfo.TAG_UPDATE)
 
         # delete remote tag - local one will stay
         TagReference.delete(remote_repo, rtag)
@@ -317,21 +320,21 @@ class TestRemote(TestBase):
         self._commit_random_file(rw_repo)
         progress = TestRemoteProgress()
         res = remote.push(lhead.reference, progress)
-        assert isinstance(res, IterableList)
+        self.assertIsInstance(res, IterableList)
         self._do_test_push_result(res, remote)
         progress.make_assertion()
 
         # rejected - undo last commit
         lhead.reset("HEAD~1")
         res = remote.push(lhead.reference)
-        assert res[0].flags & PushInfo.ERROR
-        assert res[0].flags & PushInfo.REJECTED
+        self.assertTrue(res[0].flags & PushInfo.ERROR)
+        self.assertTrue(res[0].flags & PushInfo.REJECTED)
         self._do_test_push_result(res, remote)
 
         # force rejected pull
         res = remote.push('+%s' % lhead.reference)
         self.assertEqual(res[0].flags & PushInfo.ERROR, 0)
-        assert res[0].flags & PushInfo.FORCED_UPDATE
+        self.assertTrue(res[0].flags & PushInfo.FORCED_UPDATE)
         self._do_test_push_result(res, remote)
 
         # invalid refspec
@@ -343,7 +346,7 @@ class TestRemote(TestBase):
         new_tag = TagReference.create(rw_repo, to_be_updated)  # @UnusedVariable
         other_tag = TagReference.create(rw_repo, "my_obj_tag.2.1aRV", message="my message")
         res = remote.push(progress=progress, tags=True)
-        assert res[-1].flags & PushInfo.NEW_TAG
+        self.assertTrue(res[-1].flags & PushInfo.NEW_TAG)
         progress.make_assertion()
         self._do_test_push_result(res, remote)
 
@@ -352,7 +355,8 @@ class TestRemote(TestBase):
         new_tag = TagReference.create(rw_repo, to_be_updated, ref='HEAD~1', force=True)
         res = remote.push(tags=True)
         self._do_test_push_result(res, remote)
-        assert res[-1].flags & PushInfo.REJECTED and res[-1].flags & PushInfo.ERROR
+        self.assertTrue(res[-1].flags & PushInfo.REJECTED)
+        self.assertTrue(res[-1].flags & PushInfo.ERROR)
 
         # push force this tag
         res = remote.push("+%s" % new_tag.path)
@@ -362,7 +366,7 @@ class TestRemote(TestBase):
         # delete tag - have to do it using refspec
         res = remote.push(":%s" % new_tag.path)
         self._do_test_push_result(res, remote)
-        assert res[0].flags & PushInfo.DELETED
+        self.assertTrue(res[0].flags & PushInfo.DELETED)
         # Currently progress is not properly transferred, especially not using
         # the git daemon
         # progress.assert_received_message()
@@ -371,8 +375,8 @@ class TestRemote(TestBase):
         new_head = Head.create(rw_repo, "my_new_branch")
         progress = TestRemoteProgress()
         res = remote.push(new_head, progress)
-        assert len(res) > 0
-        assert res[0].flags & PushInfo.NEW_HEAD
+        self.assertGreater(len(res), 0)
+        self.assertTrue(res[0].flags & PushInfo.NEW_HEAD)
         progress.make_assertion()
         self._do_test_push_result(res, remote)
 
@@ -380,7 +384,7 @@ class TestRemote(TestBase):
         res = remote.push(":%s" % new_head.path)
         self._do_test_push_result(res, remote)
         Head.delete(rw_repo, new_head)
-        assert res[-1].flags & PushInfo.DELETED
+        self.assertTrue(res[-1].flags & PushInfo.DELETED)
 
         # --all
         res = remote.push(all=True)
@@ -393,7 +397,7 @@ class TestRemote(TestBase):
         TagReference.delete(rw_repo, new_tag, other_tag)
         remote.push(":%s" % other_tag.path)
 
-    @skipIf(HIDE_WINDOWS_KNOWN_ERRORS, "FIXME: Freezes!")
+    @skipIf(HIDE_WINDOWS_FREEZE_ERRORS, "FIXME: Freezes!")
     @with_rw_and_rw_remote_repo('0.1.6')
     def test_base(self, rw_repo, remote_repo):
         num_remotes = 0
@@ -402,17 +406,16 @@ class TestRemote(TestBase):
 
         for remote in rw_repo.remotes:
             num_remotes += 1
-            assert remote == remote
-            assert str(remote) != repr(remote)
+            self.assertEqual(remote, remote)
+            self.assertNotEqual(str(remote), repr(remote))
             remote_set.add(remote)
             remote_set.add(remote)  # should already exist
-
             # REFS
             refs = remote.refs
-            assert refs
+            self.assertTrue(refs)
             for ref in refs:
-                assert ref.remote_name == remote.name
-                assert ref.remote_head
+                self.assertEqual(ref.remote_name, remote.name)
+                self.assertTrue(ref.remote_head)
             # END for each ref
 
             # OPTIONS
@@ -439,11 +442,11 @@ class TestRemote(TestBase):
             # RENAME
             other_name = "totally_other_name"
             prev_name = remote.name
-            assert remote.rename(other_name) == remote
-            assert prev_name != remote.name
+            self.assertEqual(remote.rename(other_name), remote)
+            self.assertNotEqual(prev_name, remote.name)
             # multiple times
             for _ in range(2):
-                assert remote.rename(prev_name).name == prev_name
+                self.assertEqual(remote.rename(prev_name).name, prev_name)
             # END for each rename ( back to prev_name )
 
             # PUSH/PULL TESTING
@@ -460,9 +463,9 @@ class TestRemote(TestBase):
             remote.update()
         # END for each remote
 
-        assert ran_fetch_test
-        assert num_remotes
-        assert num_remotes == len(remote_set)
+        self.assertTrue(ran_fetch_test)
+        self.assertTrue(num_remotes)
+        self.assertEqual(num_remotes, len(remote_set))
 
         origin = rw_repo.remote('origin')
         assert origin == rw_repo.remotes.origin
@@ -482,8 +485,8 @@ class TestRemote(TestBase):
                 num_deleted += 1
             # end
         # end for each branch
-        assert num_deleted > 0
-        assert len(rw_repo.remotes.origin.fetch(prune=True)) == 1, "deleted everything but master"
+        self.assertGreater(num_deleted, 0)
+        self.assertEqual(len(rw_repo.remotes.origin.fetch(prune=True)), 1, "deleted everything but master")
 
     @with_rw_repo('HEAD', bare=True)
     def test_creation_and_removal(self, bare_rw_repo):
@@ -491,14 +494,14 @@ class TestRemote(TestBase):
         arg_list = (new_name, "git@server:hello.git")
         remote = Remote.create(bare_rw_repo, *arg_list)
         self.assertEqual(remote.name, "test_new_one")
-        assert remote in bare_rw_repo.remotes
-        assert remote.exists()
+        self.assertIn(remote, bare_rw_repo.remotes)
+        self.assertTrue(remote.exists())
 
         # create same one again
         self.failUnlessRaises(GitCommandError, Remote.create, bare_rw_repo, *arg_list)
 
         Remote.remove(bare_rw_repo, new_name)
-        assert remote.exists()      # We still have a cache that doesn't know we were deleted by name
+        self.assertTrue(remote.exists())      # We still have a cache that doesn't know we were deleted by name
         remote._clear_cache()
         assert not remote.exists()  # Cache should be renewed now. This is an issue ...
 
@@ -534,16 +537,16 @@ class TestRemote(TestBase):
                                   remote_info_line_fmt % "subdir/tagname",
                                   fetch_info_line_fmt % 'tag')
 
-        assert isinstance(fi.ref, TagReference)
-        assert fi.ref.path.startswith('refs/tags')
+        self.assertIsInstance(fi.ref, TagReference)
+        assert fi.ref.path.startswith('refs/tags'), fi.ref.path
 
         # it could be in a remote direcftory though
         fi = FetchInfo._from_line(self.rorepo,
                                   remote_info_line_fmt % "remotename/tags/tagname",
                                   fetch_info_line_fmt % 'tag')
 
-        assert isinstance(fi.ref, TagReference)
-        assert fi.ref.path.startswith('refs/remotes/')
+        self.assertIsInstance(fi.ref, TagReference)
+        assert fi.ref.path.startswith('refs/remotes/'), fi.ref.path
 
         # it can also be anywhere !
         tag_path = "refs/something/remotename/tags/tagname"
@@ -551,7 +554,7 @@ class TestRemote(TestBase):
                                   remote_info_line_fmt % tag_path,
                                   fetch_info_line_fmt % 'tag')
 
-        assert isinstance(fi.ref, TagReference)
+        self.assertIsInstance(fi.ref, TagReference)
         self.assertEqual(fi.ref.path, tag_path)
 
         # branches default to refs/remotes
@@ -559,7 +562,7 @@ class TestRemote(TestBase):
                                   remote_info_line_fmt % "remotename/branch",
                                   fetch_info_line_fmt % 'branch')
 
-        assert isinstance(fi.ref, RemoteReference)
+        self.assertIsInstance(fi.ref, RemoteReference)
         self.assertEqual(fi.ref.remote_name, 'remotename')
 
         # but you can force it anywhere, in which case we only have a references
@@ -567,7 +570,7 @@ class TestRemote(TestBase):
                                   remote_info_line_fmt % "refs/something/branch",
                                   fetch_info_line_fmt % 'branch')
 
-        assert type(fi.ref) is Reference
+        assert type(fi.ref) is Reference, type(fi.ref)
         self.assertEqual(fi.ref.path, "refs/something/branch")
 
     def test_uncommon_branch_names(self):
@@ -578,10 +581,10 @@ class TestRemote(TestBase):
         # +refs/pull/*:refs/heads/pull/*
         res = [FetchInfo._from_line('ShouldntMatterRepo', stderr, fetch_line)
                for stderr, fetch_line in zip(stderr_lines, fetch_lines)]
-        assert len(res)
+        self.assertGreater(len(res), 0)
         self.assertEqual(res[0].remote_ref_path, 'refs/pull/1/head')
         self.assertEqual(res[0].ref.path, 'refs/heads/pull/1/head')
-        assert isinstance(res[0].ref, Head)
+        self.assertIsInstance(res[0].ref, Head)
 
     @with_rw_repo('HEAD', bare=False)
     def test_multiple_urls(self, rw_repo):
@@ -626,3 +629,14 @@ class TestRemote(TestBase):
         self.assertEqual(list(remote.urls), [test3])
         # will raise fatal: Will not delete all non-push URLs
         assert_raises(GitCommandError, remote.delete_url, test3)
+
+    def test_fetch_error(self):
+        rem = self.rorepo.remote('origin')
+        with self.assertRaisesRegex(GitCommandError, "Couldn't find remote ref __BAD_REF__"):
+            rem.fetch('__BAD_REF__')
+
+    @with_rw_repo('0.1.6', bare=False)
+    def test_push_error(self, repo):
+        rem = repo.remote('origin')
+        with self.assertRaisesRegex(GitCommandError, "src refspec __BAD_REF__ does not match any"):
+            rem.push('__BAD_REF__')

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -472,12 +472,16 @@ class TestRepo(TestBase):
         head = self.rorepo.create_head("new_head", "HEAD~1")
         self.rorepo.delete_head(head)
 
-        tag = self.rorepo.create_tag("new_tag", "HEAD~2")
-        self.rorepo.delete_tag(tag)
+        try:
+            tag = self.rorepo.create_tag("new_tag", "HEAD~2")
+        finally:
+            self.rorepo.delete_tag(tag)
         with self.rorepo.config_writer():
             pass
-        remote = self.rorepo.create_remote("new_remote", "git@server:repo.git")
-        self.rorepo.delete_remote(remote)
+        try:
+            remote = self.rorepo.create_remote("new_remote", "git@server:repo.git")
+        finally:
+            self.rorepo.delete_remote(remote)
 
     def test_comparison_and_hash(self):
         # this is only a preliminary test, more testing done in test_index

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -418,7 +418,7 @@ class TestSubmodule(TestBase):
         # Error if there is no submodule file here
         self.failUnlessRaises(IOError, Submodule._config_parser, rwrepo, rwrepo.commit(self.k_no_subm_tag), True)
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
+    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,  ## ACTUALLY skipped by `git.submodule.base#L869`.
     #         "FIXME: fails with: PermissionError: [WinError 32] The process cannot access the file because"
     #         "it is being used by another process: "
     #         "'C:\\Users\\ankostis\\AppData\\Local\\Temp\\tmp95c3z83bnon_bare_test_base_rw\\git\\ext\\gitdb\\gitdb\\ext\\smmap'")  # noqa E501

--- a/git/util.py
+++ b/git/util.py
@@ -17,7 +17,7 @@ import time
 from functools import wraps
 
 from git.compat import is_win
-from gitdb.util import (# NOQA
+from gitdb.util import (# NOQA @IgnorePep8
     make_sha,
     LockedFD,               # @UnusedImport
     file_contents_ro,       # @UnusedImport

--- a/git/util.py
+++ b/git/util.py
@@ -51,6 +51,7 @@ __all__ = ("stream_copy", "join_path", "to_native_path_windows", "to_native_path
 #: so the errors marked with this var are considered "acknowledged" ones, awaiting remedy,
 #: till then, we wish to hide them.
 HIDE_WINDOWS_KNOWN_ERRORS = is_win and os.environ.get('HIDE_WINDOWS_KNOWN_ERRORS', True)
+HIDE_WINDOWS_FREEZE_ERRORS = is_win and os.environ.get('HIDE_WINDOWS_FREEZE_ERRORS', HIDE_WINDOWS_KNOWN_ERRORS)
 
 #{ Utility Methods
 

--- a/git/util.py
+++ b/git/util.py
@@ -199,33 +199,34 @@ class RemoteProgress(object):
     DONE_TOKEN = 'done.'
     TOKEN_SEPARATOR = ', '
 
-    __slots__ = ("_cur_line", "_seen_ops", "_error_lines")
+    __slots__ = ('_cur_line',
+                 '_seen_ops',
+                 'error_lines',  # Lines that started with 'error:' or 'fatal:'.
+                 'other_lines')  # Lines not denoting progress (i.e.g. push-infos).
     re_op_absolute = re.compile(r"(remote: )?([\w\s]+):\s+()(\d+)()(.*)")
     re_op_relative = re.compile(r"(remote: )?([\w\s]+):\s+(\d+)% \((\d+)/(\d+)\)(.*)")
 
     def __init__(self):
         self._seen_ops = list()
         self._cur_line = None
-        self._error_lines = []
-
-    def error_lines(self):
-        """Returns all lines that started with error: or fatal:"""
-        return self._error_lines
+        self.error_lines = []
+        self.other_lines = []
 
     def _parse_progress_line(self, line):
         """Parse progress information from the given line as retrieved by git-push
         or git-fetch.
 
-        Lines that seem to contain an error (i.e. start with error: or fatal:) are stored
-        separately and can be queried using `error_lines()`.
+        - Lines that do not contain progress info are stored in :attr:`other_lines`.
+        - Lines that seem to contain an error (i.e. start with error: or fatal:) are stored
+        in :attr:`error_lines`.
 
         :return: list(line, ...) list of lines that could not be processed"""
         # handle
         # Counting objects: 4, done.
         # Compressing objects:  50% (1/2)   \rCompressing objects: 100% (2/2)   \rCompressing objects: 100% (2/2), done.
         self._cur_line = line
-        if len(self._error_lines) > 0 or self._cur_line.startswith(('error:', 'fatal:')):
-            self._error_lines.append(self._cur_line)
+        if len(self.error_lines) > 0 or self._cur_line.startswith(('error:', 'fatal:')):
+            self.error_lines.append(self._cur_line)
             return []
 
         sub_lines = line.split('\r')
@@ -284,6 +285,7 @@ class RemoteProgress(object):
                 self.line_dropped(sline)
                 # Note: Don't add this line to the failed lines, as we have to silently
                 # drop it
+                self.other_lines.extend(failed_lines)
                 return failed_lines
             # END handle op code
 
@@ -309,6 +311,7 @@ class RemoteProgress(object):
                         max_count and float(max_count),
                         message)
         # END for each sub line
+        self.other_lines.extend(failed_lines)
         return failed_lines
 
     def new_message_handler(self):


### PR DESCRIPTION
+ git-daemon:
  + Use git-daemon PORT above 10k; on Windows all below need Admin rights.
  + Used relative daemon-paths with `--base-pth`.
  + Simplify git-daemon start/stop/ex-hanlding.
  +FIXED git-daemon  @with_rw_and_rw_remote_repo():
  + "Polish" most remote & config urls, converting \-->/.
  + test_base.test_with_rw_remote_and_rw_repo() PASS.
+ Remote: 
  + test_remote: apply polish-urls on `_do_test_fetch()` checking function.
  + test_remote.test_base() now freezes on Windows! (so still hidden win_err).
pump fetch-infos instead of GIL-reading stderr.
  + Push-cmd also keep (and optionally raise) any error messages.
+ `cmd.handle_process_output()` accepts null-finalizer, to pump completely
stderr before raising any errors.
+ test: Enable `TestGit.test_environment()` on Windows (to checks stderr
consumption).
+ util: delete unused `absolute_project_path()`.
+ Control separately *freezing* TCs on Windows with `git.util.HIDE_WINDOWS_FREEZE_ERRORS` flag.