### PR TITLE
Fix param format of Repo.commit

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -471,8 +471,10 @@ class Repo(object):
 
     def commit(self, rev=None):
         """The Commit object for the specified revision
+
         :param rev: revision specifier, see git-rev-parse for viable options.
-        :return: ``git.Commit``"""
+        :return: ``git.Commit``
+        """
         if rev is None:
             return self.head.commit
         return self.rev_parse(str(rev) + "^0")


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

This fixes the format:

`
The Commit object for the specified revision :param rev: revision specifier, see git-rev-parse for viable options. :return: git.Commit
`