### PR TITLE
Global ConfigParser

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -281,7 +281,7 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
         else:
             if config_level is None:
                 if read_only:
-                    self._file_or_files = [get_config_path(f) for f in CONFIG_LEVELS[:-1]]
+                    self._file_or_files = [get_config_path(f) for f in CONFIG_LEVELS if f != 'repository']
                 else:
                     raise ValueError("No configuration level or configuration files specified")
             else:

--- a/git/config.py
+++ b/git/config.py
@@ -211,7 +211,7 @@ def get_config_path(config_level):
     elif config_level == "global":
         return osp.normpath(osp.expanduser("~/.gitconfig"))
     elif config_level == "repository":
-        raise ValueError("repository configuration level not allowed")
+        raise ValueError("No repo to get repository configuration from. Use Repo._get_config_path")
 
     ValueError("Invalid configuration level: %r" % config_level)
 

--- a/git/config.py
+++ b/git/config.py
@@ -213,7 +213,7 @@ def get_config_path(config_level):
     elif config_level == "repository":
         raise ValueError("No repo to get repository configuration from. Use Repo._get_config_path")
 
-    ValueError("Invalid configuration level: %r" % config_level)
+    raise ValueError("Invalid configuration level: %r" % config_level)
 
 
 class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, object)):


### PR DESCRIPTION
fixes #775 

We can instantiate a GitConfigParser with no files specified, if we do so, then it'll figure out where those files are. It does this by either having a `config_level` specified to it or, in the case of a config reader, by default we might want to read from all configuration levels, just like is currently the case in Repo.config_writer(), so we iterate through all of them (except repository level) and add all files to the parser. 

If the repository level is specified, we raise a unique ValueError telling the user to use the Repo object instead.