### PR TITLE
BF: there is no exc variable, raising NotASurrogateError if that is the right thing todo

### DIFF
--- a/git/compat.py
+++ b/git/compat.py
@@ -204,7 +204,7 @@ def replace_surrogate_encode(mystring):
         # The following magic comes from Py3.3's Python/codecs.c file:
         if not 0xD800 <= code <= 0xDCFF:
             # Not a surrogate. Fail with the original exception.
-            raise exc
+            raise NotASurrogateError
         # mybytes = [0xe0 | (code >> 12),
         #            0x80 | ((code >> 6) & 0x3f),
         #            0x80 | (code & 0x3f)]


### PR DESCRIPTION
a blind fix for a blind (not tested) line of code which has some variable lost from old pre-refactoring code I guess ;)

PS FWIW -- we have managed to run into it in quite a strange place, so not really sure how yet, here is our backtrace with 2.1.0 GitPython on Debian stretch
```
======================================================================
ERROR: Failure: NameError (global name 'exc' is not defined)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/buildbot/datalad-pr-docker-dl-nd90/build/datalad/tests/test__main__.py", line 17, in <module>
    from .. import __main__, __version__
  File "/home/buildbot/datalad-pr-docker-dl-nd90/build/datalad/__main__.py", line 13, in <module>
    from .auto import AutomagicIO
  File "/home/buildbot/datalad-pr-docker-dl-nd90/build/datalad/auto.py", line 20, in <module>
    import h5py
  File "/usr/lib/python2.7/dist-packages/h5py/__init__.py", line 60, in <module>
    from .tests import run_tests
  File "/usr/lib/python2.7/dist-packages/h5py/tests/__init__.py", line 15, in <module>
    from . import old, hl
  File "/usr/lib/python2.7/dist-packages/h5py/tests/old/__init__.py", line 4, in <module>
    from . import ( test_attrs,
  File "/usr/lib/python2.7/dist-packages/h5py/tests/old/test_group.py", line 41, in <module>
    fsencode(u"α")
  File "/usr/lib/python2.7/dist-packages/h5py/_hl/compat.py", line 68, in fsencode
    return filename.encode(encoding, errors)
  File "/usr/lib/python2.7/dist-packages/git/compat.py", line 180, in surrogateescape_handler
    decoded = replace_surrogate_encode(mystring)
  File "/usr/lib/python2.7/dist-packages/git/compat.py", line 207, in replace_surrogate_encode
    raise exc
NameError: global name 'exc' is not defined
```