### PR TITLE
worktrees: make non-packed refs also work correctly.

### DIFF
--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -37,6 +37,10 @@ class RemoteReference(Head):
         # and delete remainders manually
         for ref in refs:
             try:
+                os.remove(osp.join(repo.common_dir, ref.path))
+            except OSError:
+                pass
+            try:
                 os.remove(osp.join(repo.git_dir, ref.path))
             except OSError:
                 pass

--- a/git/remote.py
+++ b/git/remote.py
@@ -652,7 +652,7 @@ class Remote(LazyMixin, Iterable):
                     continue
 
         # read head information
-        with open(osp.join(self.repo.git_dir, 'FETCH_HEAD'), 'rb') as fp:
+        with open(osp.join(self.repo.common_dir, 'FETCH_HEAD'), 'rb') as fp:
             fetch_head_info = [l.decode(defenc) for l in fp.readlines()]
 
         l_fil = len(fetch_info_lines)

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -74,6 +74,7 @@ class Repo(object):
     working_dir = None
     _working_tree_dir = None
     git_dir = None
+    _common_dir = None
 
     # precompiled regex
     re_whitespace = re.compile(r'\s+')
@@ -169,17 +170,23 @@ class Repo(object):
             # lets not assume the option exists, although it should
             pass
 
+        try:
+            common_dir = open(osp.join(self.git_dir, 'commondir'), 'rt').readlines()[0].strip()
+            self._common_dir = osp.join(self.git_dir, common_dir)
+        except (OSError, IOError):
+            self._common_dir = None
+
         # adjust the wd in case we are actually bare - we didn't know that
         # in the first place
         if self._bare:
             self._working_tree_dir = None
         # END working dir handling
 
-        self.working_dir = self._working_tree_dir or self.git_dir
+        self.working_dir = self._working_tree_dir or self.common_dir
         self.git = self.GitCommandWrapperType(self.working_dir)
 
         # special handling, in special times
-        args = [osp.join(self.git_dir, 'objects')]
+        args = [osp.join(self.common_dir, 'objects')]
         if issubclass(odbt, GitCmdObjectDB):
             args.append(self.git)
         self.odb = odbt(*args)
@@ -235,6 +242,13 @@ class Repo(object):
         """:return: The working tree directory of our git repository. If this is a bare repository, None is returned.
         """
         return self._working_tree_dir
+
+    @property
+    def common_dir(self):
+        """:return: The git dir that holds everything except possibly HEAD,
+        FETCH_HEAD, ORIG_HEAD, COMMIT_EDITMSG, index, and logs/ .
+        """
+        return self._common_dir or self.git_dir
 
     @property
     def bare(self):
@@ -574,7 +588,7 @@ class Repo(object):
         :note:
             The method does not check for the existence of the paths in alts
             as the caller is responsible."""
-        alternates_path = osp.join(self.git_dir, 'objects', 'info', 'alternates')
+        alternates_path = osp.join(self.common_dir, 'objects', 'info', 'alternates')
         if not alts:
             if osp.isfile(alternates_path):
                 os.remove(alternates_path)
@@ -932,7 +946,7 @@ class Repo(object):
             * All remaining keyword arguments are given to the git-clone command
 
         :return: ``git.Repo`` (the newly cloned repo)"""
-        return self._clone(self.git, self.git_dir, path, type(self.odb), progress, **kwargs)
+        return self._clone(self.git, self.common_dir, path, type(self.odb), progress, **kwargs)
 
     @classmethod
     def clone_from(cls, url, to_path, progress=None, env=None, **kwargs):

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -935,6 +935,8 @@ class TestRepo(TestBase):
         commit = repo.head.commit
         self.assertIsInstance(commit, Object)
 
+        self.assertIsInstance(repo.heads['aaaaaaaa'], Head)
+
     @with_rw_directory
     def test_git_work_tree_env(self, rw_dir):
         """Check that we yield to GIT_WORK_TREE"""


### PR DESCRIPTION
Turns out aec58a9 did the right thing for /packed/ refs, but didn't work
correctly on /unpacked/ refs.  So this patch gives unpacked refs the
same treatment.

Without the fix here, the test added will cause this traceback:

======================================================================
ERROR: Check that we find .git as a worktree file and find the worktree
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pjones/devel/github.com/GitPython/git/test/lib/helper.py", line 92, in wrapper
    return func(self, path)
  File "/home/pjones/devel/github.com/GitPython/git/test/test_repo.py", line 938, in test_git_work_tree_dotgit
    self.assertIsInstance(repo.heads['aaaaaaaa'], Head)
  File "/home/pjones/devel/github.com/GitPython/git/util.py", line 893, in __getitem__
    raise IndexError("No item found with id %r" % (self._prefix + index))
IndexError: No item found with id 'aaaaaaaa'

Woops.

Signed-off-by: Peter Jones <pjones@redhat.com>