### PR TITLE
Define PermissionError in Python versions < 3.3

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -43,6 +43,10 @@ from .util import (
     stream_copy,
 )
 
+try:
+    PermissionError
+except NameError:  # Python < 3.3
+    PermissionError = OSError
 
 execute_kwargs = {'istream', 'with_extended_output',
                   'with_exceptions', 'as_process', 'stdout_as_string',
@@ -211,22 +215,15 @@ class Git(LazyMixin):
 
         # test if the new git executable path is valid
 
-        if sys.version_info < (3,):
-            # - a GitCommandNotFound error is spawned by ourselves
-            # - a OSError is spawned if the git executable provided
-            #   cannot be executed for whatever reason
-            exceptions = (GitCommandNotFound, OSError)
-        else:
-            # - a GitCommandNotFound error is spawned by ourselves
-            # - a PermissionError is spawned if the git executable provided
-            #   cannot be executed for whatever reason
-            exceptions = (GitCommandNotFound, PermissionError)
-
+        # - a GitCommandNotFound error is spawned by ourselves
+        # - a PermissionError is spawned if the git executable provided
+        #   cannot be executed for whatever reason
+        
         has_git = False
         try:
             cls().version()
             has_git = True
-        except exceptions:
+        except (GitCommandNotFound, PermissionError):
             pass
 
         # warn or raise exception if test failed


### PR DESCRIPTION
Simplify the logic by defining [__PermissionError__](https://docs.python.org/3/library/exceptions.html#PermissionError) in Python 2 in alignment with Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).