### PR TITLE
Accept datetime instances as dates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,4 +42,5 @@ Contributors are:
 -Harmon <harmon.public _at_ gmail.com>
 -Liam Beguin <liambeguin _at_ gmail.com>
 -Ram Rachum <ram _at_ rachum.com>
+-Alba Mendez <me _at_ alba.sh>
 Portions derived from other open source works and are clearly marked.

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -135,6 +135,7 @@ def parse_date(string_date):
     """
     Parse the given date as one of the following
 
+        * aware datetime instance
         * Git internal format: timestamp offset
         * RFC 2822: Thu, 07 Apr 2005 22:13:13 +0200.
         * ISO 8601 2005-04-07T22:13:13
@@ -144,6 +145,10 @@ def parse_date(string_date):
     :raise ValueError: If the format could not be understood
     :note: Date can also be YYYY.MM.DD, MM/DD/YYYY and DD.MM.YYYY.
     """
+    if isinstance(string_date, datetime) and string_date.tzinfo:
+        offset = -int(string_date.utcoffset().total_seconds())
+        return int(string_date.astimezone(utc).timestamp()), offset
+
     # git time
     try:
         if string_date.count(' ') == 1 and string_date.rfind(':') == -1:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -174,6 +174,10 @@ class TestUtils(TestBase):
         self.assertIn('@', get_user_id())
 
     def test_parse_date(self):
+        # parse_date(from_timestamp()) must return the tuple unchanged
+        for timestamp, offset in (1522827734, -7200), (1522827734, 0), (1522827734, +3600):
+            self.assertEqual(parse_date(from_timestamp(timestamp, offset)), (timestamp, offset))
+
         # test all supported formats
         def assert_rval(rval, veri_time, offset=0):
             self.assertEqual(len(rval), 2)
@@ -200,6 +204,7 @@ class TestUtils(TestBase):
         # END for each date type
 
         # and failure
+        self.assertRaises(ValueError, parse_date, datetime.now())  # non-aware datetime
         self.assertRaises(ValueError, parse_date, 'invalid format')
         self.assertRaises(ValueError, parse_date, '123456789 -02000')
         self.assertRaises(ValueError, parse_date, ' 123456789 -0200')


### PR DESCRIPTION
There's no easy way to re-create a commit (i.e. for rewriting purposes), because dates must be formatted as strings, passed, then parsed back.

This patch allows `parse_date()` to accept datetime instances, such as those produced by `from_timestamp()`.
Re-creating a commit is then possible:

~~~ python
Commit.create_from_tree(
  repo=commit.repo,
  tree=commit.tree,
  message=commit.message,
  parent_commits=commit.parents,
  author=commit.author,
  author_date=commit.authored_datetime,
  committer=commit.committer,
  commit_date=commit.committed_datetime,
)
~~~