### PR TITLE
#993 fix: wrong refs 'HEAD' exception

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -20,7 +20,8 @@ from git.config import (
 from git.exc import (
     InvalidGitRepositoryError,
     NoSuchPathError,
-    RepositoryDirtyError
+    RepositoryDirtyError,
+    BadName
 )
 from git.objects.base import IndexObject, Object
 from git.objects.util import Traversable
@@ -1153,10 +1154,10 @@ class Submodule(IndexObject, Iterable, Traversable):
     @classmethod
     def iter_items(cls, repo, parent_commit='HEAD'):
         """:return: iterator yielding Submodule instances available in the given repository"""
-        pc = repo.commit(parent_commit)         # parent commit instance
         try:
+            pc = repo.commit(parent_commit)         # parent commit instance
             parser = cls._config_parser(repo, pc, read_only=True)
-        except IOError:
+        except (IOError, BadName):
             return
         # END handle empty iterator
 


### PR DESCRIPTION
When git HEAD refs is broken, it raise BadName exception.
so submodules logic which is using a rev_parse function to HEAD get Exception, so handle BadName to return empty list 

https://github.com/gitpython-developers/GitPython/commit/b303cb0c5995bf9c74db34a8082cdf5258c250fe
https://github.com/gitpython-developers/GitPython/blob/b303cb0c5995bf9c74db34a8082cdf5258c250fe/git/diff.py#L281-L287