### PR TITLE
fix(cmd): checking process.DEVNUL were needlessly opening `os.devnull`

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -580,7 +580,7 @@ class Git(LazyMixin):
 
         stdout_sink = (PIPE
                        if with_stdout
-                       else getattr(subprocess, 'DEVNULL', open(os.devnull, 'wb')))
+                       else getattr(subprocess, 'DEVNULL', None) or open(os.devnull, 'wb'))
         log.debug("Popen(%s, cwd=%s, universal_newlines=%s, shell=%s)",
                   command, cwd, universal_newlines, shell)
         try:


### PR DESCRIPTION
Also this fixes resource-leak warning on Windows Python-3.5.3+:

```
D:\python-3.5.2.amd64\lib\site-packages\git\cmd.py:583: ResourceWarning:
unclosed file <_io.BufferedWriter name='nul'>
  else getattr(subprocess, 'DEVNULL', open(os.devnull, 'wb')))
```