### PR TITLE
test(clone): verify stderr for a failing clone into a non-empty dir

### DIFF
--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This module is part of GitPython and is released under
+# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+
+from pathlib import Path
+import re
+
+import git
+
+from .lib import (
+    TestBase,
+    with_rw_directory,
+)
+
+class TestClone(TestBase):
+    @with_rw_directory
+    def test_checkout_in_non_empty_dir(self, rw_dir):
+        non_empty_dir = Path(rw_dir)
+        garbage_file = non_empty_dir / 'not-empty'
+        garbage_file.write_text('Garbage!')
+
+        # Verify that cloning into the non-empty dir fails while complaining about the target directory not being empty/non-existent
+        try:
+            self.rorepo.clone(non_empty_dir)
+        except git.GitCommandError as exc:
+            self.assertTrue(exc.stderr, "GitCommandError's 'stderr' is unexpectedly empty")
+            expr = re.compile(r'(?is).*\bfatal:\s+destination\s+path\b.*\bexists\b.*\bnot\b.*\bempty\s+directory\b')
+            self.assertTrue(expr.search(exc.stderr), '"%s" does not match "%s"' % (expr.pattern, exc.stderr))
+        else:
+            self.fail("GitCommandError not raised")

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -12,6 +12,7 @@ from .lib import (
     with_rw_directory,
 )
 
+
 class TestClone(TestBase):
     @with_rw_directory
     def test_checkout_in_non_empty_dir(self, rw_dir):
@@ -19,7 +20,8 @@ class TestClone(TestBase):
         garbage_file = non_empty_dir / 'not-empty'
         garbage_file.write_text('Garbage!')
 
-        # Verify that cloning into the non-empty dir fails while complaining about the target directory not being empty/non-existent
+        # Verify that cloning into the non-empty dir fails while complaining about
+        # the target directory not being empty/non-existent
         try:
             self.rorepo.clone(non_empty_dir)
         except git.GitCommandError as exc:


### PR DESCRIPTION
This adds a test case that would have caught #1221. It thus addresses (partially) the concern of "how to prevent breaking things in the future" expressed in #1223. It additionally verifies that the fix in #1224 actually works.

Edit: this _should_ introduce a single _failing_ test case that should be flipped to passing by #1224.