### PR TITLE
BF: tolerate errors while parsing fetch lines

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -705,8 +705,12 @@ class Remote(LazyMixin, Iterable):
             # end truncate correct list
         # end sanity check + sanitization
 
-        output.extend(FetchInfo._from_line(self.repo, err_line, fetch_line)
-                      for err_line, fetch_line in zip(fetch_info_lines, fetch_head_info))
+        for err_line, fetch_line in zip(fetch_info_lines, fetch_head_info):
+            try:
+                output.append(FetchInfo._from_line(self.repo, err_line, fetch_line))
+            except ValueError as exc:
+                log.debug("Caught error while parsing line: %s", exc)
+                log.warning("Git informed while fetching: %s", err_line.strip())
         return output
 
     def _get_push_info(self, proc, progress):


### PR DESCRIPTION
At first I thought to provide special treatment to git config lines and
otherwise keep raising uncaught exception, but then decided that it might be
better to loose some progress information than to crash.
Also _get_push_info below is doing similarish catching of all exceptions
(although doesn't even log them).

With this change, log (if enabled and not suppressed) would show

	[WARNING] Git informed while fetching: git config pull.rebase false  # merge (the default strategy)

in the case of recently introduced change to the output in the following
git commit :

	d18c950a69f3a24e1e3add3d9fc427641f53e12b is the first bad commit
	commit d18c950a69f3a24e1e3add3d9fc427641f53e12b
	Author: Alex Henrie <alexhenrie24@gmail.com>
	Date:   Mon Mar 9 21:54:20 2020 -0600

		pull: warn if the user didn't say whether to rebase or to merge

		Often novice Git users forget to say "pull --rebase" and end up with an
		unnecessary merge from upstream. What they usually want is either "pull
		--rebase" in the simpler cases, or "pull --ff-only" to update the copy
		of main integration branches, and rebase their work separately. The
		pull.rebase configuration variable exists to help them in the simpler
		cases, but there is no mechanism to make these users aware of it.

		Issue a warning message when no --[no-]rebase option from the command
		line and no pull.rebase configuration variable is given. This will
		inconvenience those who never want to "pull --rebase", who haven't had
		to do anything special, but the cost of the inconvenience is paid only
		once per user, which should be a reasonable cost to help a number of new
		users.

		Signed-off-by: Alex Henrie <alexhenrie24@gmail.com>
		Signed-off-by: Junio C Hamano <gitster@pobox.com>

	 builtin/pull.c               | 16 ++++++++++++++++
	 t/t5521-pull-options.sh      | 22 +++++++++++-----------
	 t/t7601-merge-pull-config.sh | 38 ++++++++++++++++++++++++++++++++++++++
	 3 files changed, 65 insertions(+), 11 deletions(-)

Closes #1014