### PR TITLE
Fix Git.transform_kwarg

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -893,7 +893,7 @@ class Git(LazyMixin):
         else:
             if value is True:
                 return ["--%s" % dashify(name)]
-            elif value not in (False, None):
+            elif value is not False and value is not None:
                 return ["--%s=%s" % (dashify(name), value)]
         return []
 

--- a/git/test/test_git.py
+++ b/git/test/test_git.py
@@ -86,6 +86,7 @@ class TestGit(TestBase):
 
         assert_equal(["--max-count"], self.git.transform_kwargs(**{'max_count': True}))
         assert_equal(["--max-count=5"], self.git.transform_kwargs(**{'max_count': 5}))
+        assert_equal(["--max-count=0"], self.git.transform_kwargs(**{'max_count': 0}))
         assert_equal([], self.git.transform_kwargs(**{'max_count': None}))
 
         # Multiple args are supported by using lists/tuples


### PR DESCRIPTION
While working on our project I found that `old_repo.git.rev_list('HEAD', max_parents=0)` started to work differently after the new release of GitPython and our tests started to fail. After some debugging I found the problem. Kwargs were not transformed correctly if a value was set to 0 due to wrong if condition:

```
>>> 0 not in (False, None)
False
>>> 0 is not False and 0 is not None
True
```

The commit also contains a test for the edge case.