### PR TITLE
Fix encoding issue with stderr_value and kill_after_timeout

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -780,8 +780,8 @@ class Git(LazyMixin):
                 if kill_after_timeout:
                     watchdog.cancel()
                     if kill_check.isSet():
-                        stderr_value = 'Timeout: the command "%s" did not complete in %d ' \
-                                       'secs.' % (" ".join(command), kill_after_timeout)
+                        stderr_value = ('Timeout: the command "%s" did not complete in %d '
+                                        'secs.' % (" ".join(command), kill_after_timeout)).encode(defenc)
                 # strip trailing "\n"
                 if stdout_value.endswith(b"\n"):
                     stdout_value = stdout_value[:-1]


### PR DESCRIPTION
We don't properly encode our error message under python3.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>