### PR TITLE
Fix how Diff handles commits that contain submodule changes

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -67,7 +67,7 @@ __all__ = ('Git',)
 
 def handle_process_output(process, stdout_handler, stderr_handler,
                           finalizer=None, decode_streams=True):
-    """Registers for notifications to lean that process output is ready to read, and dispatches lines to
+    """Registers for notifications to learn that process output is ready to read, and dispatches lines to
     the respective line handlers.
     This function returns once the finalizer returns
 

--- a/git/diff.py
+++ b/git/diff.py
@@ -278,6 +278,14 @@ class Diff(object):
         if self.b_mode:
             self.b_mode = mode_str_to_int(self.b_mode)
 
+        # Determine whether this diff references a submodule, if it does then
+        # we need to overwrite "repo" to the corresponding submodule's repo instead
+        if repo and a_rawpath:
+            for submodule in repo.submodules:
+                if submodule.path == a_rawpath.decode("utf-8"):
+                    repo = submodule.module()
+                    break
+
         if a_blob_id is None or a_blob_id == self.NULL_HEX_SHA:
             self.a_blob = None
         else:

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -280,23 +280,23 @@ class TestDiff(TestBase):
         """Test that diff is able to correctly diff commits that cover submodule changes"""
         # Init a temp git repo that will be referenced as a submodule
         sub = Repo.init(self.submodule_dir)
-        with open(f"{self.submodule_dir}/subfile", "w") as sub_subfile:
+        with open(self.submodule_dir + "/subfile", "w") as sub_subfile:
             sub_subfile.write("")
         sub.index.add(["subfile"])
         sub.index.commit("first commit")
 
         # Init a temp git repo that will incorporate the submodule
         repo = Repo.init(self.repo_dir)
-        with open(f"{self.repo_dir}/test", "w") as foo_test:
+        with open(self.repo_dir + "/test", "w") as foo_test:
             foo_test.write("")
         repo.index.add(['test'])
-        Submodule.add(repo, "subtest", "sub", url=f"file://{self.submodule_dir}")
+        Submodule.add(repo, "subtest", "sub", url="file://" + self.submodule_dir)
         repo.index.commit("first commit")
         repo.create_tag('1')
 
         # Add a commit to the submodule
         submodule = repo.submodule('subtest')
-        with open(f"{self.repo_dir}/sub/subfile", "w") as foo_sub_subfile:
+        with open(self.repo_dir + "/sub/subfile", "w") as foo_sub_subfile:
             foo_sub_subfile.write("blub")
         submodule.module().index.add(["subfile"])
         submodule.module().index.commit("changed subfile")

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -13,3 +13,4 @@ git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard __testing_point__
+git submodule update --init --recursive


### PR DESCRIPTION
This PR addresses the issue reported in #891

The problem was that `Diff` was receiving the parent `Repo` but commit hashes from the submodule repo, resulting in `Diff` being unable to find the commits. This was due to the output of `git diff-tree <parent_commit_1> <parent_commit_2>` containing the hashes from the submodule:
```
$ git diff-tree 53a7920fe21c49edb4471978361c1f23bf4034b1 d4f583c621da537db510ee19b2198d2192df84a9
:160000 160000 8324c24a8c6d60bd83a5356e81e5278e54ef49fc 5ac7216dccc0c1352d53a17efbc5b3bfafc0fd46 M	sub
```
This implementation fixes that issue by comparing the `a_rawpath` to all of the repo's submodule `path`s and overwriting `repo` to the submodule's repo if there's a match. If there are ideas concerning a more efficient way to identify this situation I'm more than happy to entertain other approaches.

The test added by this PR is based off of the repro provided in #891. While it's a great repro case I don't feel like it's a particularly elegant test so I'm open to suggestions there as well.

Fixed a typo in a comment in `cmd.py` and resolved a deprecation warning within the `test_diff.py` file while I was in there. I also added `git submodule update --init --recursive`  to `init-tests-after-clone.sh` because there are a decent number of tests that fail without `gitdb` and `smmap` cloned.