### PR TITLE
Include test files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,13 @@ include AUTHORS
 include README
 include requirements.txt
 
+include .gitattributes
+include .gitignore
+include .gitmodules
+
+recursive-include .git *
 recursive-include doc *
+recursive-include etc *
 
 graft git/test/fixtures
 graft git/test/performance


### PR DESCRIPTION
These files are missing from sdists but are needed for the unit tests as far as I can determine.