### PR TITLE
Only gc.collect() under windows

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -209,9 +209,17 @@ class Repo(object):
     def close(self):
         if self.git:
             self.git.clear_cache()
-            gc.collect()
+            # Tempfiles objects on Windows are holding references to
+            # open files until they are collected by the garbage
+            # collector, thus preventing deletion.
+            # TODO: Find these references and ensure they are closed
+            # and deleted synchronously rather than forcing a gc
+            # collection.
+            if is_win:
+                gc.collect()
             gitdb.util.mman.collect()
-            gc.collect()
+            if is_win:
+                gc.collect()
 
     def __eq__(self, rhs):
         if isinstance(rhs, Repo):


### PR DESCRIPTION
Under Windows, tempfile objects are holding references to open files
until the garbage collector closes them and frees them.  Explicit
calls to gc.collect() were added to the finalizer for the Repo class
to force them to be closed synchronously.  However, this is expensive,
especially in large, long-running programs.  As a temporary measure
to alleviate the performance regression on other platforms, only
perform these calls when running under Windows.

Fixes #605 