### PR TITLE
Fixed error in documentation

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -384,7 +384,6 @@ class Diff(object):
     @property
     def renamed_file(self):
         """:returns: True if the blob of our diff has been renamed
-        :note: This property is deprecated, please use ``renamed_file`` instead.
         """
         return self.rename_from != self.rename_to
 


### PR DESCRIPTION
The renamed_file function contains the following which ends up on readthedocs: 
  :note: This property is deprecated, please use ``renamed_file`` instead.

Removed the line