### PR TITLE
Don't change the meaning of string literals

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -3,8 +3,6 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
-from __future__ import unicode_literals
-
 import contextlib
 from functools import wraps
 import getpass


### PR DESCRIPTION
This line singlehandedly has caused a slew of painful bugs for us in production since we upgraded from 2.0.8 to 2.0.9, seeing various UnicodeDecodeErrors on repositories with branches/tags/etc that have non-ASCII characters in them.  For most repos that only use the ASCII alphabet, implicit encoding and decoding is now happening, and most of the time we get lucky because they accidentally just work.

After reverting this one liner, our production issues all went away.

@ankostis What's the reason this line was included in f11fdf1d9d22a198511b02f3ca90146cfa5deb5c? It's the only module in the GitPython code base now that uses unicode literals, which makes reasoning about the code related to strings in this module rather confusing.  Could we perhaps just change the strings that _should_ be unicode for your patch and mark those with `u'...'` string literals explicitly rather than changing the meaning of all strings at once?
