### PR TITLE
delete bom symbol

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -302,9 +302,15 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
         while True:
             # we assume to read binary !
             line = fp.readline().decode(defenc)
+
+            # Remove UTF-8 ByteOrderMark (BOM)
+            if lineno == 0:
+                line = line.replace('\ufeff', '')
             if not line:
                 break
-            lineno = lineno + 1
+
+            lineno += 1
+
             # comment or blank line?
             if line.strip() == '' or self.re_comment.match(line):
                 continue


### PR DESCRIPTION
Hi!
Error fix:

>>> import git
>>> repository = git.Repo("/home/bat/Apps/fsoft/")
>>> repository.submodules

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/bat/Apps/GitPython/git/repo/base.py", line 323, in submodules
    return Submodule.list_items(self)
  File "/home/bat/Apps/GitPython/git/util.py", line 942, in list_items
    out_list.extend(cls.iter_items(repo, *args, **kwargs))
  File "/home/bat/Apps/GitPython/git/objects/submodule/base.py", line 1171, in iter_items
    for sms in parser.sections():
  File "/home/bat/Apps/GitPython/git/config.py", line 78, in assure_data_present
    self.read()
  File "/home/bat/Apps/GitPython/git/config.py", line 412, in read
    self._read(fp, fp.name)
  File "/home/bat/Apps/GitPython/git/config.py", line 337, in _read
    raise cp.MissingSectionHeaderError(fpname, lineno, line)
configparser.MissingSectionHeaderError: File contains no section headers.
file: '/home/bat/Apps/fsoft/.gitmodules', line: 1
'\ufeff[submodule "eflib"]\n'
