### PR TITLE
Fix cloning to path with unicode

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -401,7 +401,7 @@ class Git(LazyMixin):
             :raise GitCommandError: if the return status is not 0"""
             if stderr is None:
                 stderr = b''
-            stderr = force_bytes(stderr)
+            stderr = force_bytes(data=stderr, encoding='utf-8')
 
             status = self.proc.wait()
 

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -245,6 +245,20 @@ class TestRepo(TestBase):
         assert_equal(cloned.config_reader().get_value('core', 'filemode'), False)
         assert_equal(cloned.config_reader().get_value('submodule "repo"', 'update'), 'checkout')
 
+    def test_clone_from_with_path_contains_unicode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            unicode_dir_name = '\u0394'
+            path_with_unicode = os.path.join(tmpdir, unicode_dir_name)
+            os.makedirs(path_with_unicode)
+
+            try:
+                Repo.clone_from(
+                    url=self._small_repo_url(),
+                    to_path=path_with_unicode,
+                )
+            except UnicodeEncodeError:
+                self.fail('Raised UnicodeEncodeError')
+
     @with_rw_repo('HEAD')
     def test_max_chunk_size(self, repo):
         class TestOutputStream(object):


### PR DESCRIPTION
Fix cloning to directories with a path containing Unicode characters
Closes issue #920