### PR TITLE
Fix #858

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,5 +29,6 @@ Contributors are:
 -Tim Swast <swast _at_ google.com>
 -William Luc Ritchie
 -David Host <hostdm _at_ outlook.com>
+-Stefan Stancu <stefan.stancu _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/remote.py
+++ b/git/remote.py
@@ -544,10 +544,9 @@ class Remote(LazyMixin, Iterable):
                 except GitCommandError as ex:
                     if any(msg in str(ex) for msg in ['correct access rights', 'cannot run ssh']):
                         # If ssh is not setup to access this repository, see issue 694
-                        result = Git().execute(
-                            ['git', 'config', '--get', 'remote.%s.url' % self.name]
-                        )
-                        yield result
+                        remote_details = self.repo.git.config('--get-all', 'remote.%s.url' % self.name)
+                        for line in remote_details.split('\n'):
+                            yield line
                     else:
                         raise ex
             else:


### PR DESCRIPTION
This patch ensures that `git config --get remote.the_remote.url` is always ran inside the correct current working directory, and fixes #858 