### PR TITLE
Store submodule name

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -358,7 +358,9 @@ class Submodule(IndexObject, Iterable, Traversable):
         if sm.exists():
             # reretrieve submodule from tree
             try:
-                return repo.head.commit.tree[path]
+                sm = repo.head.commit.tree[path]
+                sm._name = name
+                return sm
             except KeyError:
                 # could only be in index
                 index = repo.index


### PR DESCRIPTION
Fixes https://github.com/gitpython-developers/GitPython/issues/678

Seems there are a plethora of things that expect to be able to get a submodule's name. However it is not defined if `Submodule.add` finds the submodule already exists. This is one attempt at trying to solve this issue.