### PR TITLE
Fix package name in intro docs to reflect actual pypi name

### DIFF
--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -32,7 +32,7 @@ installed, just run the following from the command-line:
 
 .. sourcecode:: none
 
-    # pip install gitpython
+    # pip install GitPython
 
 This command will download the latest version of GitPython from the
 `Python Package Index <http://pypi.python.org/pypi/GitPython>`_ and install it


### PR DESCRIPTION
The package uses PascalCase on pypi. Having the wrong name in the docs is confusing.