### PR TITLE
Fix inheritance issue at commit.iter_items

### DIFF
--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -269,7 +269,7 @@ class Commit(base.Object, Iterable, Diffable, Traversable, Serializable):
             # END handle extra info
 
             assert len(hexsha) == 40, "Invalid line: %s" % hexsha
-            yield Commit(repo, hex_to_bin(hexsha))
+            yield cls(repo, hex_to_bin(hexsha))
         # END for each line in stream
         # TODO: Review this - it seems process handling got a bit out of control
         # due to many developers trying to fix the open file handles issue

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -199,6 +199,13 @@ class TestCommit(TestCommitSerialization):
         less_ltd_commits = list(Commit.iter_items(self.rorepo, 'master', paths=('CHANGES', 'AUTHORS')))
         assert len(ltd_commits) < len(less_ltd_commits)
 
+        class Child(Commit):
+            def __init__(self, *args, **kwargs):
+                super(Child, self).__init__(*args, **kwargs)
+
+        child_commits = list(Child.iter_items(self.rorepo, 'master', paths=('CHANGES', 'AUTHORS')))
+        assert type(child_commits[0]) == Child
+
     def test_iter_items(self):
         # pretty not allowed
         self.assertRaises(ValueError, Commit.iter_items, self.rorepo, 'master', pretty="raw")


### PR DESCRIPTION
The iterator used to yield Commit() objects, which does not play well
with inheritance. Yield cls() instead.

Signed-off-by: Yuri Volchkov <yuri@volch.org>