### PR TITLE
Fix missing stderr when the progress parameter of _clone is None

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -988,8 +988,6 @@ class Repo(object):
     def _clone(cls, git: 'Git', url: PathLike, path: PathLike, odb_default_type: Type[GitCmdObjectDB],
                progress: Optional[Callable], multi_options: Optional[List[str]] = None, **kwargs: Any
                ) -> 'Repo':
-        progress_checked = to_progress_instance(progress)
-
         odbt = kwargs.pop('odbt', odb_default_type)
 
         # when pathlib.Path or other classbased path is passed
@@ -1012,9 +1010,9 @@ class Repo(object):
         if multi_options:
             multi = ' '.join(multi_options).split(' ')
         proc = git.clone(multi, Git.polish_url(url), clone_path, with_extended_output=True, as_process=True,
-                         v=True, universal_newlines=True, **add_progress(kwargs, git, progress_checked))
-        if progress_checked:
-            handle_process_output(proc, None, progress_checked.new_message_handler(),
+                         v=True, universal_newlines=True, **add_progress(kwargs, git, progress))
+        if progress:
+            handle_process_output(proc, None, to_progress_instance(progress).new_message_handler(),
                                   finalize_process, decode_streams=False)
         else:
             (stdout, stderr) = proc.communicate()

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This module is part of GitPython and is released under
+# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+
+from pathlib import Path
+import re
+
+import git
+
+from .lib import (
+    TestBase,
+    with_rw_directory,
+)
+
+class TestClone(TestBase):
+    @with_rw_directory
+    def test_checkout_in_non_empty_dir(self, rw_dir):
+        non_empty_dir = Path(rw_dir)
+        garbage_file = non_empty_dir / 'not-empty'
+        garbage_file.write_text('Garbage!')
+
+        # Verify that cloning into the non-empty dir fails while complaining about the target directory not being empty/non-existent
+        try:
+            self.rorepo.clone(non_empty_dir)
+        except git.GitCommandError as exc:
+            self.assertTrue(exc.stderr, "GitCommandError's 'stderr' is unexpectedly empty")
+            expr = re.compile(r'(?is).*\bfatal:\s+destination\s+path\b.*\bexists\b.*\bnot\b.*\bempty\s+directory\b')
+            self.assertTrue(expr.search(exc.stderr), '"%s" does not match "%s"' % (expr.pattern, exc.stderr))
+        else:
+            self.fail("GitCommandError not raised")

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -12,6 +12,7 @@ from .lib import (
     with_rw_directory,
 )
 
+
 class TestClone(TestBase):
     @with_rw_directory
     def test_checkout_in_non_empty_dir(self, rw_dir):
@@ -19,7 +20,8 @@ class TestClone(TestBase):
         garbage_file = non_empty_dir / 'not-empty'
         garbage_file.write_text('Garbage!')
 
-        # Verify that cloning into the non-empty dir fails while complaining about the target directory not being empty/non-existent
+        # Verify that cloning into the non-empty dir fails while complaining about
+        # the target directory not being empty/non-existent
         try:
             self.rorepo.clone(non_empty_dir)
         except git.GitCommandError as exc:


### PR DESCRIPTION
Try to fix #1221

The `to_progress_instance` function will convert `None` to `RemoteProgress` instance, so the line `if progress_checked` is True if `progress` parameter is `None`. 