### PR TITLE
Respect _common_dir when finding repository config file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,5 +27,6 @@ Contributors are:
 -Charles Bouchard-Légaré <cblegare.atl _at_ ntis.ca>
 -Yaroslav Halchenko <debian _at_ onerussian.com>
 -Tim Swast <swast _at_ google.com>
+-William Luc Ritchie
 
 Portions derived from other open source works and are clearly marked.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -416,7 +416,7 @@ class Repo(object):
         elif config_level == "global":
             return osp.normpath(osp.expanduser("~/.gitconfig"))
         elif config_level == "repository":
-            return osp.normpath(osp.join(self.git_dir, "config"))
+            return osp.normpath(osp.join(self._common_dir or self.git_dir, "config"))
 
         raise ValueError("Invalid configuration level: %r" % config_level)
 

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -974,6 +974,11 @@ class TestRepo(TestBase):
         commit = repo.head.commit
         self.assertIsInstance(commit, Object)
 
+        # this ensures we can read the remotes, which confirms we're reading
+        # the config correctly.
+        origin = repo.remotes.origin
+        self.assertIsInstance(origin, Remote)
+
         self.assertIsInstance(repo.heads['aaaaaaaa'], Head)
 
     @with_rw_directory


### PR DESCRIPTION
Among other things, remotes are now correctly identified when in a separate worktree.