### PR TITLE
Fix exception on import in MacOS

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -79,5 +79,8 @@ def refresh(path=None):
 #} END initialize git executable path
 
 #################
-refresh()
+try:
+    refresh()
+except Exception as exc:
+    raise ImportError('Failed to initialize: {0}'.format(exc))
 #################


### PR DESCRIPTION
This is related to my fix in #658. Apparently, MacOS adds a git executable that is just a stub which displays an error. This gets past the try/except I added in #658, and allows all of the GitPython components to be imported, but since the executable is not *actually* git, it results in an exception when ``refresh()`` attemepts to run a ``git version``.

Fixes #762.