### PR TITLE
Fix default actor name handling

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -591,7 +591,7 @@ class Actor(object):
             return user_id
 
         def default_name():
-            default_email().split('@')[0]
+            return default_email().split('@')[0]
 
         for attr, evar, cvar, default in (('name', env_name, cls.conf_name, default_name),
                                           ('email', env_email, cls.conf_email, default_email)):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -226,15 +226,25 @@ class TestUtils(TestBase):
         }
         os.environ.update(env)
         for cr in (None, self.rorepo.config_reader()):
-            Actor.committer(cr)
-            Actor.author(cr)
+            committer = Actor.committer(cr)
+            author = Actor.author(cr)
+            self.assertEqual(committer.name, 'Jane Doe')
+            self.assertEqual(committer.email, 'jane@example.com')
+            self.assertEqual(author.name, 'John Doe')
+            self.assertEqual(author.email, 'jdoe@example.com')
         self.assertFalse(mock_get_uid.called)
 
     @mock.patch("getpass.getuser")
     def test_actor_get_uid_laziness_called(self, mock_get_uid):
+        mock_get_uid.return_value = "user"
         for cr in (None, self.rorepo.config_reader()):
-            Actor.committer(cr)
-            Actor.author(cr)
+            committer = Actor.committer(cr)
+            author = Actor.author(cr)
+            if cr is None:  # otherwise, use value from config_reader
+                self.assertEqual(committer.name, 'user')
+                self.assertTrue(committer.email.startswith('user@'))
+                self.assertEqual(author.name, 'user')
+                self.assertTrue(committer.email.startswith('user@'))
         self.assertTrue(mock_get_uid.called)
         self.assertEqual(mock_get_uid.call_count, 4)
 


### PR DESCRIPTION
In c96476b, the new default_name nested function does not contain a
retun statement. This leads to an issue when the environment variables
are not present, where the actor name would not be set.

Signed-off-by: Athos Ribeiro <athos@redhat.com>