### PR TITLE
Remove windows special handling

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 from git.cmd import handle_process_output, Git
-from git.compat import (defenc, force_text, is_win)
+from git.compat import (defenc, force_text)
 from git.exc import GitCommandError
 from git.util import (
     LazyMixin,
@@ -414,15 +414,6 @@ class Remote(LazyMixin, Iterable):
         self.repo = repo  # type: 'Repo'
         self.name = name
 
-        if is_win:
-            # some oddity: on windows, python 2.5, it for some reason does not realize
-            # that it has the config_writer property, but instead calls __getattr__
-            # which will not yield the expected results. 'pinging' the members
-            # with a dir call creates the config_writer property that we require
-            # ... bugs like these make me wonder whether python really wants to be used
-            # for production. It doesn't happen on linux though.
-            dir(self)
-        # END windows special handling
 
     def __getattr__(self, attr):
         """Allows to call this instance like

--- a/git/remote.py
+++ b/git/remote.py
@@ -414,7 +414,6 @@ class Remote(LazyMixin, Iterable):
         self.repo = repo  # type: 'Repo'
         self.name = name
 
-
     def __getattr__(self, attr):
         """Allows to call this instance like
         remote.special( \\*args, \\*\\*kwargs) to call git-remote special self.name"""


### PR DESCRIPTION
Remove windows special handling when creating Remote

Python2.5 is no longer supported, and it will cause a problem when init Remote with a no remote git repo.