### PR TITLE
RF+BF: store stdout/stderr without pretty-prefix; collect/populate stdout/err in the exception if none is there

### DIFF
--- a/git/exc.py
+++ b/git/exc.py
@@ -55,12 +55,16 @@ class CommandError(UnicodeMixin, GitError):
         self._cmd = safe_decode(command[0])
         self._cmdline = u' '.join(safe_decode(i) for i in command)
         self._cause = status and u" due to: %s" % status or "!"
-        self.stdout = stdout and u"\n  stdout: '%s'" % safe_decode(stdout) or ''
-        self.stderr = stderr and u"\n  stderr: '%s'" % safe_decode(stderr) or ''
+        self.stdout = stdout and safe_decode(stdout) or ''
+        self.stderr = stderr and safe_decode(stderr) or ''
 
     def __unicode__(self):
         return (self._msg + "\n  cmdline: %s%s%s") % (
-            self._cmd, self._cause, self._cmdline, self.stdout, self.stderr)
+            self._cmd, self._cause,
+            self._cmdline,
+            u"\n  stdout: '%s'" % self.stdout if self.stdout else '',
+            u"\n  stderr: '%s'" % self.stderr if self.stderr else ''
+        )
 
 
 class GitCommandNotFound(CommandError):


### PR DESCRIPTION
Closes #599 
Attn: https://github.com/datalad/datalad/pull/2876
TODOs:
- [ ] Fix up possible broken tests

Demo:
```shell
$> cat demo-progress.py  
from git import RemoteProgress, Repo
import sys
url = "http://github.com/gitpython-developers/GitPython"

try:
    Repo.clone_from(url, "/dev/null")
except Exception as e:
    print("No progress - Exception %s with stderr: %r" % (e, e.stderr))

class phandler(RemoteProgress):
    def update(self, *args):
        sys.stdout.write('.')
        sys.stdout.flush()

try:
    Repo.clone_from(url, "/dev/null", progress=phandler())
except Exception as e:
    print("With progress - Exception %s with stderr: %r" % (e, e.stderr))

print("Now without exceptions")
print("Without progress")
Repo.clone_from(url, "/tmp/git-python")
print("With progress")
Repo.clone_from(url, "/tmp/git-python-progress", progress=phandler())
(dev) 1 6408.....................................:Thu 27 Sep 2018 10:17:05 AM EDT:.
(git)hopa:~deb/python-git[bf-progress-stderr2]git
$> rm -rf /tmp/git-python*; python2 demo-progress.py 
No progress - Exception Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v http://github.com/gitpython-developers/GitPython /dev/null
  stderr: 'fatal: destination path '/dev/null' already exists and is not an empty directory.
' with stderr: u"fatal: destination path '/dev/null' already exists and is not an empty directory.\n"
With progress - Exception Cmd('git') failed due to: exit code(128)
  cmdline: git clone --progress -v http://github.com/gitpython-developers/GitPython /dev/null
  stderr: 'fatal: destination path '/dev/null' already exists and is not an empty directory.
' with stderr: u"fatal: destination path '/dev/null' already exists and is not an empty directory.\n"
Now without exceptions
Without progress
With progress
..........................................................................................................................................................................................................%                     (dev) 1 6409.....................................:Thu 27 Sep 2018 10:17:25 AM EDT:.
(git)hopa:~deb/python-git[bf-progress-stderr2]git
$> rm -rf /tmp/git-python*; python3 demo-progress.py 
No progress - Exception Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v http://github.com/gitpython-developers/GitPython /dev/null
  stderr: 'fatal: destination path '/dev/null' already exists and is not an empty directory.
' with stderr: "fatal: destination path '/dev/null' already exists and is not an empty directory.\n"
With progress - Exception Cmd('git') failed due to: exit code(128)
  cmdline: git clone --progress -v http://github.com/gitpython-developers/GitPython /dev/null
  stderr: 'fatal: destination path '/dev/null' already exists and is not an empty directory.
' with stderr: "fatal: destination path '/dev/null' already exists and is not an empty directory.\n"
Now without exceptions
Without progress
With progress
.............................................................................................................................................................................................................%    
```