### PR TITLE
WIP: use `cygpath.exe` to convert Windows paths and respect mount-points

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -6,6 +6,10 @@ Changelog
 ====================================
 
 * support for worktrees
+* fix(cygwin): use ``cygpath.exe`` to convert *Windows* paths and respect
+  different mount-points (e.g. *MSYS2* which is a *Cygwin* clone mounts drives
+  under root).
+
 
 2.1.3 - Bugfixes
 ====================================
@@ -34,7 +38,7 @@ Notable fixes
 * The `GIT_DIR` environment variable does not override the `path` argument when
   initializing a `Repo` object anymore. However, if said `path` unset, `GIT_DIR`
   will be used to fill the void.
-  
+
 All issues and PRs can be viewed in all detail when following this URL:
 https://github.com/gitpython-developers/GitPython/issues?q=is%3Aclosed+milestone%3A%22v2.1.0+-+proper+windows+support%22
 
@@ -63,7 +67,7 @@ https://github.com/gitpython-developers/GitPython/issues?q=is%3Aclosed+milestone
 2.0.7 - New Features
 ====================
 
-* `IndexFile.commit(...,skip_hooks=False)` added. This parameter emulates the 
+* `IndexFile.commit(...,skip_hooks=False)` added. This parameter emulates the
    behaviour of `--no-verify` on the command-line.
 
 2.0.6 - Fixes and Features
@@ -103,7 +107,7 @@ https://github.com/gitpython-developers/GitPython/issues?q=is%3Aclosed+milestone
   commit messages contained ``\r`` characters
 * Fix: progress handler exceptions are not caught anymore, which would usually just hide bugs
   previously.
-* Fix: The `Git.execute` method will now redirect `stdout` to `devnull` if `with_stdout` is false, 
+* Fix: The `Git.execute` method will now redirect `stdout` to `devnull` if `with_stdout` is false,
   which is the intended behaviour based on the parameter's documentation.
 
 2.0.2 - Fixes

--- a/git/util.py
+++ b/git/util.py
@@ -350,7 +350,7 @@ def is_cygwin_git(git_executable):
                                        universal_newlines=True)
             uname_out, _ = process.communicate()
             #retcode = process.poll()
-            is_cygwin = 'CYGWIN' in uname_out
+            is_cygwin = 'CYGWIN' in uname_out or 'MSYS' in uname_out
         except Exception as ex:
             log.debug('Failed checking if running in CYGWIN due to: %r', ex)
         _is_cygwin_cache[git_executable] = is_cygwin

--- a/git/util.py
+++ b/git/util.py
@@ -4,7 +4,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import contextlib
-from functools import wraps
+from functools import wraps, lru_cache
 import getpass
 import logging
 import os
@@ -286,6 +286,7 @@ _cygpath_parsers = (
 )
 
 
+@lru_cache()
 def cygpath(path):
     """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
     for regex, parser, recurse in _cygpath_parsers:

--- a/git/util.py
+++ b/git/util.py
@@ -4,7 +4,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import contextlib
-from functools import wraps, lru_cache
+from functools import wraps
 import getpass
 import logging
 import os
@@ -18,6 +18,10 @@ try:
     from unittest import SkipTest
 except ImportError:
     from unittest2 import SkipTest
+try:
+    from functools import lru_cache
+except ImportError:
+    from repoze.lru import lru_cache
 
 from gitdb.util import (# NOQA @IgnorePep8
     make_sha,
@@ -286,7 +290,7 @@ _cygpath_parsers = (
 )
 
 
-@lru_cache()
+@lru_cache(500)  # Sice arg required only for py3.2 backport `repoze.lru` lib.
 def cygpath(path):
     """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
     for regex, parser, recurse in _cygpath_parsers:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 gitdb>=0.6.4
 ddt>=1.1.1
+ordereddict; python_version < '2.7'
+repoze.lru; python_version < '3.2'
 unittest2; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ def _stamp_version(filename):
 install_requires = ['gitdb2 >= 2.0.0']
 extras_require = {
     ':python_version == "2.6"': ['ordereddict'],
+    ':python_version < "3.2"': ['repoze.lru'],
 }
 test_requires = ['ddt>=1.1.1']
 if sys.version_info[:2] < (2, 7):


### PR DESCRIPTION
Currently the `/cygdrive/` mount-point is hard-coded in GitPython's conversions `git/utils.py` since version 2.1.3 that Cygwin support was added.  This PR purports to use Cygwin's `cygpath -w | -u` utility for path conversions.  
An added benefit is support out-of-the-box for *MSYS2* which is a *Cygwin* clone based on the excellent *pacman* package manager that (at last) mounts Windows-drives under root(`/`).

It is still a WorkInProgress (WIP) because although [all *travis* TCs pass](https://travis-ci.org/ankostis/GitPython/builds/250043838) on the POSIX part, *appveyor* now fails on all non-Cygwin builds; prior to this PR, it was only Cygwin builds that were failing in a couple of TCs: https://ci.appveyor.com/project/ankostis/gitpython/build/1.0.443).