### PR TITLE
Fix UnicodeDecodeError in diff filename

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -275,7 +275,7 @@ class Diff(object):
         # we need to overwrite "repo" to the corresponding submodule's repo instead
         if repo and a_rawpath:
             for submodule in repo.submodules:
-                if submodule.path == a_rawpath.decode("utf-8"):
+                if submodule.path == a_rawpath.decode(defenc, 'replace'):
                     if submodule.module_exists():
                         repo = submodule.module()
                     break


### PR DESCRIPTION
Fix for #1081.

If the filename of a diff object contained non UTF-8 chars, GitPython was raising a UnicodeDecodeError.

This PR fixes this by using the "replace" flag when decoding.
Furthermore, the variable `defenc` is used, that is `sys.getfilesystemencoding()`. 