### PR TITLE
Travis CI: 'sudo' tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
-      sudo: required
     - python: "nightly"
       dist: xenial
-      sudo: required
   allow_failures:
     - python: "nightly"
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.5"
   - "3.6"
   # - "pypy" - won't work as smmap doesn't work (see gitdb/.travis.yml for details)
-matrix:
+matrix: 
   include:
     - python: 3.7
       dist: xenial


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).