### PR TITLE
 Restore order of operators before executing the git command only for < py3.6

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -19,6 +19,7 @@ import sys
 import threading
 from collections import OrderedDict
 from textwrap import dedent
+import warnings
 
 from git.compat import (
     defenc,
@@ -902,8 +903,14 @@ class Git(LazyMixin):
 
     def transform_kwargs(self, split_single_char_options=True, **kwargs):
         """Transforms Python style kwargs into git command line options."""
+        # Python 3.6 preserves the order of kwargs and thus has a stable
+        # order. For older versions sort the kwargs by the key to get a stable
+        # order.
+        if sys.version_info[:2] < (3, 6):
+            kwargs = OrderedDict(sorted(kwargs.items(), key=lambda x: x[0]))
+            warnings.warn("Python 3.5 support is deprecated. It does not preserve the order\n" +
+                          "for key-word arguments. Thus they will be sorted!!")
         args = []
-        kwargs = OrderedDict(sorted(kwargs.items(), key=lambda x: x[0]))
         for k, v in kwargs.items():
             if isinstance(v, (list, tuple)):
                 for value in v:


### PR DESCRIPTION
Since Python 3.6 kwargs are stable ordered again and Python 3.5 reached
its end-of-life too, so we can revert 89ade7bfff534ae799d7dd693b206931d5ed3d4f
again. Thus make it able to pass ordered options to Git commands again.