### PR TITLE
Do not error in race condition of directory existing

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -174,7 +174,7 @@ def assure_directory_exists(path, is_file=False):
         path = osp.dirname(path)
     # END handle file
     if not osp.isdir(path):
-        os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         return True
     return False
 


### PR DESCRIPTION
This address a rare race condition where the directory is created by simultaneous processes both trying to create things under the same folder.

https://github.com/ansible/awx/issues/6119

```
File "/awx_devel/awx/main/tasks.py", line 2255, in make_local_copy
  source_branch = git_repo.create_head(tmp_branch_name, scm_revision)
File "/venv/awx/lib/python3.6/site-packages/git/repo/base.py", line 389, in create_head
  return Head.create(self, path, commit, force, logmsg)
File "/venv/awx/lib/python3.6/site-packages/git/refs/symbolic.py", line 546, in create
  return cls._create(repo, path, cls._resolve_ref_on_create, reference, force, logmsg)
File "/venv/awx/lib/python3.6/site-packages/git/refs/symbolic.py", line 513, in _create
  ref.set_reference(target, logmsg)
File "/venv/awx/lib/python3.6/site-packages/git/refs/symbolic.py", line 329, in set_reference
  assure_directory_exists(fpath, is_file=True)
File "/venv/awx/lib/python3.6/site-packages/git/util.py", line 181, in assure_directory_exists
  os.makedirs(path)
File "/venv/awx/lib64/python3.6/os.py", line 220, in makedirs
  mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/var/lib/awx/projects/_71__project_aspectmatter/.git/refs/heads/awx_internal'
```

This has been available since python 3.2, and I see in your setup.py that you don't support python2 any longer, so this kwarg shouldn't cause problems.