### PR TITLE
Parse rejected deletes.

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -156,7 +156,10 @@ class PushInfo(object):
         if flags & cls.DELETED:
             from_ref = None
         else:
-            from_ref = Reference.from_path(remote.repo, from_ref_string)
+            if from_ref_string == "(delete)":
+                from_ref = None
+            else:
+                from_ref = Reference.from_path(remote.repo, from_ref_string)
 
         # commit handling, could be message or commit info
         old_commit = None

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -385,6 +385,14 @@ class TestRemote(TestBase):
         progress.make_assertion()
         self._do_test_push_result(res, remote)
 
+        # rejected stale delete
+        force_with_lease = "%s:0000000000000000000000000000000000000000" % new_head.path
+        res = remote.push(":%s" % new_head.path, force_with_lease=force_with_lease)
+        self.assertTrue(res[0].flags & PushInfo.ERROR)
+        self.assertTrue(res[0].flags & PushInfo.REJECTED)
+        self.assertIsNone(res[0].local_ref)
+        self._do_test_push_result(res, remote)
+
         # delete new branch on the remote end and locally
         res = remote.push(":%s" % new_head.path)
         self._do_test_push_result(res, remote)


### PR DESCRIPTION
Successful branch deletions look like

```
-	:refs/heads/test-delete	[deleted]
```

however rejected branch deletions look like

```
!	(delete):refs/heads/test-delete	[rejected] (stale info)
```

for some reason. Parse those as well.