### PR TITLE
BF: Added missing NullHandler to logger in git.remote

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -38,6 +38,7 @@ from .refs import (
 
 
 log = logging.getLogger('git.remote')
+log.addHandler(logging.NullHandler())
 
 
 __all__ = ('RemoteProgress', 'PushInfo', 'FetchInfo', 'Remote')


### PR DESCRIPTION
Stumbled upon a `No handlers could be found for logger "git.remote"` message.
Apparently this issue has been addressed in PR #300 already. Back then `git/remote.py` wasn't included, so here is a one liner to do so.