### PR TITLE
Fix commit.py documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,5 +28,6 @@ Contributors are:
 -Yaroslav Halchenko <debian _at_ onerussian.com>
 -Tim Swast <swast _at_ google.com>
 -William Luc Ritchie
+-David Host <hostdm _at_ outlook.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -81,7 +81,7 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
         :param tree: Tree
             Tree object
         :param author: Actor
-            is the author string ( will be implicitly converted into an Actor object )
+            is the author Actor object
         :param authored_date: int_seconds_since_epoch
             is the authored DateTime - use time.gmtime() to convert it into a
             different format


### PR DESCRIPTION
Closes #806: author parameter requires Actor type, not string.

Updates documentation to reflect this.