### PR TITLE
Retrofit `repo` class as context-man to cleanup global mman on repo-delete

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -49,7 +49,8 @@ from git.util import (                  # @NoMove @IgnorePep8
     LockFile,
     BlockingLockFile,
     Stats,
-    Actor
+    Actor,
+    rmtree,
 )
 
 #} END imports

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -822,27 +822,30 @@ class Git(LazyMixin):
             is realized as non-existent
 
         :param kwargs:
-            is a dict of keyword arguments.
-            This function accepts the same optional keyword arguments
-            as execute().
-
-        ``Examples``::
+            It contains key-values for the following:
+            - the :meth:`execute()` kwds, as listed in :var:`execute_kwargs`;
+            - "command options" to be converted by :meth:`transform_kwargs()`;
+            - the `'insert_kwargs_after'` key which its value must match one of ``*args``,
+              and any cmd-options will be appended after the matched arg.
+        
+        Examples::
+        
             git.rev_list('master', max_count=10, header=True)
+        
+        turns into::
+        
+           git rev-list max-count 10 --header master
 
         :return: Same as ``execute``"""
         # Handle optional arguments prior to calling transform_kwargs
         # otherwise these'll end up in args, which is bad.
-        _kwargs = dict()
-        for kwarg in execute_kwargs:
-            try:
-                _kwargs[kwarg] = kwargs.pop(kwarg)
-            except KeyError:
-                pass
+        exec_kwargs = dict((k, v) for k, v in kwargs.items() if k in execute_kwargs)
+        opts_kwargs = dict((k, v) for k, v in kwargs.items() if k not in execute_kwargs)
 
-        insert_after_this_arg = kwargs.pop('insert_kwargs_after', None)
+        insert_after_this_arg = opts_kwargs.pop('insert_kwargs_after', None)
 
         # Prepare the argument list
-        opt_args = self.transform_kwargs(**kwargs)
+        opt_args = self.transform_kwargs(**opts_kwargs)
         ext_args = self.__unpack_args([a for a in args if a is not None])
 
         if insert_after_this_arg is None:
@@ -851,11 +854,11 @@ class Git(LazyMixin):
             try:
                 index = ext_args.index(insert_after_this_arg)
             except ValueError:
-                raise ValueError("Couldn't find argument '%s' in args %s to insert kwargs after"
+                raise ValueError("Couldn't find argument '%s' in args %s to insert cmd options after"
                                  % (insert_after_this_arg, str(ext_args)))
             # end handle error
             args = ext_args[:index + 1] + opt_args + ext_args[index + 1:]
-        # end handle kwargs
+        # end handle opts_kwargs
 
         call = [self.GIT_PYTHON_GIT_EXECUTABLE]
 
@@ -870,7 +873,7 @@ class Git(LazyMixin):
         call.append(dashify(method))
         call.extend(args)
 
-        return self.execute(call, **_kwargs)
+        return self.execute(call, **exec_kwargs)
 
     def _parse_object_header(self, header_line):
         """


### PR DESCRIPTION
Some changes for this release:
See #553 for difficulties when working on Windows, where open file-handles actually "lock" the underlying files, and repos cannot be deleted.

More changes:

- Small pythonism on  #541, improves  docstring of `cmd._call_process()`.
- Export `gitpython.util.rmtree()` for deleting repos in *Windows* where blobs are readonly.