### PR TITLE
fix for extra back slashes for windows UNC paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,4 +42,5 @@ Contributors are:
 -Harmon <harmon.public _at_ gmail.com>
 -Liam Beguin <liambeguin _at_ gmail.com>
 -Ram Rachum <ram _at_ rachum.com>
+-Cole Hudson <m.cole.hudson _at_ gmail.com>
 Portions derived from other open source works and are clearly marked.

--- a/git/config.py
+++ b/git/config.py
@@ -419,6 +419,8 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
                         optval = string_decode(optval[1:])
                     # end handle multi-line
                     # preserves multiple values for duplicate optnames
+                    # fix for extra back slashes so windows UNC paths are not mangled
+                    optval = optval.replace('\\\\', '\\')
                     cursect.add(optname, optval)
                 else:
                     # check if it's an option with no value - it's just ignored by git


### PR DESCRIPTION
This is to address UNC paths breaking, as discussed in issue #1019 