### PR TITLE
BF: pass original exception into replace_surrogate_encode

### DIFF
--- a/git/compat.py
+++ b/git/compat.py
@@ -177,7 +177,7 @@ def surrogateescape_handler(exc):
             # exception anyway after this function is called, even though I think
             # it's doing what it should. It seems that the strict encoder is called
             # to encode the unicode string that this function returns ...
-            decoded = replace_surrogate_encode(mystring)
+            decoded = replace_surrogate_encode(mystring, exc)
         else:
             raise exc
     except NotASurrogateError:
@@ -189,7 +189,7 @@ class NotASurrogateError(Exception):
     pass
 
 
-def replace_surrogate_encode(mystring):
+def replace_surrogate_encode(mystring, exc):
     """
     Returns a (unicode) string, not the more logical bytes, because the codecs
     register_error functionality expects this.
@@ -204,7 +204,7 @@ def replace_surrogate_encode(mystring):
         # The following magic comes from Py3.3's Python/codecs.c file:
         if not 0xD800 <= code <= 0xDCFF:
             # Not a surrogate. Fail with the original exception.
-            raise NotASurrogateError
+            raise exc
         # mybytes = [0xe0 | (code >> 12),
         #            0x80 | ((code >> 6) & 0x3f),
         #            0x80 | (code & 0x3f)]


### PR DESCRIPTION
Fixes my incorrect fix in #598 ;-)