### PR TITLE
Fix TypeError in git.execute(..., output_stream=file)

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -794,7 +794,7 @@ class Git(LazyMixin):
             else:
                 max_chunk_size = max_chunk_size if max_chunk_size and max_chunk_size > 0 else io.DEFAULT_BUFFER_SIZE
                 stream_copy(proc.stdout, output_stream, max_chunk_size)
-                stdout_value = output_stream
+                stdout_value = proc.stdout.read()
                 stderr_value = proc.stderr.read()
                 # strip trailing "\n"
                 if stderr_value.endswith(b"\n"):

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -7,6 +7,7 @@
 import os
 import subprocess
 import sys
+from tempfile import TemporaryFile
 
 from git import (
     Git,
@@ -107,6 +108,11 @@ class TestGit(TestBase):
         # this_should_not_be_ignored=False implies it *should* be ignored
         self.git.version(pass_this_kwarg=False)
         assert_true("pass_this_kwarg" not in git.call_args[1])
+
+    @raises(GitCommandError)
+    def test_it_raises_proper_exception_with_output_stream(self):
+        tmp_file = TemporaryFile()
+        self.git.checkout('non-existent-branch', output_stream=tmp_file)
 
     def test_it_accepts_environment_variables(self):
         filename = fixture_path("ls_tree_empty")


### PR DESCRIPTION
This fixes issue #619 - raise GitCommandError(not TypeError) when output_stream is set
in `git.execute(...)`.