### PR TITLE
Stop emulating mmap on Windows

### DIFF
--- a/git/test/performance/test_odb.py
+++ b/git/test/performance/test_odb.py
@@ -3,10 +3,6 @@ from __future__ import print_function
 
 import sys
 from time import time
-from unittest.case import skipIf
-
-from git.compat import PY3
-from git.util import HIDE_WINDOWS_KNOWN_ERRORS
 
 from .lib import (
     TestBigRepoR
@@ -15,8 +11,6 @@ from .lib import (
 
 class TestObjDBPerformance(TestBigRepoR):
 
-    @skipIf(HIDE_WINDOWS_KNOWN_ERRORS and PY3,
-            "FIXME: smmp fails with: TypeError: Can't convert 'bytes' object to str implicitly")
     def test_random_access(self):
         results = [["Iterate Commits"], ["Iterate Blobs"], ["Retrieve Blob Data"]]
         for repo in (self.gitrorepo, self.puregitrorepo):

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -808,8 +808,6 @@ class TestRepo(TestBase):
         git_file_repo = Repo(rwrepo.working_tree_dir)
         self.assertEqual(osp.abspath(git_file_repo.git_dir), real_path_abs)
 
-    @skipIf(HIDE_WINDOWS_KNOWN_ERRORS and PY3,
-            "FIXME: smmp fails with: TypeError: Can't convert 'bytes' object to str implicitly")
     def test_file_handle_leaks(self):
         def last_commit(repo, rev, path):
             commit = next(repo.iter_commits(rev, path, max_count=1))

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -9,7 +9,6 @@ import git
 from git.cmd import Git
 from git.compat import (
     string_types,
-    is_win,
 )
 from git.exc import (
     InvalidGitRepositoryError,

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -38,20 +38,6 @@ from git.util import (
 import os.path as osp
 
 
-# Change the configuration if possible to prevent the underlying memory manager
-# to keep file handles open. On windows we get problems as they are not properly
-# closed due to mmap bugs on windows (as it appears)
-if is_win:
-    try:
-        import smmap.util  # @UnusedImport
-        smmap.util.MapRegion._test_read_into_memory = True
-    except ImportError:
-        sys.stderr.write("The submodule tests will fail as some files cannot be removed due to open file handles.\n")
-        sys.stderr.write(
-            "The latest version of gitdb uses a memory map manager which can be configured to work around this problem")
-# END handle windows platform
-
-
 class TestRootProgress(RootUpdateProgress):
 
     """Just prints messages, for now without checking the correctness of the states"""


### PR DESCRIPTION
This is the matching-fix of https://github.com/gitpython-developers/smmap/pull/30

Now 2 more "hidden-errors" TCs pass in Windows (see #525):
+ TestRepo.test_file_handle_leaks()
+ TestObjDbPerformance.test_random_access()
