### PR TITLE
fix(fetch): use the correct FETCH_HEAD from within a worktree

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -22,8 +22,6 @@ from git.util import (
     join_path,
 )
 
-import os.path as osp
-
 from .config import (
     SectionConstraint,
     cp,
@@ -685,7 +683,8 @@ class Remote(LazyMixin, Iterable):
                     continue
 
         # read head information
-        with open(osp.join(self.repo.common_dir, 'FETCH_HEAD'), 'rb') as fp:
+        fetch_head = SymbolicReference(self.repo, "FETCH_HEAD")
+        with open(fetch_head.abspath, 'rb') as fp:
             fetch_head_info = [line.decode(defenc) for line in fp.readlines()]
 
         l_fil = len(fetch_info_lines)


### PR DESCRIPTION
`FETCH_HEAD` is one of the symbolic references local to the current
worktree and as such should _not_ be looked up in the `common_dir`. But
instead of just hard coding the "right thing" (`git_dir`) lets defer this
to the `SymbolicReference` class which already contains this knowledge in
its `abspath` property.

This was introduced by #654. I suspect an overzealous search & replace of `git_dir` -> `common_dir` was the cause here.

FYI: this bug can be reproduced by this Python script. I've not been able to convert that into a test case though:
```python
import logging
import os
import os.path
from tempfile import TemporaryDirectory

import git


logging.basicConfig(
    level=logging.DEBUG,
)

with TemporaryDirectory() as tmpdir:
    # create repo to have something to fetch from
    with git.Repo.init(os.path.join(tmpdir, "source"), expand_vars=False) as src_repo:
        author = git.Actor('Bob Tester', 'bob@example.net')
        src_repo.index.commit(
            message="Initial commit",
            author_date="0 +0000",
            commit_date="0 +0000",
            author=author,
            committer=author,
        )

    with git.Repo.clone_from(src_repo.working_dir, os.path.join(tmpdir, "test")) as repo:
        fetchinfo, = repo.remotes.origin.fetch(["master"])

        subtree = "some-subdir"
        repo.git.worktree("add", subtree, fetchinfo.ref.commit)

        # pollute the top-level FETCH_HEAD so it'll definitely not match the fetch we're about to do below
        repo.remotes.origin.fetch([fetchinfo.ref.commit.hexsha for _ in range(5)])

        with git.Repo(os.path.join(repo.working_dir, subtree), expand_vars=False) as subrepo:
            # throws due to reading $(cat .git/common_dir)/.git/FETCH_HEAD instead of .git/FETCH_HEAD
            subrepo.remotes.origin.fetch(["master"])
```