### PR TITLE
check for GIT_WORK_TREE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,5 +16,6 @@ Contributors are:
 -Vincent Driessen <me _at_ nvie.com>
 -Phil Elson <pelson _dot_ pub _at_ gmail.com>
 -Bernard `Guyzmo` Pratz <guyzmo+gitpython+pub@m0g.net>
+-Timothy B. Hartman <tbhartman _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -133,7 +133,7 @@ class Repo(object):
             # removed. It's just cleaner.
             if is_git_dir(curpath):
                 self.git_dir = curpath
-                self._working_tree_dir = os.path.dirname(self.git_dir)
+                self._working_tree_dir = os.getenv('GIT_WORK_TREE', os.path.dirname(self.git_dir))
                 break
 
             sm_gitpath = find_submodule_git_dir(osp.join(curpath, '.git'))


### PR DESCRIPTION
This uses GIT_WORK_TREE environment variable if present.

In response to gitpython-developers/GitPython/issues/587.

Not all tests are passing on my master, but no new tests are failing with my commit.

I have added a test.