### PR TITLE
Fixes to support Python 2.6 again.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,9 @@ environment:
     matrix:
         ## MINGW
         #
+      - PYTHON: "C:\\Python26"
+        PYTHON_VERSION: "2.6"
+        GIT_PATH: "%GIT_DAEMON_PATH%"
       - PYTHON: "C:\\Python27"
         PYTHON_VERSION: "2.7"
         GIT_PATH: "%GIT_DAEMON_PATH%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   # - "pypy" - won't work as smmap doesn't work (see gitdb/.travis.yml for details)
+#matrix:
+#  allow_failures:
+#    - python: "2.6"
 git:
   # a higher depth is needed for most of the tests - must be high enough to not actually be shallow
   # as we clone our own repository in the process
@@ -15,6 +19,7 @@ install:
   - git fetch --tags
   - pip install -r test-requirements.txt
   - pip install codecov sphinx
+  - if [ "$TRAVIS_PYTHON_VERSION" == '2.6' ]; then pip install unittest2; fi
 
   # generate some reflog as git-python tests need it (in master)
   - ./init-tests-after-clone.sh

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -139,9 +139,9 @@ def dict_to_slots_and__excluded_are_none(self, d, excluded=()):
 CREATE_NO_WINDOW = 0x08000000
 
 ## CREATE_NEW_PROCESS_GROUP is needed to allow killing it afterwards,
-# seehttps://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal
+# see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal
 PROC_CREATIONFLAGS = (CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
-                      if is_win
+                      if is_win and sys.version_info >= (2, 7)
                       else 0)
 
 
@@ -245,7 +245,7 @@ class Git(LazyMixin):
                 return
 
             # can be that nothing really exists anymore ...
-            if os is None or os.kill is None:
+            if os is None or getattr(os, 'kill', None) is None:
                 return
 
             # try to kill it
@@ -831,8 +831,12 @@ class Git(LazyMixin):
         :return: Same as ``execute``"""
         # Handle optional arguments prior to calling transform_kwargs
         # otherwise these'll end up in args, which is bad.
-        _kwargs = {k: v for k, v in kwargs.items() if k in execute_kwargs}
-        kwargs = {k: v for k, v in kwargs.items() if k not in execute_kwargs}
+        _kwargs = dict()
+        for kwarg in execute_kwargs:
+            try:
+                _kwargs[kwarg] = kwargs.pop(kwarg)
+            except KeyError:
+                pass
 
         insert_after_this_arg = kwargs.pop('insert_kwargs_after', None)
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -3,7 +3,10 @@ from io import BytesIO
 import logging
 import os
 import stat
-from unittest.case import SkipTest
+try:
+    from unittest import SkipTest
+except ImportError:
+    from unittest2 import SkipTest
 import uuid
 
 import git

--- a/git/test/lib/helper.py
+++ b/git/test/lib/helper.py
@@ -7,20 +7,24 @@ from __future__ import print_function
 
 import contextlib
 from functools import wraps
+import sys
 import io
 import logging
 import os
 import tempfile
 import textwrap
 import time
-from unittest import TestCase
-import unittest
 
-from git.compat import string_types, is_win, PY3
+from git.compat import string_types, is_win
 from git.util import rmtree, cwd
 
 import os.path as osp
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
+TestCase = unittest.TestCase
 
 ospd = osp.dirname
 
@@ -335,8 +339,11 @@ class TestBase(TestCase):
       of the project history ( to assure tests don't fail for others ).
     """
 
-    if not PY3:
-        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+    # On py26, unittest2 has assertRaisesRegex
+    # On py3, unittest has assertRaisesRegex
+    # On py27, we use unittest, which names it differently:
+    if sys.version_info[0:2] == (2, 7):
+        assertRaisesRegex = TestCase.assertRaisesRegexp
 
     def _small_repo_url(self):
         """:return" a path to a small, clonable repository"""

--- a/git/test/test_base.py
+++ b/git/test/test_base.py
@@ -7,7 +7,10 @@
 import os
 import sys
 import tempfile
-from unittest import skipIf
+try:
+    from unittest import SkipTest, skipIf
+except ImportError:
+    from unittest2 import SkipTest, skipIf
 
 from git import (
     Blob,
@@ -131,7 +134,6 @@ class TestBase(TestBase):
         try:
             file_path.encode(sys.getfilesystemencoding())
         except UnicodeEncodeError:
-            from unittest import SkipTest
             raise SkipTest("Environment doesn't support unicode filenames")
 
         with open(file_path, "wb") as fp:

--- a/git/test/test_fun.py
+++ b/git/test/test_fun.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 from stat import S_IFDIR, S_IFREG, S_IFLNK
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
 
 from git.compat import PY3
 from git.index import IndexFile

--- a/git/test/test_index.py
+++ b/git/test/test_index.py
@@ -13,7 +13,10 @@ from stat import (
 )
 import sys
 import tempfile
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
 
 from git import (
     IndexFile,
@@ -149,8 +152,9 @@ class TestIndex(TestBase):
         except Exception as ex:
             msg_py3 = "required argument is not an integer"
             msg_py2 = "cannot convert argument to integer"
-            ## msg_py26 ="unsupported operand type(s) for &: 'str' and 'long'"
-            assert msg_py2 in str(ex) or msg_py3 in str(ex), str(ex)
+            msg_py26 = "unsupported operand type(s) for &: 'str' and 'long'"
+            assert msg_py2 in str(ex) or msg_py3 in str(ex) or \
+                msg_py26 in str(ex), str(ex)
 
         ## 2nd time should not fail due to stray lock file
         try:

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -6,7 +6,10 @@
 
 import random
 import tempfile
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
 
 from git import (
     RemoteProgress,

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -11,7 +11,10 @@ import os
 import pickle
 import sys
 import tempfile
-from unittest.case import skipIf
+try:
+    from unittest import skipIf, SkipTest
+except ImportError:
+    from unittest2 import skipIf, SkipTest
 
 from git import (
     InvalidGitRepositoryError,
@@ -53,7 +56,6 @@ from git.test.lib import (
 from git.util import HIDE_WINDOWS_KNOWN_ERRORS, cygpath
 from git.test.lib import with_rw_directory
 from git.util import join_path_native, rmtree, rmfile, bin_to_hex
-from unittest import SkipTest
 
 import functools as fnt
 import os.path as osp

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -3,7 +3,10 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import os
 import sys
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
 
 import git
 from git.cmd import Git

--- a/git/test/test_tree.py
+++ b/git/test/test_tree.py
@@ -6,7 +6,10 @@
 
 from io import BytesIO
 import sys
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
 
 from git import (
     Tree,

--- a/git/test/test_util.py
+++ b/git/test/test_util.py
@@ -6,7 +6,11 @@
 
 import tempfile
 import time
-from unittest.case import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    from unittest2 import skipIf
+
 
 import ddt
 

--- a/git/util.py
+++ b/git/util.py
@@ -11,11 +11,15 @@ import getpass
 import logging
 import os
 import platform
+import subprocess
 import re
 import shutil
 import stat
 import time
-from unittest.case import SkipTest
+try:
+    from unittest import SkipTest
+except ImportError:
+    from unittest2 import SkipTest
 
 from gitdb.util import (# NOQA @IgnorePep8
     make_sha,
@@ -303,7 +307,7 @@ def is_cygwin_git(git_executable):
     if not is_win:
         return False
 
-    from subprocess import check_output
+    #from subprocess import check_output
 
     is_cygwin = _is_cygwin_cache.get(git_executable)
     if is_cygwin is None:
@@ -316,8 +320,11 @@ def is_cygwin_git(git_executable):
 
             ## Just a name given, not a real path.
             uname_cmd = osp.join(git_dir, 'uname')
-            uname = check_output(uname_cmd, universal_newlines=True)
-            is_cygwin = 'CYGWIN' in uname
+            process = subprocess.Popen([uname_cmd], stdout=subprocess.PIPE,
+                                       universal_newlines=True)
+            uname_out, _ = process.communicate()
+            #retcode = process.poll()
+            is_cygwin = 'CYGWIN' in uname_out
         except Exception as ex:
             log.debug('Failed checking if running in CYGWIN due to: %r', ex)
         _is_cygwin_cache[git_executable] = is_cygwin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 gitdb>=0.6.4
 ddt>=1.1.1
+unittest2; python_version < '2.7'


### PR DESCRIPTION
GitPython 2.0.9 has some issues on Python 2.6 (see issue #540).

This PR fixes them. For details, see the commit message.
The Travis runs now pass on all Python versions including 2.6.

Please review.
