### PR TITLE
Ensure only fully matching symrefs are deleted

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -445,12 +445,14 @@ class SymbolicReference(object):
                     made_change = False
                     dropped_last_line = False
                     for line in reader:
+                        line = line.decode(defenc)
+                        _, _, line_ref = line.partition(' ')
+                        line_ref = line_ref.strip()
                         # keep line if it is a comment or if the ref to delete is not
                         # in the line
                         # If we deleted the last line and this one is a tag-reference object,
                         # we drop it as well
-                        line = line.decode(defenc)
-                        if (line.startswith('#') or full_ref_path not in line) and \
+                        if (line.startswith('#') or full_ref_path != line_ref) and \
                                 (not dropped_last_line or dropped_last_line and not line.startswith('^')):
                             new_lines.append(line)
                             dropped_last_line = False


### PR DESCRIPTION
Deleting a symbolic ref with e.g. the name 'refs/remotes/origin/mas'
would also delete 'refs/remotes/origin/master' if the ref had to be
deleted from the pack file.

In order to fix this the full ref is now checked for a match.