### PR TITLE
Fix submodules listing error

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1184,8 +1184,9 @@ class Submodule(IndexObject, Iterable, Traversable):
                     entry = index.entries[index.entry_key(p, 0)]
                     sm = Submodule(repo, entry.binsha, entry.mode, entry.path)
                 except KeyError:
-                    raise InvalidGitRepositoryError(
-                        "Gitmodule path %r did not exist in revision of parent commit %s" % (p, parent_commit))
+                    # The submodule doesn't exist, probably it wasn't
+                    # removed from the .gitmodules file.
+                    continue
                 # END handle keyerror
             # END handle critical error
 

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -2,6 +2,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import os
+import shutil
 import sys
 from unittest import skipIf
 
@@ -659,6 +660,24 @@ class TestSubmodule(TestBase):
             self.failUnlessRaises(ValueError, parent.create_submodule, name, name,
                                   url=empty_repo_dir, no_checkout=checkout_mode and True or False)
         # end for each checkout mode
+
+    @with_rw_directory
+    def test_list_only_valid_submodules(self, rwdir):
+        repo_path = osp.join(rwdir, 'parent')
+        repo = git.Repo.init(repo_path)
+        repo.git.submodule('add', self._small_repo_url(), 'module')
+        repo.index.commit("add submodule")
+
+        assert len(repo.submodules) == 1
+
+        # Delete the directory from submodule
+        submodule_path = osp.join(repo_path, 'module')
+        shutil.rmtree(submodule_path)
+        repo.git.add([submodule_path])
+        repo.index.commit("remove submodule")
+
+        repo = git.Repo(repo_path)
+        assert len(repo.submodules) == 0
 
     @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
             """FIXME on cygwin: File "C:\\projects\\gitpython\\git\\cmd.py", line 671, in execute

--- a/git/test/test_submodule.py
+++ b/git/test/test_submodule.py
@@ -480,9 +480,8 @@ class TestSubmodule(TestBase):
         with sm.config_writer() as writer:
             writer.set_value('path', fp)    # change path to something with prefix AFTER url change
 
-        # update fails as list_items in such a situations cannot work, as it cannot
-        # find the entry at the changed path
-        self.failUnlessRaises(InvalidGitRepositoryError, rm.update, recursive=False)
+        # update doesn't fail, because list_items ignores the wrong path in such situations.
+        rm.update(recursive=False)
 
         # move it properly - doesn't work as it its path currently points to an indexentry
         # which doesn't exist ( move it to some path, it doesn't matter here )


### PR DESCRIPTION
Fix #279

When the path doesn't exist, gitpython throws an error, this usually happens when the user deletes the submodule directory but not the submodule entry in `.gitmodules`.