### PR TITLE
 Enable git diff-tree with empty second tree-ish param 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,5 +26,6 @@ Contributors are:
 -Mikuláš Poul <mikulaspoul _at_ gmail.com>
 -Charles Bouchard-Légaré <cblegare.atl _at_ ntis.ca>
 -Yaroslav Halchenko <debian _at_ onerussian.com>
+-Stefan Gangefors
 
 Portions derived from other open source works and are clearly marked.

--- a/git/diff.py
+++ b/git/diff.py
@@ -82,6 +82,7 @@ class Diffable(object):
         :param other:
             Is the item to compare us with.
             If None, we will be compared to the working tree.
+            If empty string, it will be compared to it's parent with diff-tree.
             If Treeish, it will be compared against the respective tree
             If Index ( type ), it will be compared against the index.
             If git.NULL_TREE, it will compare against the empty tree.
@@ -132,7 +133,8 @@ class Diffable(object):
             diff_cmd = self.repo.git.diff_tree
         elif other is not None:
             args.insert(0, '-r')  # recursive diff-tree
-            args.insert(0, other)
+            if other != '':
+                args.insert(0, other)
             diff_cmd = self.repo.git.diff_tree
 
         args.insert(0, self)

--- a/git/diff.py
+++ b/git/diff.py
@@ -81,7 +81,7 @@ class Diffable(object):
 
         :param other:
             Is the item to compare us with.
-            If None, we will be compared to the working tree.
+            If None, it will be compared to the working tree.
             If empty string, it will be compared to it's parent with diff-tree.
             If Treeish, it will be compared against the respective tree
             If Index ( type ), it will be compared against the index.

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -266,3 +266,17 @@ class TestDiff(TestBase):
         cp = c.parents[0]
         diff_index = c.diff(cp, ["does/not/exist"])
         self.assertEqual(len(diff_index), 0)
+
+    def test_diff_tree_empty_other(self):
+        initial_commit = self.rorepo.commit('9066712dca21ef35c534e068f2cc4fefdccf1ea3')
+
+        # Test that we can use an empty string as other in a diff.
+        # It should do a diff-tree without the second tree-ish param
+        diff_index = initial_commit.diff('')
+        self.assertEqual(len(diff_index), 16)
+        self.assertEqual(diff_index[0].change_type, 'M')
+        self.assertTrue(diff_index[12].deleted_file)
+        self.assertTrue(diff_index[14].renamed)
+        self.assertEqual(diff_index[14].rename_from, 'test/asserts.py')
+        self.assertEqual(diff_index[14].rename_to, 'test/testlib/asserts.py')
+        self.assertEqual(diff_index[15].change_type, 'A')


### PR DESCRIPTION
Executing `git diff-tree` and omitting the second tree-ish argument
wasn't possible before. This PR enables this behaviour by allowing
the caller to send in an empty string.

Allowing an empty string keeps backwards compatibility for all other
allowed input types.