### PR TITLE
Doc fix: Using camellcase package name in "pip install" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you have downloaded the source code:
 
 or if you want to obtain a copy from the Pypi repository:
 
-    pip install gitpython
+    pip install GitPython
 
 Both commands will install the required package dependencies.
 


### PR DESCRIPTION
The pip install command in documentation refers the package in lower case "gitpython" instead of the actual package name in camellcase "GitPython"