### PR TITLE
DOC: minor typo

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -459,7 +459,7 @@ class Repo(object):
         :note: to receive only commits between two named revisions, use the
             "revA...revB" revision specifier
 
-        :return ``git.Commit[]``"""
+        :return: ``git.Commit[]``"""
         if rev is None:
             rev = self.head.commit
 


### PR DESCRIPTION
This fixes the documentation there: http://gitpython.readthedocs.io/en/stable/reference.html#git.repo.base.Repo.iter_commits