### PR TITLE
FIX #535: expand also GIT_DIR var on Repo-construction

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -100,8 +100,8 @@ class Repo(object):
                 repo = Repo("$REPOSITORIES/Development/git-python.git")
 
             - In *Cygwin*, path may be a `'cygdrive/...'` prefixed path.
-            - If `None, current-directory is used.
-            - The :envvar:`GIT_DIR` if set and not empty takes precendance over this parameter.
+            - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also evals to false,
+              the current-directory is used.
         :param odbt:
             Object DataBase type - a type which is constructed by providing
             the directory containing the database objects, i.e. .git/objects. It will
@@ -114,7 +114,9 @@ class Repo(object):
         :raise InvalidGitRepositoryError:
         :raise NoSuchPathError:
         :return: git.Repo """
-        epath = os.getenv('GIT_DIR') or path or os.getcwd()
+        epath = path or os.getenv('GIT_DIR')
+        if not epath:
+            epath = os.getcwd()
         if Git.is_cygwin():
             epath = decygpath(epath)
         epath = _expand_path(epath or path or os.getcwd())

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -181,9 +181,6 @@ def git_daemon_launched(base_path, ip, port):
                               as_process=True)
         # yes, I know ... fortunately, this is always going to work if sleep time is just large enough
         time.sleep(0.5 * (1 + is_win))
-
-        yield
-
     except Exception as ex:
         msg = textwrap.dedent("""
         Launching git-daemon failed due to: %s
@@ -203,8 +200,10 @@ def git_daemon_launched(base_path, ip, port):
               CYGWIN has no daemon, but if one exists, it gets along fine (but has also paths problems).""")
         log.warning(msg, ex, ip, port, base_path, base_path, exc_info=1)
 
-        yield
+        yield  # OK, assume daemon started manually.
 
+    else:
+        yield  # Yield outside try, to avoid catching
     finally:
         if gd:
             try:

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -119,7 +119,7 @@ def with_rw_repo(working_tree_ref, bare=False):
             if bare:
                 prefix = ''
             # END handle prefix
-            repo_dir = tempfile.mktemp("%sbare_%s" % (prefix, func.__name__))
+            repo_dir = tempfile.mktemp(prefix="%sbare_%s" % (prefix, func.__name__))
             rw_repo = self.rorepo.clone(repo_dir, shared=True, bare=bare, n=True)
 
             rw_repo.head.commit = rw_repo.commit(working_tree_ref)
@@ -248,7 +248,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
         @wraps(func)
         def remote_repo_creator(self):
             rw_daemon_repo_dir = tempfile.mktemp(prefix="daemon_repo-%s-" % func.__name__)
-            rw_repo_dir = tempfile.mktemp("daemon_cloned_repo-%s-" % func.__name__)
+            rw_repo_dir = tempfile.mktemp(prefix="daemon_cloned_repo-%s-" % func.__name__)
 
             rw_daemon_repo = self.rorepo.clone(rw_daemon_repo_dir, shared=True, bare=True)
             # recursive alternates info ?


### PR DESCRIPTION
+ Ignore "empty" GIT_DIR vars.
+ Improve documentation on the constructor `path` parameter.
Minor repo-code and doc correcions.
  + Expansion of paths also `osp.normalize()` them.
  + Make Repo-fields --> class-fields to avoid initializations on
construct.
  + Explain and rename `git.repo.fun.find_git_dir()` is for submodules
(`find_submodule_git_dir()`).
