### PR TITLE
Add Code Climate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  pep8:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.py"
+exclude_paths: 


### PR DESCRIPTION
This commit configures code quality analysis by Code Climate.

Results are provided by open source Code Climate engines. Based on
the languages present in this repository, I've enabled the following
engines:

 - duplication
 - pep8
 - radon