### PR TITLE
Check if submodule exists before referencing

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -283,7 +283,8 @@ class Diff(object):
         if repo and a_rawpath:
             for submodule in repo.submodules:
                 if submodule.path == a_rawpath.decode("utf-8"):
-                    repo = submodule.module()
+                    if submodule.module_exists():
+                        repo = submodule.module()
                     break
 
         if a_blob_id is None or a_blob_id == self.NULL_HEX_SHA:


### PR DESCRIPTION
If you don't set the recursive option when you git clone
The following error:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/git/objects/submodule/base.py", line 1037, in module
    repo = git.Repo(module_checkout_abspath)
  File "/usr/local/lib/python3.7/site-packages/git/repo/base.py", line 184, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /Users/tanaga/Inci_e3b_modules/Agents_e3b

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/git/cmd.py", line 92, in pump_stream
    handler(line)
  File "/usr/local/lib/python3.7/site-packages/git/diff.py", line 534, in handle_diff_line
    '', change_type, score)
  File "/usr/local/lib/python3.7/site-packages/git/diff.py", line 286, in __init__
    repo = submodule.module()
  File "/usr/local/lib/python3.7/site-packages/git/util.py", line 72, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/git/objects/submodule/base.py", line 1042, in module
    raise InvalidGitRepositoryError("No valid repository at %s" % module_checkout_abspath)
git.exc.InvalidGitRepositoryError: No valid repository at /Users/tanaga/Inci_e3b_modules/Agents_e3b

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.2_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/site-packages/git/cmd.py", line 95, in pump_stream
    raise CommandError(['<%s-pump>' % name] + cmdline, ex)
git.exc.CommandError: Cmd('<stdout-pump>') failed due to: InvalidGitRepositoryError('No valid repository at /Users/tanaga/Inci_e3b_modules/Agents_e3b')
  cmdline: <stdout-pump> git diff-tree 1503302cd7ddc45641c8b03255e4c6cb6cebbcbe f900136f66bcbc675b24fd44a26c1a06520c7ed1 -r --abbrev=40 --full-index -M --raw --no-color
```

This is useful for ci
