### PR TITLE
Replace password in URI by stars if present to avoid leaking secrets in logs

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -28,7 +28,7 @@ from git.compat import (
     is_win,
 )
 from git.exc import CommandError
-from git.util import is_cygwin_git, cygpath, expand_path
+from git.util import is_cygwin_git, cygpath, expand_path, remove_password_if_present
 
 from .exc import (
     GitCommandError,
@@ -682,8 +682,10 @@ class Git(LazyMixin):
         :note:
            If you add additional keyword arguments to the signature of this method,
            you must update the execute_kwargs tuple housed in this module."""
+        # Remove password for the command if present
+        redacted_command = remove_password_if_present(command)
         if self.GIT_PYTHON_TRACE and (self.GIT_PYTHON_TRACE != 'full' or as_process):
-            log.info(' '.join(command))
+            log.info(' '.join(redacted_command))
 
         # Allow the user to have the command executed in their working dir.
         cwd = self._working_dir or os.getcwd()

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -82,8 +82,8 @@ def handle_process_output(process, stdout_handler, stderr_handler,
                         line = line.decode(defenc)
                     handler(line)
         except Exception as ex:
-            log.error("Pumping %r of cmd(%s) failed due to: %r", name, cmdline, ex)
-            raise CommandError(['<%s-pump>' % name] + cmdline, ex) from ex
+            log.error("Pumping %r of cmd(%s) failed due to: %r", name, remove_password_if_present(cmdline), ex)
+            raise CommandError(['<%s-pump>' % name] + remove_password_if_present(cmdline), ex) from ex
         finally:
             stream.close()
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -969,7 +969,13 @@ class Repo(object):
             handle_process_output(proc, None, progress.new_message_handler(), finalize_process, decode_streams=False)
         else:
             (stdout, stderr) = proc.communicate()
-            log.debug("Cmd(%s)'s unused stdout: %s", getattr(proc, 'args', ''), stdout)
+            cmdline = getattr(proc, 'args', '')
+            uri = cmdline[-2]
+            if "://" in uri and "@" in uri:
+                cred = uri.split("://")[1].split("@")[0].split(":")
+                if len(cred) == 2:
+                    cmdline[-2] = uri.replace(cred[1], "******")
+            log.debug("Cmd(%s)'s unused stdout: %s", cmdline, stdout)
             finalize_process(proc, stderr=stderr)
 
         # our git command could have a different working dir than our actual

--- a/git/util.py
+++ b/git/util.py
@@ -356,14 +356,14 @@ def remove_password_if_present(cmdline):
             url = urlsplit(to_parse)
             # Remove password from the URL if present
             if url.password is None:
-                raise ValueError()
+                continue
 
             edited_url = url._replace(
                 netloc=url.netloc.replace(url.password, "*****"))
             new_cmdline[index] = urlunsplit(edited_url)
         except ValueError:
             # This is not a valid URL
-            pass
+            continue
     return new_cmdline
 
 

--- a/git/util.py
+++ b/git/util.py
@@ -16,6 +16,7 @@ import stat
 from sys import maxsize
 import time
 from unittest import SkipTest
+from urllib.parse import urlsplit, urlunsplit
 
 from gitdb.util import (# NOQA @IgnorePep8
     make_sha,
@@ -337,6 +338,33 @@ def expand_path(p, expand_vars=True):
         return osp.normpath(osp.abspath(p))
     except Exception:
         return None
+
+
+def remove_password_if_present(cmdline):
+    """
+    Parse any command line argument and if on of the element is an URL with a
+    password, replace it by stars.  If nothing found just returns a copy of the
+    command line as-is.
+
+    This should be used for every log line that print a command line.
+    """
+    redacted_cmdline = []
+    for to_parse in cmdline:
+        try:
+            url = urlsplit(to_parse)
+            # Remove password from the URL if present
+            if url.password is None:
+                raise ValueError()
+
+            edited_url = url._replace(
+                netloc=url.netloc.replace(url.password, "*****"))
+            redacted_cmdline.append(urlunsplit(edited_url))
+        except ValueError:
+            redacted_cmdline.append(to_parse)
+            # This is not a valid URL
+            pass
+    return redacted_cmdline
+
 
 #} END utilities
 

--- a/git/util.py
+++ b/git/util.py
@@ -349,7 +349,9 @@ def remove_password_if_present(cmdline):
 
     This should be used for every log line that print a command line.
     """
+    new_cmdline = []
     for index, to_parse in enumerate(cmdline):
+        new_cmdline.append(to_parse)
         try:
             url = urlsplit(to_parse)
             # Remove password from the URL if present
@@ -358,11 +360,11 @@ def remove_password_if_present(cmdline):
 
             edited_url = url._replace(
                 netloc=url.netloc.replace(url.password, "*****"))
-            cmdline[index] = urlunsplit(edited_url)
+            new_cmdline[index] = urlunsplit(edited_url)
         except ValueError:
             # This is not a valid URL
             pass
-    return cmdline
+    return new_cmdline
 
 
 #} END utilities

--- a/git/util.py
+++ b/git/util.py
@@ -343,13 +343,13 @@ def expand_path(p, expand_vars=True):
 def remove_password_if_present(cmdline):
     """
     Parse any command line argument and if on of the element is an URL with a
-    password, replace it by stars.  If nothing found just returns a copy of the
-    command line as-is.
+    password, replace it by stars (in-place).
+
+    If nothing found just returns the command line as-is.
 
     This should be used for every log line that print a command line.
     """
-    redacted_cmdline = []
-    for to_parse in cmdline:
+    for index, to_parse in enumerate(cmdline):
         try:
             url = urlsplit(to_parse)
             # Remove password from the URL if present
@@ -358,12 +358,11 @@ def remove_password_if_present(cmdline):
 
             edited_url = url._replace(
                 netloc=url.netloc.replace(url.password, "*****"))
-            redacted_cmdline.append(urlunsplit(edited_url))
+            cmdline[index] = urlunsplit(edited_url)
         except ValueError:
-            redacted_cmdline.append(to_parse)
             # This is not a valid URL
             pass
-    return redacted_cmdline
+    return cmdline
 
 
 #} END utilities

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -244,7 +244,7 @@ class TestRepo(TestBase):
         password = "fakepassword1234"
         try:
             Repo.clone_from(
-                url=f"https://fakeuser:{password}@fakerepo.example.com/testrepo",
+                url="https://fakeuser:{}@fakerepo.example.com/testrepo".format(password),
                 to_path=rw_dir)
         except GitCommandError as err:
             assert password not in str(err)

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -238,6 +238,17 @@ class TestRepo(TestBase):
             except UnicodeEncodeError:
                 self.fail('Raised UnicodeEncodeError')
 
+    @with_rw_directory
+    def test_leaking_password_in_clone_logs(self, rw_dir):
+        """Check that the password is not printed on the logs"""
+        password = "fakepassword1234"
+        try:
+            Repo.clone_from(
+                url=f"https://fakeuser:{password}@fakerepo.example.com/testrepo",
+                to_path=rw_dir)
+        except GitCommandError as err:
+            assert password not in str(err)
+
     @with_rw_repo('HEAD')
     def test_max_chunk_size(self, repo):
         class TestOutputStream(TestBase):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -240,7 +240,6 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     def test_leaking_password_in_clone_logs(self, rw_dir):
-        """Check that the password is not printed on the logs"""
         password = "fakepassword1234"
         try:
             Repo.clone_from(
@@ -249,6 +248,10 @@ class TestRepo(TestBase):
                 to_path=rw_dir)
         except GitCommandError as err:
             assert password not in str(err), "The error message '%s' should not contain the password" % err
+        # Working example from a blank private project
+        Repo.clone_from(
+            url="https://gitlab+deploy-token-392045:mLWhVus7bjLsy8xj8q2V@gitlab.com/mercierm/test_git_python",
+            to_path=rw_dir)
 
     @with_rw_repo('HEAD')
     def test_max_chunk_size(self, repo):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -244,10 +244,11 @@ class TestRepo(TestBase):
         password = "fakepassword1234"
         try:
             Repo.clone_from(
-                url="https://fakeuser:{}@fakerepo.example.com/testrepo".format(password),
+                url="https://fakeuser:{}@fakerepo.example.com/testrepo".format(
+                    password),
                 to_path=rw_dir)
         except GitCommandError as err:
-            assert password not in str(err)
+            assert password not in str(err), "The error message '%s' should not contain the password" % err
 
     @with_rw_repo('HEAD')
     def test_max_chunk_size(self, repo):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -325,7 +325,6 @@ class TestUtils(TestBase):
         self.assertEqual(t1._name, t2._name)
 
     def test_remove_password_from_command_line(self):
-        """Check that the password is not printed on the logs"""
         password = "fakepassword1234"
         url_with_pass = "https://fakeuser:{}@fakerepo.example.com/testrepo".format(password)
         url_without_pass = "https://fakerepo.example.com/testrepo"
@@ -334,6 +333,10 @@ class TestUtils(TestBase):
         cmd_2 = ["git", "clone", "-v", url_without_pass]
         cmd_3 = ["no", "url", "in", "this", "one"]
 
-        assert password not in remove_password_if_present(cmd_1)
+        redacted_cmd_1 = remove_password_if_present(cmd_1)
+        assert password not in " ".join(redacted_cmd_1)
+        # Check that we use a copy
+        assert cmd_1 is not redacted_cmd_1
+        assert password in " ".join(cmd_1)
         assert cmd_2 == remove_password_if_present(cmd_2)
         assert cmd_3 == remove_password_if_present(cmd_3)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -30,7 +30,8 @@ from git.util import (
     Actor,
     IterableList,
     cygpath,
-    decygpath
+    decygpath,
+    remove_password_if_present,
 )
 
 
@@ -322,3 +323,17 @@ class TestUtils(TestBase):
         t2 = pickle.loads(pickle.dumps(t1))
         self.assertEqual(t1._offset, t2._offset)
         self.assertEqual(t1._name, t2._name)
+
+    def test_remove_password_from_command_line(self):
+        """Check that the password is not printed on the logs"""
+        password = "fakepassword1234"
+        url_with_pass = "https://fakeuser:{}@fakerepo.example.com/testrepo".format(password)
+        url_without_pass = "https://fakerepo.example.com/testrepo"
+
+        cmd_1 = ["git", "clone", "-v", url_with_pass]
+        cmd_2 = ["git", "clone", "-v", url_without_pass]
+        cmd_3 = ["no", "url", "in", "this", "one"]
+
+        assert password not in remove_password_if_present(cmd_1)
+        assert cmd_2 == remove_password_if_present(cmd_2)
+        assert cmd_3 == remove_password_if_present(cmd_3)


### PR DESCRIPTION
Currently, if you use a git URI containing a password like `https://username:pass@git.example.com/project` and an exception occurs during a git clone the password is printed in the logs. It also happen when the logging is at debug level.

To avoid secrets to leak in the logs, this patch replace the password by a fix amount of stars (`******`).   