### PR TITLE
Stop importing on runtime dependent projects as submodules

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -15,24 +15,6 @@ import os.path as osp
 __version__ = 'git'
 
 
-#{ Initialization
-def _init_externals():
-    """Initialize external projects by putting them into the path"""
-    if __version__ == 'git':
-        sys.path.insert(0, osp.join(osp.dirname(__file__), 'ext', 'gitdb'))
-
-    try:
-        import gitdb
-    except ImportError:
-        raise ImportError("'gitdb' could not be found in your PYTHONPATH")
-    # END verify import
-
-#} END initialization
-
-#################
-_init_externals()
-#################
-
 #{ Imports
 
 from git.config import GitConfigParser  # @NoMove @IgnorePep8


### PR DESCRIPTION
As discussed in the last comments of #511, the projects stops relying on git's _submodules_ to import its dependencies.  That means that for TravisCI to succeed, the correct revisions must exist in PyPi, and hence, more frequent releases.
