### PR TITLE
cmd.py: AutoInterrupt.__del__: Avoid some unwanted tracebacks by catching some more errors

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -261,7 +261,12 @@ class Git(LazyMixin):
                 # for some reason, providing None for stdout/stderr still prints something. This is why
                 # we simply use the shell and redirect to nul. Its slower than CreateProcess, question
                 # is whether we really want to see all these messages. Its annoying no matter what.
-                call(("TASKKILL /F /T /PID %s 2>nul 1>nul" % str(proc.pid)), shell=True)
+                try:
+                    call(("TASKKILL /F /T /PID %s 2>nul 1>nul" % str(proc.pid)), shell=True)
+                except:
+                    pass
+            except:
+                pass
             # END exception handling
 
         def __getattr__(self, attr):


### PR DESCRIPTION
I see the following in an application that uses GitPython:
When the application raises an unknown exception it terminates with sys.exit(2)

When the exception is raised by GitPython I see that I land in the following line (although my application is running on Linux):
call(("TASKKILL /F /T /PID %s 2>nul 1>nul" % str(proc.pid)), shell=True)

Here I get the following exception (not always but in some cases):
Exception ignored in: <bound method GitRepository.__del__ of <GitRepository '/big/yocto/msc-ldk'>>
Traceback (most recent call last):
  File "/home/srei/work/git/GitPython/git/repo/base.py", line 182, in __del__
  File "/home/srei/work/git/GitPython/git/cmd.py", line 965, in clear_cache
  File "/home/srei/work/git/GitPython/git/cmd.py", line 265, in __del__
  File "/usr/lib/python3.4/subprocess.py", line 537, in call
TypeError: 'NoneType' object is not callable

I took a look at the attribute error exception: it was the following:
'NoneType' object has no attribute 'SIGTERM'

I fixed this problem by wrapping the call line in a try: except block

However there remained another problem (that happened also only in rare cases):
Exception ignored in: <bound method GitRepository.__del__ of <GitRepository '/big/yocto/msc-ldk'>>
Traceback (most recent call last):
  File "/home/srei/work/git/GitPython/git/repo/base.py", line 182, in __del__
  File "/home/srei/work/git/GitPython/git/cmd.py", line 967, in clear_cache
  File "/home/srei/work/git/GitPython/git/cmd.py", line 254, in __del__
  File "/usr/lib/python3.4/subprocess.py", line 1686, in terminate
  File "/usr/lib/python3.4/subprocess.py", line 1681, in send_signal
TypeError: an integer is required (got type NoneType)

I fixed this one by adding a general except for proc.terminate and proc.wait

It would be really great when you would merge this improvement. These sporadic tracebacks are really annoying