### PR TITLE
BF: install_requires not just requires for setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     package_dir={'git': 'git'},
     license="BSD License",
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    requires=requirements,
+    install_requires=requirements,
     tests_require=requirements + test_requirements,
     zip_safe=False,
     long_description="""GitPython is a python library used to interact with Git repositories""",


### PR DESCRIPTION
Originally detected while running DataLad tests on CRON  https://github.com/datalad/datalad/issues/3395 although mystery remains why not earlier.

To say the truth I am not fan of the approach (defer to reading requirements.txt) introduced in ce21f63 but I guess it is a separate issue