### PR TITLE
Fix creating references containing '@'

### DIFF
--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -208,7 +208,14 @@ def rev_parse(repo, rev):
                 ref = repo.head.ref
             else:
                 if token == '@':
-                    ref = name_to_object(repo, rev[:start], return_ref=True)
+                    try:
+                        ref = name_to_object(repo, rev[:start], return_ref=True)
+                    except BadObject:
+                        # If this doesn't result in an object we most likely
+                        # encounter a reference containing the '@' character.
+                        # In this case we just to continue the search.
+                        start += 1
+                        continue
                 else:
                     obj = name_to_object(repo, rev[:start])
                 # END handle token

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -701,6 +701,10 @@ class TestRepo(TestBase):
         ahead = rwrepo.create_head('aaaaaaaa')
         assert(rwrepo.rev_parse(str(ahead)) == ahead.commit)
 
+        # verify @ in branch names are possible
+        bhead = rwrepo.create_head('aaa@aaa')
+        assert (rwrepo.rev_parse(str(bhead)) == bhead.commit)
+
     def test_rev_parse(self):
         rev_parse = self.rorepo.rev_parse
 


### PR DESCRIPTION
References containing the '@' char are legal in git but fail with
[1]. This fails because as soon as '@' is encountered we stop
searching for a ref name, assume it is there and fail while retrieving
it. This can be fixed by catching this exception and continue with the
search for a valid ref.

```
[1] Trace:
Traceback (most recent call last):
  File "/opt/zuul/lib/python3.7/site-packages/zuul/merger/merger.py", line 108, in __init__
   self._ensure_cloned()
  File "/opt/zuul/lib/python3.7/site-packages/zuul/merger/merger.py", line 178, in _ensure_cloned
    repo.create_head(ref.remote_head, ref, force=True)
  File "/opt/zuul/lib/python3.7/site-packages/git/repo/base.py", line 373, in create_head
    return Head.create(self, path, commit, force, logmsg)
  File "/opt/zuul/lib/python3.7/site-packages/git/refs/symbolic.py", line 546, in create
    return cls._create(repo, path, cls._resolve_ref_on_create, reference, force, logmsg)
  File "/opt/zuul/lib/python3.7/site-packages/git/refs/symbolic.py", line 497, in _create
    target = repo.rev_parse(str(reference))
  File "/opt/zuul/lib/python3.7/site-packages/git/repo/fun.py", line 211, in rev_parse
    ref = name_to_object(repo, rev[:start], return_ref=True)
  File "/opt/zuul/lib/python3.7/site-packages/git/repo/fun.py", line 142, in name_to_object
    raise BadObject("Couldn't find reference named %r" % name)
gitdb.exc.BadObject: <unprintable BadObject object>
```