### PR TITLE
Add support for 'C'-type diffs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,5 +34,6 @@ Contributors are:
 -Stefan Stancu <stefan.stancu _at_ gmail.com>
 -César Izurieta <cesar _at_ caih.org>
 -Arthur Milchior <arthur _at_ milchior.fr>
+-JJ Graham <thetwoj _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/diff.py
+++ b/git/diff.py
@@ -258,7 +258,7 @@ class Diff(object):
     NULL_BIN_SHA = b"\0" * 20
 
     __slots__ = ("a_blob", "b_blob", "a_mode", "b_mode", "a_rawpath", "b_rawpath",
-                 "new_file", "deleted_file", "copied_file", "raw_rename_from", 
+                 "new_file", "deleted_file", "copied_file", "raw_rename_from",
                  "raw_rename_to", "diff", "change_type", "score")
 
     def __init__(self, repo, a_rawpath, b_rawpath, a_blob_id, b_blob_id, a_mode,
@@ -432,7 +432,7 @@ class Diff(object):
                 a_path, b_path = header.groups()
 
             new_file, deleted_file, copied_file = \
-                    bool(new_file_mode), bool(deleted_file_mode), bool(copied_file_name)
+                bool(new_file_mode), bool(deleted_file_mode), bool(copied_file_name)
 
             a_path = cls._pick_best_path(a_path, rename_from, a_path_fallback)
             b_path = cls._pick_best_path(b_path, rename_to, b_path_fallback)

--- a/git/diff.py
+++ b/git/diff.py
@@ -247,7 +247,7 @@ class Diff(object):
                                 (?:^deleted[ ]file[ ]mode[ ](?P<deleted_file_mode>.+)(?:\n|$))?
                                 (?:^similarity[ ]index[ ]\d+%\n
                                    ^copy[ ]from[ ].*\n
-                                   ^copy[ ]to[ ](?P<copied_file_mode>.*)(?:\n|$))?
+                                   ^copy[ ]to[ ](?P<copied_file_name>.*)(?:\n|$))?
                                 (?:^index[ ](?P<a_blob_id>[0-9A-Fa-f]+)
                                     \.\.(?P<b_blob_id>[0-9A-Fa-f]+)[ ]?(?P<b_mode>.+)?(?:\n|$))?
                                 (?:^---[ ](?P<a_path>[^\t\n\r\f\v]*)[\t\r\f\v]*(?:\n|$))?
@@ -427,12 +427,12 @@ class Diff(object):
             a_path_fallback, b_path_fallback, \
                 old_mode, new_mode, \
                 rename_from, rename_to, \
-                new_file_mode, deleted_file_mode, copied_file_mode, \
+                new_file_mode, deleted_file_mode, copied_file_name, \
                 a_blob_id, b_blob_id, b_mode, \
                 a_path, b_path = header.groups()
 
             new_file, deleted_file, copied_file = \
-                    bool(new_file_mode), bool(deleted_file_mode), bool(copied_file_mode)
+                    bool(new_file_mode), bool(deleted_file_mode), bool(copied_file_name)
 
             a_path = cls._pick_best_path(a_path, rename_from, a_path_fallback)
             b_path = cls._pick_best_path(b_path, rename_to, b_path_fallback)

--- a/git/diff.py
+++ b/git/diff.py
@@ -167,7 +167,7 @@ class DiffIndex(list):
     # R = Renamed
     # M = Modified
     # T = Changed in the type
-    change_type = ("A", "D", "R", "M", "T")
+    change_type = ("A", "C", "D", "R", "M", "T")
 
     def iter_change_type(self, change_type):
         """
@@ -245,7 +245,9 @@ class Diff(object):
                                    ^rename[ ]to[ ](?P<rename_to>.*)(?:\n|$))?
                                 (?:^new[ ]file[ ]mode[ ](?P<new_file_mode>.+)(?:\n|$))?
                                 (?:^deleted[ ]file[ ]mode[ ](?P<deleted_file_mode>.+)(?:\n|$))?
-                                (?:^copied[ ]file[ ]mode[ ](?P<copied_file_mode>.+)(?:\n|$))?
+                                (?:^similarity[ ]index[ ]\d+%\n
+                                   ^copy[ ]from[ ].*\n
+                                   ^copy[ ]to[ ](?P<copied_file_mode>.*)(?:\n|$))?
                                 (?:^index[ ](?P<a_blob_id>[0-9A-Fa-f]+)
                                     \.\.(?P<b_blob_id>[0-9A-Fa-f]+)[ ]?(?P<b_mode>.+)?(?:\n|$))?
                                 (?:^---[ ](?P<a_path>[^\t\n\r\f\v]*)[\t\r\f\v]*(?:\n|$))?

--- a/git/test/fixtures/diff_copied_mode
+++ b/git/test/fixtures/diff_copied_mode
@@ -1,0 +1,4 @@
+diff --git a/test1.txt b/test2.txt
+similarity index 100%
+copy from test1.txt
+copy to test2.txt

--- a/git/test/fixtures/diff_copied_mode_raw
+++ b/git/test/fixtures/diff_copied_mode_raw
@@ -1,0 +1,1 @@
+:100644 100644 cfe9dea cfe9dea C100     test1.txt       test2.txt

--- a/git/test/fixtures/diff_copied_mode_raw
+++ b/git/test/fixtures/diff_copied_mode_raw
@@ -1,1 +1,1 @@
-:100644 100644 cfe9dea cfe9dea C100     test1.txt       test2.txt
+:100644 100644 cfe9deac6e10683917e80f877566b58644aa21df cfe9deac6e10683917e80f877566b58644aa21df C100	test1.txt	test2.txt

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -120,7 +120,6 @@ class TestDiff(TestBase):
         assert_equal(1, len(diffs))
 
         diff = diffs[0]
-        print(diff)
         assert_true(diff.copied_file)
         assert isinstance(str(diff), str)
 

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -112,6 +112,27 @@ class TestDiff(TestBase):
         self.assertEqual(diff.score, 100)
         self.assertEqual(len(list(diffs.iter_change_type('R'))), 1)
 
+    def test_diff_with_copied_file(self):
+        output = StringProcessAdapter(fixture('diff_copied_mode'))
+        diffs = Diff._index_from_patch_format(self.rorepo, output)
+        self._assert_diff_format(diffs)
+
+        assert_equal(1, len(diffs))
+
+        diff = diffs[0]
+        print(diff)
+        assert_true(diff.copied_file)
+        assert isinstance(str(diff), str)
+
+        output = StringProcessAdapter(fixture('diff_copied_mode_raw'))
+        diffs = Diff._index_from_raw_format(self.rorepo, output)
+        self.assertEqual(len(diffs), 1)
+        diff = diffs[0]
+        self.assertEqual(diff.change_type, 'C')
+        self.assertEqual(diff.score, 100)
+        self.assertEqual(len(list(diffs.iter_change_type('C'))), 1)
+
+
     def test_diff_with_change_in_type(self):
         output = StringProcessAdapter(fixture('diff_change_in_type'))
         diffs = Diff._index_from_patch_format(self.rorepo, output)

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -121,6 +121,8 @@ class TestDiff(TestBase):
 
         diff = diffs[0]
         assert_true(diff.copied_file)
+        assert_true(diff.a_path, u'test1.txt')
+        assert_true(diff.b_path, u'test2.txt')
         assert isinstance(str(diff), str)
 
         output = StringProcessAdapter(fixture('diff_copied_mode_raw'))
@@ -129,8 +131,9 @@ class TestDiff(TestBase):
         diff = diffs[0]
         self.assertEqual(diff.change_type, 'C')
         self.assertEqual(diff.score, 100)
+        self.assertEqual(diff.a_path, u'test1.txt')
+        self.assertEqual(diff.b_path, u'test2.txt')
         self.assertEqual(len(list(diffs.iter_change_type('C'))), 1)
-
 
     def test_diff_with_change_in_type(self):
         output = StringProcessAdapter(fixture('diff_change_in_type'))


### PR DESCRIPTION
This addresses #932 by adding support for the 'C' (copied) change type.

I used the repro case provided in the issue as the basis for the new test that covers this addition.

