### PR TITLE
Fix 'PushInfo' object has no attribute 'name'

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -717,7 +717,7 @@ class Remote(LazyMixin, Iterable):
         # read the lines manually as it will use carriage returns between the messages
         # to override the previous one. This is why we read the bytes manually
         progress_handler = progress.new_message_handler()
-        output = IterableList('name')
+        output = []
 
         def stdout_handler(line):
             try:
@@ -833,7 +833,7 @@ class Remote(LazyMixin, Iterable):
         :note: No further progress information is returned after push returns.
         :param kwargs: Additional arguments to be passed to git-push
         :return:
-            IterableList(PushInfo, ...) iterable list of PushInfo instances, each
+            list(PushInfo, ...) list of PushInfo instances, each
             one informing about an individual head which had been updated on the remote
             side.
             If the push contains rejected heads, these will have the PushInfo.ERROR bit set

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -31,7 +31,7 @@ from git.test.lib import (
     GIT_DAEMON_PORT,
     assert_raises
 )
-from git.util import IterableList, rmtree, HIDE_WINDOWS_FREEZE_ERRORS
+from git.util import rmtree, HIDE_WINDOWS_FREEZE_ERRORS
 import os.path as osp
 
 

--- a/git/test/test_remote.py
+++ b/git/test/test_remote.py
@@ -325,7 +325,7 @@ class TestRemote(TestBase):
         self._commit_random_file(rw_repo)
         progress = TestRemoteProgress()
         res = remote.push(lhead.reference, progress)
-        self.assertIsInstance(res, IterableList)
+        self.assertIsInstance(res, list)
         self._do_test_push_result(res, remote)
         progress.make_assertion()
 


### PR DESCRIPTION
This PR addresses #820 

As identified in the issue, running the following short script:
```
import git
git_client = git.Repo.clone_from(your_favorite_repo, 'test_clone')
result = git_client.remotes.origin.push()
print(result.summary)
```
Results in an exception like:
```
Traceback (most recent call last):
  File "/home/jj/scratch/GitPython/git/jjtestfile.py", line 4, in <module>
    print(result.summary)
  File "/home/jj/scratch/GitPython/git/util.py", line 877, in __getattr__
    if getattr(item, self._id_attr) == attr:
AttributeError: 'PushInfo' object has no attribute 'name'
```

This is a bit of a misleading exception because `results` is actually an `IterableList(PushInfo, ...)`, not an instance of `PushInfo`. The implementation of `IterableList` is looking for the `name` attribute on the items it contains because that's the `id_attr` that is provided when the `IterableList` is created in `_get_push_info()`:

```
output = IterableList('name')
```
Unfortunately this doesn't pan out well because `PushInfo` doesn't contain a `name` attribute, so the functionality that `IterableList` implements breaks down.

One way to resolve the issue would be to simply reference the `PushInfo` directly:
```
print(result[0].summary)
```
But the current exception prevents that from being obvious. After reading through the functionality exposed by `IterableList` I don't believe that it is actually providing any particular usefulness in this case because `PushInfo` doesn't contain any attributes that make for a logical `id_attr`. I think it makes more sense to replace this use of `IterableList` with a plain old `list`, that way the exception becomes much more helpful:

```
Traceback (most recent call last):
  File "/home/jj/scratch/GitPython/git/jjtestfile.py", line 4, in <module>
    print(result.summary)
AttributeError: 'list' object has no attribute 'summary'
```