### PR TITLE
Fix test-only issue with git 2.20 or later handling a clobbered tag

### DIFF
--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -253,9 +253,15 @@ class TestRemote(TestBase):
         self.assertEqual(tinfo.ref.commit, rtag.commit)
         self.assertTrue(tinfo.flags & tinfo.NEW_TAG)
 
-        # adjust tag commit
+        # adjust the local tag commit
         Reference.set_object(rtag, rhead.commit.parents[0].parents[0])
-        res = fetch_and_test(remote, tags=True)
+
+        # as of git 2.20 one cannot clobber local tags that have changed without
+        # specifying --force, and the test assumes you can clobber, so...
+        force = None
+        if rw_repo.git.version_info[:2] >= (2, 20):
+            force = True
+        res = fetch_and_test(remote, tags=True, force=force)
         tinfo = res[str(rtag)]
         self.assertEqual(tinfo.commit, rtag.commit)
         self.assertTrue(tinfo.flags & tinfo.TAG_UPDATE)


### PR DESCRIPTION
When we added the xenial image on Travis CI, it came with a git upgrade.  Xenial usually has git 2.7.4 but the one on travis has 2.20.1.  In version 2.20 there were changes around how tags can be clobbered (or not):

https://github.com/git/git/commit/0bc8d71b99e91c9e90b519073b639a5066119591

The test suite was relying on the old behavior, so we had to adjust the test.