### PR TITLE
git/repo/base.py: is_dirty(): Fix pathspec handling

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -639,7 +639,7 @@ class Repo(object):
         if not submodules:
             default_args.append('--ignore-submodules')
         if path:
-            default_args.append(path)
+            default_args.extend(["--", path])
         if index:
             # diff index against HEAD
             if osp.isfile(self.index.path) and \

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -357,6 +357,20 @@ class TestRepo(TestBase):
         assert self.rorepo.is_dirty() is False
         self.rorepo._bare = orig_val
 
+    def test_is_dirty_pathspec(self):
+        self.rorepo._bare = False
+        for index in (0, 1):
+            for working_tree in (0, 1):
+                for untracked_files in (0, 1):
+                    assert self.rorepo.is_dirty(index, working_tree, untracked_files, path=':!foo') in (True, False)
+                # END untracked files
+            # END working tree
+        # END index
+        orig_val = self.rorepo._bare
+        self.rorepo._bare = True
+        assert self.rorepo.is_dirty() is False
+        self.rorepo._bare = orig_val
+
     @with_rw_repo('HEAD')
     def test_is_dirty_with_path(self, rwrepo):
         assert rwrepo.is_dirty(path="git") is False


### PR DESCRIPTION
It's possible to specify a pathspec (eg :!foo) to git diff/status/...
but it currently fails with:

git.exc.GitCommandError: Cmd('/usr/bin/git') failed due to: exit code(128)
  cmdline: /usr/bin/git diff --abbrev=40 --full-index --raw :!foo
  stderr: 'fatal: ambiguous argument ':!foo': unknown revision or path not in the working tree.

Add missing '--' to the arguments to fix this ambiguity

Fixes: #1061 
Signed-off-by: Arnaud Patard <apatard@hupstream.com>