### PR TITLE
fix encoding problems on windows with not using default encoding but …

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -90,7 +90,7 @@ class SymbolicReference(object):
         """Returns an iterator yielding pairs of sha1/path pairs (as bytes) for the corresponding refs.
         :note: The packed refs file will be kept open as long as we iterate"""
         try:
-            with open(cls._get_packed_refs_path(repo), 'rt') as fp:
+            with open(cls._get_packed_refs_path(repo), 'rt', encoding='utf-8') as fp:
                 for line in fp:
                     line = line.strip()
                     if not line:

--- a/git/remote.py
+++ b/git/remote.py
@@ -786,8 +786,7 @@ class Remote(LazyMixin, Iterable):
         else:
             args = [refspec]
 
-        proc = self.repo.git.fetch(self, *args, as_process=True, with_stdout=False,
-                                   universal_newlines=True, v=True, **kwargs)
+        proc = self.repo.git.fetch(self, *args, as_process=True, with_stdout=False, v=True, **kwargs)
         res = self._get_fetch_info_from_stderr(proc, progress)
         if hasattr(self.repo.odb, 'update_cache'):
             self.repo.odb.update_cache()
@@ -805,8 +804,7 @@ class Remote(LazyMixin, Iterable):
             # No argument refspec, then ensure the repo's config has a fetch refspec.
             self._assert_refspec()
         kwargs = add_progress(kwargs, self.repo.git, progress)
-        proc = self.repo.git.pull(self, refspec, with_stdout=False, as_process=True,
-                                  universal_newlines=True, v=True, **kwargs)
+        proc = self.repo.git.pull(self, refspec, with_stdout=False, as_process=True, v=True, **kwargs)
         res = self._get_fetch_info_from_stderr(proc, progress)
         if hasattr(self.repo.odb, 'update_cache'):
             self.repo.odb.update_cache()
@@ -840,8 +838,7 @@ class Remote(LazyMixin, Iterable):
             If the operation fails completely, the length of the returned IterableList will
             be null."""
         kwargs = add_progress(kwargs, self.repo.git, progress)
-        proc = self.repo.git.push(self, refspec, porcelain=True, as_process=True,
-                                  universal_newlines=True, **kwargs)
+        proc = self.repo.git.push(self, refspec, porcelain=True, as_process=True, **kwargs)
         return self._get_push_info(proc, progress)
 
     @property


### PR DESCRIPTION
Solves encoding problem on windows with using fetch, pull, push commands. It similar to issues: [332](https://github.com/gitpython-developers/GitPython/issues/332), [237](https://github.com/gitpython-developers/GitPython/issues/237), explanation of problem I found [here](https://stackoverflow.com/questions/33283603/python-popen-communicate-str-encodeencoding-utf-8-errors-ignore-cr) in accepted answer. Also was encoding problem with calling repo.branches, quite simillar, file open in default locale encoding (cp-1251) for me, and getting branches names was broken. 