### PR TITLE
util: move expand_path from repo/base and use it in Git class init

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,5 +19,6 @@ Contributors are:
 -Timothy B. Hartman <tbhartman _at_ gmail.com>
 -Konstantin Popov <konstantin.popov.89 _at_ yandex.ru>
 -Peter Jones <pjones _at_ redhat.com>
+-Alexis Horgix Chotard
 
 Portions derived from other open source works and are clearly marked.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -31,7 +31,7 @@ from git.compat import (
 )
 from git.exc import CommandError
 from git.odict import OrderedDict
-from git.util import is_cygwin_git, cygpath
+from git.util import is_cygwin_git, cygpath, expand_path
 
 from .exc import (
     GitCommandError,
@@ -405,7 +405,7 @@ class Git(LazyMixin):
            It is meant to be the working tree directory if available, or the
            .git directory in case of bare repositories."""
         super(Git, self).__init__()
-        self._working_dir = working_dir
+        self._working_dir = expand_path(working_dir)
         self._git_options = ()
         self._persistent_git_options = []
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -29,7 +29,7 @@ from git.index import IndexFile
 from git.objects import Submodule, RootModule, Commit
 from git.refs import HEAD, Head, Reference, TagReference
 from git.remote import Remote, add_progress, to_progress_instance
-from git.util import Actor, finalize_process, decygpath, hex_to_bin
+from git.util import Actor, finalize_process, decygpath, hex_to_bin, expand_path
 import os.path as osp
 
 from .fun import rev_parse, is_git_dir, find_submodule_git_dir, touch, find_worktree_git_dir
@@ -48,10 +48,6 @@ BlameEntry = namedtuple('BlameEntry', ['commit', 'linenos', 'orig_path', 'orig_l
 
 
 __all__ = ('Repo',)
-
-
-def _expand_path(p):
-    return osp.normpath(osp.abspath(osp.expandvars(osp.expanduser(p))))
 
 
 class Repo(object):
@@ -121,7 +117,7 @@ class Repo(object):
             epath = os.getcwd()
         if Git.is_cygwin():
             epath = decygpath(epath)
-        epath = _expand_path(epath or path or os.getcwd())
+        epath = expand_path(epath or path or os.getcwd())
         if not os.path.exists(epath):
             raise NoSuchPathError(epath)
 
@@ -148,7 +144,7 @@ class Repo(object):
                 sm_gitpath = find_worktree_git_dir(dotgit)
 
             if sm_gitpath is not None:
-                self.git_dir = _expand_path(sm_gitpath)
+                self.git_dir = expand_path(sm_gitpath)
                 self._working_tree_dir = curpath
                 break
 
@@ -867,7 +863,7 @@ class Repo(object):
 
         :return: ``git.Repo`` (the newly created repo)"""
         if path:
-            path = _expand_path(path)
+            path = expand_path(path)
         if mkdir and path and not osp.exists(path):
             os.makedirs(path, 0o755)
 

--- a/git/util.py
+++ b/git/util.py
@@ -340,6 +340,13 @@ def finalize_process(proc, **kwargs):
     ## TODO: No close proc-streams??
     proc.wait(**kwargs)
 
+
+def expand_path(p):
+    try:
+        return osp.normpath(osp.abspath(osp.expandvars(osp.expanduser(p))))
+    except:
+        return None
+
 #} END utilities
 
 #{ Classes


### PR DESCRIPTION
Starting using GitPython, I quickly encountered a surprising behavior: a `Repo` instance could be initialized with a path like `~/path/to/some/repo` but a `Git` instance couldn't. And indeed, `Repo` expands the path it is given while `Git` doesn't.

This PR is an attempt at fixing this by moving the `_expand_path()` method previously defined in `repo/base.py` to and `expand_path()` method in the `util/` part, and using it both where it was already used and newly in the `Git` constructor.