### PR TITLE
Added parsing for '@1400000000 +0000' date format as used by git commit hooks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,5 +37,6 @@ Contributors are:
 -Anil Khatri <anil.soccer.khatri _at_ gmail.com>
 -JJ Graham <thetwoj _at_ gmail.com>
 -Ben Thayer <ben _at_ benthayer.com>
+-Dries Kennes <admin _at_ dries007.net>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -148,6 +148,8 @@ def parse_date(string_date):
     try:
         if string_date.count(' ') == 1 and string_date.rfind(':') == -1:
             timestamp, offset = string_date.split()
+            if timestamp.startswith('@'):
+                timestamp = timestamp[1:]
             timestamp = int(timestamp)
             return timestamp, utctz_to_altz(verify_utctz(offset))
         else:

--- a/git/test/test_repo.py
+++ b/git/test/test_repo.py
@@ -221,6 +221,12 @@ class TestRepo(TestBase):
         assert_equal(environment, cloned.git.environment())
 
     @with_rw_directory
+    def test_date_format(self, rw_dir):
+        repo = Repo.init(osp.join(rw_dir, "repo"))
+        # @-timestamp is the format used by git commit hooks
+        repo.index.commit("Commit messages", commit_date="@1400000000 +0000")
+
+    @with_rw_directory
     def test_clone_from_pathlib(self, rw_dir):
         if pathlib is None:  # pythons bellow 3.4 don't have pathlib
             raise SkipTest("pathlib was introduced in 3.4")


### PR DESCRIPTION
The git pre-commit hook is run with the `GIT_AUTHOR_DATE` environment variable set.
The format used (on my machine anyway) is `@1574863356 +0100`, which is not handles correctly by [`parse_date`](https://github.com/gitpython-developers/GitPython/blob/master/git/objects/util.py#L150). 

This PR fixes that crash, but it doesn't quite fully resolve issue #963. This issue also contains steps to reproduce and a stacktrace.