### PR TITLE
Fix exception causes in cmd.py

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -83,7 +83,7 @@ def handle_process_output(process, stdout_handler, stderr_handler,
                     handler(line)
         except Exception as ex:
             log.error("Pumping %r of cmd(%s) failed due to: %r", name, cmdline, ex)
-            raise CommandError(['<%s-pump>' % name] + cmdline, ex)
+            raise CommandError(['<%s-pump>' % name] + cmdline, ex) from ex
         finally:
             stream.close()
 
@@ -732,7 +732,7 @@ class Git(LazyMixin):
                          **subprocess_kwargs
                          )
         except cmd_not_found_exception as err:
-            raise GitCommandNotFound(command, err)
+            raise GitCommandNotFound(command, err) from err
 
         if as_process:
             return self.AutoInterrupt(proc, command)
@@ -982,9 +982,9 @@ class Git(LazyMixin):
         else:
             try:
                 index = ext_args.index(insert_after_this_arg)
-            except ValueError:
+            except ValueError as err:
                 raise ValueError("Couldn't find argument '%s' in args %s to insert cmd options after"
-                                 % (insert_after_this_arg, str(ext_args)))
+                                 % (insert_after_this_arg, str(ext_args))) from err
             # end handle error
             args = ext_args[:index + 1] + opt_args + ext_args[index + 1:]
         # end handle opts_kwargs


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 