### PR TITLE
docs: fix simple typo, repostory -> repository

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -466,7 +466,7 @@ class Repo(object):
             One of the following values
             system = system wide configuration file
             global = user level configuration file
-            repository = configuration file for this repostory only"""
+            repository = configuration file for this repository only"""
         return GitConfigParser(self._get_config_path(config_level), read_only=False, repo=self)
 
     def commit(self, rev=None):


### PR DESCRIPTION
There is a small typo in git/repo/base.py.

Should read `repository` rather than `repostory`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md