### PR TITLE
Dedent code blocks in tutorial.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,5 +26,6 @@ Contributors are:
 -Mikuláš Poul <mikulaspoul _at_ gmail.com>
 -Charles Bouchard-Légaré <cblegare.atl _at_ ntis.ca>
 -Yaroslav Halchenko <debian _at_ onerussian.com>
+-Tim Swast <swast _at_ google.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -19,6 +19,7 @@ The first step is to create a :class:`git.Repo <git.repo.base.Repo>` object to r
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [1-test_init_repo_object]
     :end-before: # ![1-test_init_repo_object]
 
@@ -26,6 +27,7 @@ In the above example, the directory ``self.rorepo.working_tree_dir`` equals ``/U
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [2-test_init_repo_object]
     :end-before: # ![2-test_init_repo_object]
 
@@ -33,6 +35,7 @@ A repo object provides high-level access to your data, it allows you to create a
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [3-test_init_repo_object]
     :end-before: # ![3-test_init_repo_object]
 
@@ -40,6 +43,7 @@ Query the active branch, query untracked files or whether the repository data ha
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [4-test_init_repo_object]
     :end-before: # ![4-test_init_repo_object]
 
@@ -47,6 +51,7 @@ Clone from existing repositories or initialize new empty ones.
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [5-test_init_repo_object]
     :end-before: # ![5-test_init_repo_object]
 
@@ -54,6 +59,7 @@ Archive the repository contents to a tar file.
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [6-test_init_repo_object]
     :end-before: # ![6-test_init_repo_object]
 
@@ -66,6 +72,7 @@ Query relevant repository paths ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [7-test_init_repo_object]
     :end-before: # ![7-test_init_repo_object]
 
@@ -73,6 +80,7 @@ Query relevant repository paths ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [8-test_init_repo_object]
     :end-before: # ![8-test_init_repo_object]
 
@@ -80,6 +88,7 @@ You can also create new heads ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [9-test_init_repo_object]
     :end-before: # ![9-test_init_repo_object]
 
@@ -87,6 +96,7 @@ You can also create new heads ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [10-test_init_repo_object]
     :end-before: # ![10-test_init_repo_object]
 
@@ -94,6 +104,7 @@ You can traverse down to :class:`git objects <git.objects.base.Object>` through 
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [11-test_init_repo_object]
     :end-before: # ![11-test_init_repo_object]
 
@@ -101,6 +112,7 @@ You can traverse down to :class:`git objects <git.objects.base.Object>` through 
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [12-test_init_repo_object]
     :end-before: # ![12-test_init_repo_object]
 
@@ -108,6 +120,7 @@ The :class:`index <git.index.base.IndexFile>` is also called stage in git-speak.
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [13-test_init_repo_object]
     :end-before: # ![13-test_init_repo_object]
 
@@ -115,6 +128,7 @@ The :class:`index <git.index.base.IndexFile>` is also called stage in git-speak.
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [14-test_init_repo_object]
     :end-before: # ![14-test_init_repo_object]
 
@@ -126,6 +140,7 @@ Examining References
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [1-test_references_and_objects]
     :end-before: # ![1-test_references_and_objects]
 
@@ -133,6 +148,7 @@ Examining References
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [2-test_references_and_objects]
     :end-before: # ![2-test_references_and_objects]
 
@@ -140,6 +156,7 @@ A :class:`symbolic reference <git.refs.symbolic.SymbolicReference>` is a special
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [3-test_references_and_objects]
     :end-before: # ![3-test_references_and_objects]
 
@@ -147,6 +164,7 @@ Access the :class:`reflog <git.refs.log.RefLog>` easily.
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [4-test_references_and_objects]
     :end-before: # ![4-test_references_and_objects]
 
@@ -156,6 +174,7 @@ You can easily create and delete :class:`reference types <git.refs.reference.Ref
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [5-test_references_and_objects]
     :end-before: # ![5-test_references_and_objects]
 
@@ -163,6 +182,7 @@ Create or delete :class:`tags <git.refs.tag.TagReference>` the same way except y
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [6-test_references_and_objects]
     :end-before: # ![6-test_references_and_objects]
 
@@ -170,6 +190,7 @@ Change the :class:`symbolic reference <git.refs.symbolic.SymbolicReference>` to 
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [7-test_references_and_objects]
     :end-before: # ![7-test_references_and_objects]
 
@@ -183,6 +204,7 @@ In GitPython, all objects can be accessed through their common base, can be comp
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [8-test_references_and_objects]
     :end-before: # ![8-test_references_and_objects]
 
@@ -190,6 +212,7 @@ Common fields are ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [9-test_references_and_objects]
     :end-before: # ![9-test_references_and_objects]
 
@@ -197,6 +220,7 @@ Common fields are ...
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [10-test_references_and_objects]
     :end-before: # ![10-test_references_and_objects]
 
@@ -204,6 +228,7 @@ Access :class:`blob <git.objects.blob.Blob>` data (or any object data) using str
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [11-test_references_and_objects]
     :end-before: # ![11-test_references_and_objects]
 
@@ -217,6 +242,7 @@ Obtain commits at the specified revision
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [12-test_references_and_objects]
     :end-before: # ![12-test_references_and_objects]
 
@@ -224,6 +250,7 @@ Iterate 50 commits, and if you need paging, you can specify a number of commits 
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [13-test_references_and_objects]
     :end-before: # ![13-test_references_and_objects]
 
@@ -231,6 +258,7 @@ A commit object carries all sorts of meta-data
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [14-test_references_and_objects]
     :end-before: # ![14-test_references_and_objects]
 
@@ -238,6 +266,7 @@ Note: date time is represented in a ``seconds since epoch`` format. Conversion t
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [15-test_references_and_objects]
     :end-before: # ![15-test_references_and_objects]
 
@@ -245,6 +274,7 @@ You can traverse a commit's ancestry by chaining calls to ``parents``
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [16-test_references_and_objects]
     :end-before: # ![16-test_references_and_objects]
 
@@ -257,6 +287,7 @@ A :class:`tree <git.objects.tree.Tree>` records pointers to the contents of a di
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [17-test_references_and_objects]
     :end-before: # ![17-test_references_and_objects]
 
@@ -264,6 +295,7 @@ Once you have a tree, you can get its contents
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [18-test_references_and_objects]
     :end-before: # ![18-test_references_and_objects]
 
@@ -271,6 +303,7 @@ It is useful to know that a tree behaves like a list with the ability to query e
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [19-test_references_and_objects]
     :end-before: # ![19-test_references_and_objects]
 
@@ -278,6 +311,7 @@ There is a convenience method that allows you to get a named sub-object from a t
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [20-test_references_and_objects]
     :end-before: # ![20-test_references_and_objects]
 
@@ -285,6 +319,7 @@ You can also get a commit's root tree directly from the repository
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [21-test_references_and_objects]
     :end-before: # ![21-test_references_and_objects]
 
@@ -292,6 +327,7 @@ As trees allow direct access to their intermediate child entries only, use the t
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [22-test_references_and_objects]
     :end-before: # ![22-test_references_and_objects]
 
@@ -304,6 +340,7 @@ Modify the index with ease
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [23-test_references_and_objects]
     :end-before: # ![23-test_references_and_objects]
 
@@ -311,6 +348,7 @@ Create new indices from other trees or as result of a merge. Write that result t
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [24-test_references_and_objects]
     :end-before: # ![24-test_references_and_objects]
 
@@ -321,6 +359,7 @@ Handling Remotes
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [25-test_references_and_objects]
     :end-before: # ![25-test_references_and_objects]
 
@@ -328,6 +367,7 @@ You can easily access configuration information for a remote by accessing option
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [26-test_references_and_objects]
     :end-before: # ![26-test_references_and_objects]
 
@@ -343,7 +383,9 @@ This one sets a custom script to be executed in place of `ssh`, and can be used 
     with repo.git.custom_environment(GIT_SSH=ssh_executable):
         repo.remotes.origin.fetch()
 
-Here's an example executable that can be used in place of the `ssh_executable` above::
+Here's an example executable that can be used in place of the `ssh_executable` above:
+
+.. code-block:: shell
 
     #!/bin/sh
     ID_RSA=/var/lib/openshift/5562b947ecdd5ce939000038/app-deployments/id_rsa
@@ -359,6 +401,7 @@ Submodule Handling
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [1-test_submodules]
     :end-before: # ![1-test_submodules]
 
@@ -383,6 +426,7 @@ Diffs can be made between the Index and Trees, Index and the working tree, trees
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [27-test_references_and_objects]
     :end-before: # ![27-test_references_and_objects]
 
@@ -390,6 +434,7 @@ The item returned is a DiffIndex which is essentially a list of Diff objects. It
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [28-test_references_and_objects]
     :end-before: # ![28-test_references_and_objects]
 
@@ -413,6 +458,7 @@ To switch between branches similar to ``git checkout``, you effectively need to 
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [29-test_references_and_objects]
     :end-before: # ![29-test_references_and_objects]
 
@@ -420,6 +466,7 @@ The previous approach would brutally overwrite the user's changes in the working
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [30-test_references_and_objects]
     :end-before: # ![30-test_references_and_objects]
 
@@ -430,6 +477,7 @@ In this example, we will initialize an empty repository, add an empty file to th
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: def test_add_file_and_commit
     :end-before: # ![test_add_file_and_commit]
 
@@ -441,6 +489,7 @@ In case you are missing functionality as it has not been wrapped, you may conven
 
 .. literalinclude:: ../../git/test/test_docs.py
     :language: python
+    :dedent: 8
     :start-after: # [31-test_references_and_objects]
     :end-before: # ![31-test_references_and_objects]
 


### PR DESCRIPTION
I found the extra 8 spaces at the start of the examples in the tutorial
to be distracting. The Sphinx dedent option removes these extra spaces
from the rendered code blocks.

I also got a warning about the shell code example not being lexed as
Python, so I converted this to an explicit shell code block.