### PR TITLE
Replace redacted MAINTAINER with LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:xenial
 
 # Metadata
 LABEL maintainer="jking@apache.org"
+LABEL description="CI enviroment for testing GitPython"A
 
 ENV CONTAINER_USER=user
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@
 #
 
 FROM ubuntu:xenial
-MAINTAINER James E. King III <jking@apache.org>
+
+# Metadata
+LABEL maintainer="jking@apache.org"
+
 ENV CONTAINER_USER=user
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Replacing the redacted MAINTAINER tag with the corresponding label. I also added a description.