### PR TITLE
Remove assert that can fail erroneously.

### DIFF
--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -53,7 +53,6 @@ class TestRemoteProgress(RemoteProgress):
         # Keep it for debugging
         self._seen_lines.append(line)
         rval = super(TestRemoteProgress, self)._parse_progress_line(line)
-        assert len(line) > 1, "line %r too short" % line
         return rval
 
     def line_dropped(self, line):


### PR DESCRIPTION
`git` will sometimes print out empty progress lines.