### PR TITLE
Added Git Gud to projects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,5 +35,6 @@ Contributors are:
 -César Izurieta <cesar _at_ caih.org>
 -Arthur Milchior <arthur _at_ milchior.fr>
 -JJ Graham <thetwoj _at_ gmail.com>
+-Ben Thayer <ben _at_ benthayer.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ gpg --edit-key 88710E60
 * [Loki](https://github.com/Neo23x0/Loki)
 * [Omniwallet](https://github.com/OmniLayer/omniwallet)
 * [GitViper](https://github.com/BeayemX/GitViper)
+* [Git Gud](https://github.com/bthayer2365/git-gud)
 
 ### LICENSE
 


### PR DESCRIPTION
You can view the Git Gud project at https://github.com/bthayer2365/git-gud
I've been working on it for about a month now. It's basically a CLI game that helps people learn how to use git. We're currently in pre-release on PyPi and are actively adding more levels.

I also added myself as a contributor due to PRs #949 and #950 