### PR TITLE
Make git.cmd.Git.CatFileContentStream iterable

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -497,6 +497,9 @@ class Git(LazyMixin):
         # skipcq: PYL-E0301
         def __iter__(self):
             return self
+        
+        def __next__(self):
+            return self.next()
 
         def next(self):
             line = self.readline()


### PR DESCRIPTION
Add __next__ method to git.cmd.Git.CatFileContentStream, so it can actually be used as an iterable