### PR TITLE
Fix test_commit_msg_hook_success.

### DIFF
--- a/git/test/test_index.py
+++ b/git/test/test_index.py
@@ -897,7 +897,7 @@ class TestIndex(TestBase):
         _make_hook(
             index.repo.git_dir,
             'commit-msg',
-            'echo -n " {}" >> "$1"'.format(from_hook_message)
+            'printf " {}" >> "$1"'.format(from_hook_message)
         )
         new_commit = index.commit(commit_message)
         self.assertEqual(new_commit.message, u"{} {}".format(commit_message, from_hook_message))


### PR DESCRIPTION
Test hooks are created with a `sh` shebang: https://github.com/gitpython-developers/GitPython/blob/master/git/test/test_index.py#L53

however in `sh` `echo` doesn't always support `-n`, and can print it out:

```
$ bash -c "echo -n hello"
hello # <- no newline here
$ sh -c "echo -n hello"
-n hello # <- newline here
```

Instead of `echo -n` use `printf` which works correctly in all `sh`s.