### PR TITLE
Build docs locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
   - git submodule update --init --recursive
   - git fetch --tags
   - pip install -r test-requirements.txt
-  - pip install codecov sphinx
+  - pip install -r doc/requirements.txt
+  - pip install codecov
 
   # generate some reflog as git-python tests need it (in master)
   - ./init-tests-after-clone.sh

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx<2.0
+sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['.templates']
+templates_path = []
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -94,13 +94,9 @@ pygments_style = 'sphinx'
 # Options for HTML output
 # -----------------------
 
+html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
 }
-
-# The style sheet to use for HTML and HTML Help pages. A file of that name
-# must exist either in Sphinx' static/ path, or in one of the custom paths
-# given in html_static_path.
-html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -121,7 +117,7 @@ html_style = 'default.css'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['.static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Currently `make html` will output pages without styles
or different from the online documentation.

With this change the local documentation looks the same as the online
documentation.