### PR TITLE
Converting path in _clone to str before any other operation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,5 +23,6 @@ Contributors are:
 -Ken Odegard <ken.odegard _at_ gmail.com>
 -Alexis Horgix Chotard
 -Piotr Babij <piotr.babij _at_ gmail.com>
+-Mikuláš Poul <mikulaspoul _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -905,6 +905,10 @@ class Repo(object):
 
         odbt = kwargs.pop('odbt', odb_default_type)
 
+        # when pathlib.Path or other classbased path is passed
+        if not isinstance(path, str):
+            path = str(path)
+
         ## A bug win cygwin's Git, when `--bare` or `--separate-git-dir`
         #  it prepends the cwd or(?) the `url` into the `path, so::
         #        git clone --bare  /cygwin/d/foo.git  C:\\Work

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -16,6 +16,11 @@ try:
 except ImportError:
     from unittest2 import skipIf, SkipTest
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = None
+
 from git import (
     InvalidGitRepositoryError,
     Repo,
@@ -209,6 +214,15 @@ class TestRepo(TestBase):
         cloned = Repo.clone_from(original_repo.git_dir, osp.join(rw_dir, "clone"), env=environment)
 
         assert_equal(environment, cloned.git.environment())
+
+    @with_rw_directory
+    def test_clone_from_pathlib(self, rw_dir):
+        if pathlib is None:  # pythons bellow 3.4 don't have pathlib
+            raise SkipTest("pathlib was introduced in 3.4")
+
+        original_repo = Repo.init(osp.join(rw_dir, "repo"))
+
+        Repo.clone_from(original_repo.git_dir, pathlib.Path(rw_dir) / "clone_pathlib")
 
     def test_init(self):
         prev_cwd = os.getcwd()


### PR DESCRIPTION
In case eg pathlib.Path is passed.

Fixed #684 