### PR TITLE
Fix universal_newlines TypeError

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -772,6 +772,7 @@ class Git(LazyMixin):
         status = 0
         stdout_value = b''
         stderr_value = b''
+        newline = "\n" if universal_newlines else b"\n"
         try:
             if output_stream is None:
                 if kill_after_timeout:
@@ -783,9 +784,9 @@ class Git(LazyMixin):
                         stderr_value = ('Timeout: the command "%s" did not complete in %d '
                                         'secs.' % (" ".join(command), kill_after_timeout)).encode(defenc)
                 # strip trailing "\n"
-                if stdout_value.endswith(b"\n"):
+                if stdout_value.endswith(newline):
                     stdout_value = stdout_value[:-1]
-                if stderr_value.endswith(b"\n"):
+                if stderr_value.endswith(newline):
                     stderr_value = stderr_value[:-1]
                 status = proc.returncode
             else:
@@ -794,7 +795,7 @@ class Git(LazyMixin):
                 stdout_value = proc.stdout.read()
                 stderr_value = proc.stderr.read()
                 # strip trailing "\n"
-                if stderr_value.endswith(b"\n"):
+                if stderr_value.endswith(newline):
                     stderr_value = stderr_value[:-1]
                 status = proc.wait()
             # END stdout handling


### PR DESCRIPTION
Currently, using `git.cmd.Git` with `universal_newlines=True` throws a `TypeError`:
```
In [1]: import git

In [2]: git.__version__
Out[2]: '3.1.7'

In [3]: g = git.cmd.Git()

In [4]: g.ls_files(universal_newlines=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-dc77db814df8> in <module>
----> 1 g.ls_files(universal_newlines=True)

~/venv/lib/python3.6/site-packages/git/cmd.py in <lambda>(*args, **kwargs)
    540         if name[0] == '_':
    541             return LazyMixin.__getattr__(self, name)
--> 542         return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
    543
    544     def set_persistent_git_options(self, **kwargs):

~/venv/lib/python3.6/site-packages/git/cmd.py in _call_process(self, method, *args, **kwargs)
   1003         call.extend(args)
   1004
-> 1005         return self.execute(call, **exec_kwargs)
   1006
   1007     def _parse_object_header(self, header_line):

~/venv/lib/python3.6/site-packages/git/cmd.py in execute(self, command, istream, with_extended_output, with_exceptions, as_process, output_stream, stdout_as_string, kill_after_timeout, with_stdout, universal_newlines, shell, env, max_chunk_size, **subprocess_kwargs)
    784                                         'secs.' % (" ".join(command), kill_after_timeout)).encode(defenc)
    785                 # strip trailing "\n"
--> 786                 if stdout_value.endswith(b"\n"):
    787                     stdout_value = stdout_value[:-1]
    788                 if stderr_value.endswith(b"\n"):

TypeError: endswith first arg must be str or a tuple of str, not bytes
```

I wasn't able to try out an automated test case due to #1090, but it doesn't throw an error anymore when I test it out manually:
```
~/code/GitPython (jwisniewski/20201230-universal-newlines) $ python
Python 3.6.5 (default, Sep 29 2020, 16:04:29)
[GCC Apple LLVM 12.0.0 (clang-1200.0.31.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import git
>>> g = git.cmd.Git()
>>> g.ls_files(universal_newlines=True)
'.appveyor.yml\n.codeclimate.yml\n.coveragerc\n.deepsource.toml\n[...]'
```