### PR TITLE
Avoid from_timestamp() function to raise an exception when the offset…

### DIFF
--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -121,8 +121,11 @@ utc = tzoffset(0, 'UTC')
 def from_timestamp(timestamp, tz_offset):
     """Converts a timestamp + tz_offset into an aware datetime instance."""
     utc_dt = datetime.fromtimestamp(timestamp, utc)
-    local_dt = utc_dt.astimezone(tzoffset(tz_offset))
-    return local_dt
+    try:
+        local_dt = utc_dt.astimezone(tzoffset(tz_offset))
+        return local_dt
+    except ValueError:
+        return utc_dt
 
 
 def parse_date(string_date):

--- a/git/test/test_util.py
+++ b/git/test/test_util.py
@@ -7,7 +7,7 @@
 import tempfile
 import time
 from unittest import skipIf
-
+from datetime import datetime
 
 import ddt
 
@@ -18,7 +18,8 @@ from git.objects.util import (
     utctz_to_altz,
     verify_utctz,
     parse_date,
-)
+    tzoffset,
+    from_timestamp)
 from git.test.lib import (
     TestBase,
     assert_equal
@@ -260,3 +261,16 @@ class TestUtils(TestBase):
 
         self.failUnlessRaises(IndexError, ilist.__delitem__, 0)
         self.failUnlessRaises(IndexError, ilist.__delitem__, 'something')
+
+    def test_from_timestamp(self):
+        # Correct offset: UTC+2, should return datetime + tzoffset(+2)
+        altz = utctz_to_altz('+0200')
+        self.assertEqual(datetime.fromtimestamp(1522827734, tzoffset(altz)), from_timestamp(1522827734, altz))
+
+        # Wrong offset: UTC+58, should return datetime + tzoffset(UTC)
+        altz = utctz_to_altz('+5800')
+        self.assertEqual(datetime.fromtimestamp(1522827734, tzoffset(0)), from_timestamp(1522827734, altz))
+
+        # Wrong offset: UTC-9000, should return datetime + tzoffset(UTC)
+        altz = utctz_to_altz('-9000')
+        self.assertEqual(datetime.fromtimestamp(1522827734, tzoffset(0)), from_timestamp(1522827734, altz))


### PR DESCRIPTION
… is greater or lower than 24 hours.

Add tests that exercise the new behaviour

Fix #741 