### PR TITLE
remote: compatibility with git version > 2.10

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -212,10 +212,15 @@ class FetchInfo(object):
 
     _flag_map = {'!': ERROR,
                  '+': FORCED_UPDATE,
-                 '-': TAG_UPDATE,
                  '*': 0,
                  '=': HEAD_UPTODATE,
                  ' ': FAST_FORWARD}
+
+    v = Git().version_info[:2]
+    if v >= (2, 10):
+        _flag_map['t'] = TAG_UPDATE
+    else:
+        _flag_map['-'] = TAG_UPDATE
 
     def __init__(self, ref, flags, note='', old_commit=None, remote_ref_path=None):
         """
@@ -629,7 +634,7 @@ class Remote(LazyMixin, Iterable):
         fetch_info_lines = list()
         # Basically we want all fetch info lines which appear to be in regular form, and thus have a
         # command character. Everything else we ignore,
-        cmds = set(PushInfo._flag_map.keys()) & set(FetchInfo._flag_map.keys())
+        cmds = set(FetchInfo._flag_map.keys())
 
         progress_handler = progress.new_message_handler()
         handle_process_output(proc, None, progress_handler, finalizer=None, decode_streams=False)


### PR DESCRIPTION
I found that a little change which affects the behavior of `git.remote.FetchInfo` as git version greater than or equal with 2.10.x. It case `git.test.test_remote.TestRemote.test_base` fails.

I figure out that a [commit](https://github.com/git/git/commit/2cb040baa6fcb8a6314a54933cbcb4d3fcb60401) of git changes  `git fetch --tags`'s output.
And it seems that that commit first appeared in git 2.10.0
```
➜  git git:(master) git log --oneline v2.9.3..v2.10.0 | grep 2cb0
2cb040b fetch: change flag code for displaying tag update and deleted ref
```

I have almost no contribution on github. Beg pardon if I am not doing it well.