### PR TITLE
Added usage example to Repo __init__.py call for Windows users

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -97,6 +97,7 @@ class Repo(object):
                 repo = Repo("/Users/mtrier/Development/git-python.git")
                 repo = Repo("~/Development/git-python.git")
                 repo = Repo("$REPOSITORIES/Development/git-python.git")
+                repo = Repo("C:\\Users\\mtrier\\Development\\git-python\\.git")
 
             - In *Cygwin*, path may be a `'cygdrive/...'` prefixed path.
             - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also evals to false,


### PR DESCRIPTION
This is a non-functional change intended to offer guidance to Windows users.  It's a little confusing that, say, `C:\GitHub\GitPython` is not a valid Git repository - the Repo object seems to expect a `.git` directory during initialization.