### PR TITLE
Fix repo.index.diff("HEAD", create_patch=True) always returning an empty list

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -237,7 +237,7 @@ class Diff(object):
     # precompiled regex
     re_header = re.compile(br"""
                                 ^diff[ ]--git
-                                    [ ](?P<a_path_fallback>"?a/.+?"?)[ ](?P<b_path_fallback>"?b/.+?"?)\n
+                                    [ ](?P<a_path_fallback>"?[ab]/.+?"?)[ ](?P<b_path_fallback>"?[ab]/.+?"?)\n
                                 (?:^old[ ]mode[ ](?P<old_mode>\d+)\n
                                    ^new[ ]mode[ ](?P<new_mode>\d+)(?:\n|$))?
                                 (?:^similarity[ ]index[ ]\d+%\n

--- a/git/test/test_diff.py
+++ b/git/test/test_diff.py
@@ -68,7 +68,12 @@ class TestDiff(TestBase):
 
         with open(fp, 'w') as fs:
             fs.write("Hola Mundo")
-        r.git.commit(all=True, message="change on master")
+        r.git.add(Git.polish_url(fp))
+        self.assertEqual(len(r.index.diff("HEAD", create_patch=True)), 1,
+                         "create_patch should generate patch of diff to HEAD")
+        r.git.commit(message="change on master")
+        self.assertEqual(len(r.index.diff("HEAD", create_patch=True)), 0,
+                         "create_patch should generate no patch, already on HEAD")
 
         r.git.checkout('HEAD~1', b='topic')
         with open(fp, 'w') as fs:


### PR DESCRIPTION
This PR resolves the issue reported in #852 

As @jadinm correctly identified in #852, this bug centers around the fact that the regex utilized by `_index_from_patch_format()` in `git/diff.py` always expects the first line of the diff to have the `a` file first, then `b`:
```
diff --git a/the_file.py b/the_file.py
```
When the `other` passed to `repo.index.diff(other)` is not `None` the `-R` argument is added to the git command, resulting in the positions of the `a` and `b` files being flipped in the output and causing the `_index_from_patch_format()` function invoked by the `create_patch` option to not find a regex match:
```
diff --git b/the_file.py a/the_file.py
```

This fix makes the regex slightly more permissive, allowing it to match either order of the `a` and `b` files in the output of `git diff`.

For test coverage of this change I added assertions to an existing test within `test_diff.py` that set up everything needed to reproduce this bug.

Massive props to @jadinm, their troubleshooting and feedback on the issue significantly shortened the investigation required to get this one sorted out 🎉