### PR TITLE
Fix `AttributeError` when searching a remote by name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,5 +32,6 @@ Contributors are:
 -A. Jesse Jiryu Davis <jesse _at_ emptysquare.net>
 -Steven Whitman <ninloot _at_ gmail.com>
 -Stefan Stancu <stefan.stancu _at_ gmail.com>
+-César Izurieta <cesar _at_ caih.org>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/util.py
+++ b/git/util.py
@@ -864,9 +864,12 @@ class IterableList(list):
 
     def __contains__(self, attr):
         # first try identity match for performance
-        rval = list.__contains__(self, attr)
-        if rval:
-            return rval
+        try:
+            rval = list.__contains__(self, attr)
+            if rval:
+                return rval
+        except (AttributeError, TypeError):
+            pass
         # END handle match
 
         # otherwise make a full name search


### PR DESCRIPTION
Running code like `'origin' in git.Repo('path/to/existing/repository').remotes`
raises an AttributeError instead of returning a boolean. This commit fixes that
behaviour by catching the error when doing an identity match on `IterableList`.

Minimum test case with version 2.1.11:

```python
>>> 'origin' in git.Repo('path/to/existing/repository').remotes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/cesar/.local/lib/python3.7/site-packages/git/util.py", line 867, in __contains__
    rval = list.__contains__(self, attr)
  File "/home/cesar/.local/lib/python3.7/site-packages/git/remote.py", line 451, in __eq__
    return self.name == other.name
AttributeError: 'str' object has no attribute 'name'
```