### PR TITLE
Implement update call when the object is "up to date" #871

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -390,6 +390,21 @@ class RemoteProgress(object):
         if len(self.error_lines) > 0 or self._cur_line.startswith(('error:', 'fatal:')):
             self.error_lines.append(self._cur_line)
             return []
+        elif 'up to date' in self._cur_line:
+            # Checking this way instead of startswith, because debugging for
+            # startswith(' = [up to date]') is going to be a major pain if just
+            # a single space or bracket changes.
+
+            # Strip the initial ' = [up to date]' from the line
+            message_string = line.split('date]', 1)[-1]
+
+            # Trim whitespace
+            message_string = ' '.join(message_string.split())
+
+            self.update(0,
+                        1,
+                        1,
+                        message_string)
 
         sub_lines = line.split('\r')
         failed_lines = []


### PR DESCRIPTION
In the current state the `update()` method of `RemoteProgress` is not called, if the progress terminates with ** = [up to date]**.

With this implementation, the method gets called once, containing all useful pieces of information. By passing `current_count = 1` and `max_count = 1` we assure that any percentage calculation terminates with **100%**.

**TODO**:
- Please check, if the `op_code = 0` makes sense in this case
- I opted for a more future proof, yet slower solution in the `elif`:
  - to trade durability for performance, use `.startswith(' = [up to date]')`