### PR TITLE
Fix error on comparing git.Remote

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -448,7 +448,7 @@ class Remote(LazyMixin, Iterable):
         return '<git.%s "%s">' % (self.__class__.__name__, self.name)
 
     def __eq__(self, other):
-        return self.name == other.name
+        return isinstance(other, type(self)) and self.name == other.name
 
     def __ne__(self, other):
         return not (self == other)


### PR DESCRIPTION
We can't use `'foo' in repo.remotes` syntax in current version, but `'foo' in repo.refs` works fine.

It raises `AttributeError` before it runs full name search:

```py
In [2]: r = git.Repo('.')

In [3]: 'origin' in r.remotes
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-800621fb1c9b> in <module>
----> 1 'origin' in r.remotes

~/Projects/GitPython/git/util.py in __contains__(self, attr)
    865     def __contains__(self, attr):
    866         # first try identity match for performance
--> 867         rval = list.__contains__(self, attr)
    868         if rval:
    869             return rval

~/Projects/GitPython/git/remote.py in __eq__(self, other)
    449
    450     def __eq__(self, other):
--> 451         return self.name == other.name
    452
    453     def __ne__(self, other):

AttributeError: 'str' object has no attribute 'name'
```

fix it add type check before it compares `name`.