### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .venv/
+venv/
 /*.egg-info
 /lib/GitPython.egg-info
 cover/


### PR DESCRIPTION
Even though `.venv` is in *.gitignore*, `venv` doesn't.