### PR TITLE
Add types to git/config.py

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -40,6 +40,18 @@ from .util import (
     stream_copy,
 )
 
+# typing ---------------------------------------------------------------------------
+
+from typing import TYPE_CHECKING
+
+from git.types import TBD
+
+if TYPE_CHECKING:
+   pass
+
+
+# ---------------------------------------------------------------------------------
+
 execute_kwargs = {'istream', 'with_extended_output',
                   'with_exceptions', 'as_process', 'stdout_as_string',
                   'output_stream', 'with_stdout', 'kill_after_timeout',

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -42,7 +42,7 @@ from .util import (
 
 # typing ---------------------------------------------------------------------------
 
-from typing import Any, BinaryIO, Callable, Dict, Mapping, Sequence, TYPE_CHECKING, Union
+from typing import Any, BinaryIO, Callable, Dict, List, Mapping, Sequence, TYPE_CHECKING, Union
 
 from git.types import PathLike, TBD
 
@@ -443,7 +443,7 @@ class Git(LazyMixin):
 
         __slots__ = ('_stream', '_nbr', '_size')
 
-        def __init__(self, size, stream):
+        def __init__(self, size: int, stream: BinaryIO) -> None:
             self._stream = stream
             self._size = size
             self._nbr = 0           # num bytes read
@@ -454,7 +454,7 @@ class Git(LazyMixin):
                 stream.read(1)
             # END handle empty streams
 
-        def read(self, size=-1):
+        def read(self, size: int = -1) -> bytes:
             bytes_left = self._size - self._nbr
             if bytes_left == 0:
                 return b''
@@ -474,7 +474,7 @@ class Git(LazyMixin):
             # END finish reading
             return data
 
-        def readline(self, size=-1):
+        def readline(self, size: int = -1) -> bytes:
             if self._nbr == self._size:
                 return b''
 
@@ -496,7 +496,7 @@ class Git(LazyMixin):
 
             return data
 
-        def readlines(self, size=-1):
+        def readlines(self, size: int = -1) -> List[bytes]:
             if self._nbr == self._size:
                 return []
 
@@ -517,20 +517,20 @@ class Git(LazyMixin):
             return out
 
         # skipcq: PYL-E0301
-        def __iter__(self):
+        def __iter__(self) -> 'Git.CatFileContentStream':
             return self
 
-        def __next__(self):
+        def __next__(self) -> bytes:
             return self.next()
 
-        def next(self):
+        def next(self) -> bytes:
             line = self.readline()
             if not line:
                 raise StopIteration
 
             return line
 
-        def __del__(self):
+        def __del__(self) -> None:
             bytes_left = self._size - self._nbr
             if bytes_left:
                 # read and discard - seeking is impossible within a stream
@@ -538,7 +538,7 @@ class Git(LazyMixin):
                 self._stream.read(bytes_left + 1)
             # END handle incomplete read
 
-    def __init__(self, working_dir=None):
+    def __init__(self, working_dir: Union[None, PathLike]=None):
         """Initialize this instance with:
 
         :param working_dir:

--- a/git/compat.py
+++ b/git/compat.py
@@ -44,9 +44,9 @@ defenc = sys.getfilesystemencoding()
 def safe_decode(s: None) -> None: ...
 
 @overload
-def safe_decode(s: Union[IO[str], AnyStr]) -> str: ...
+def safe_decode(s: AnyStr) -> str: ...
 
-def safe_decode(s: Union[IO[str], AnyStr, None]) -> Optional[str]:
+def safe_decode(s: Union[AnyStr, None]) -> Optional[str]:
     """Safely decodes a binary string to unicode"""
     if isinstance(s, str):
         return s

--- a/git/config.py
+++ b/git/config.py
@@ -31,9 +31,9 @@ import configparser as cp
 
 # typing-------------------------------------------------------
 
-from typing import TYPE_CHECKING, Tuple
+from typing import Any, Callable, Mapping, TYPE_CHECKING, Tuple
 
-from git.types import Literal
+from git.types import Literal, Lit_config_levels, TBD
 
 if TYPE_CHECKING:
     pass
@@ -59,7 +59,7 @@ CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbr
 class MetaParserBuilder(abc.ABCMeta):
 
     """Utlity class wrapping base-class methods into decorators that assure read-only properties"""
-    def __new__(cls, name, bases, clsdict):
+    def __new__(cls, name: str, bases: TBD, clsdict: Mapping[str, Any]) -> TBD:
         """
         Equip all base-class methods with a needs_values decorator, and all non-const methods
         with a set_dirty_and_flush_changes decorator in addition to that."""
@@ -85,23 +85,23 @@ class MetaParserBuilder(abc.ABCMeta):
         return new_type
 
 
-def needs_values(func):
+def needs_values(func: Callable) -> Callable:
     """Returns method assuring we read values (on demand) before we try to access them"""
 
     @wraps(func)
-    def assure_data_present(self, *args, **kwargs):
+    def assure_data_present(self, *args: Any, **kwargs: Any) -> Any:
         self.read()
         return func(self, *args, **kwargs)
     # END wrapper method
     return assure_data_present
 
 
-def set_dirty_and_flush_changes(non_const_func):
+def set_dirty_and_flush_changes(non_const_func: Callable) -> Callable:
     """Return method that checks whether given non constant function may be called.
     If so, the instance will be set dirty.
     Additionally, we flush the changes right to disk"""
 
-    def flush_changes(self, *args, **kwargs):
+    def flush_changes(self, *args: Any, **kwargs: Any) -> Any:
         rval = non_const_func(self, *args, **kwargs)
         self._dirty = True
         self.write()
@@ -206,7 +206,7 @@ class _OMD(OrderedDict):
         return [(k, self.getall(k)) for k in self]
 
 
-def get_config_path(config_level: Literal['system', 'global', 'user', 'repository']) -> str:
+def get_config_path(config_level: Lit_config_levels) -> str:
 
     # we do not support an absolute path of the gitconfig on windows ,
     # use the global config instead

--- a/git/config.py
+++ b/git/config.py
@@ -31,7 +31,7 @@ import configparser as cp
 
 # typing-------------------------------------------------------
 
-from typing import Any, Callable, Mapping, TYPE_CHECKING, Tuple
+from typing import Any, Callable, List, Mapping, TYPE_CHECKING, Tuple, Union, overload
 
 from git.types import Literal, Lit_config_levels, TBD
 
@@ -164,26 +164,25 @@ class SectionConstraint(object):
 class _OMD(OrderedDict):
     """Ordered multi-dict."""
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         super(_OMD, self).__setitem__(key, [value])
 
-    def add(self, key, value):
+    def add(self, key: str, value: Any) -> None:
         if key not in self:
             super(_OMD, self).__setitem__(key, [value])
-            return
-
+            return None
         super(_OMD, self).__getitem__(key).append(value)
 
-    def setall(self, key, values):
+    def setall(self, key: str, values: Any) -> None:
         super(_OMD, self).__setitem__(key, values)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         return super(_OMD, self).__getitem__(key)[-1]
 
-    def getlast(self, key):
+    def getlast(self, key: str) -> Any:
         return super(_OMD, self).__getitem__(key)[-1]
 
-    def setlast(self, key, value):
+    def setlast(self, key: str, value: Any) -> None:
         if key not in self:
             super(_OMD, self).__setitem__(key, [value])
             return
@@ -191,17 +190,25 @@ class _OMD(OrderedDict):
         prior = super(_OMD, self).__getitem__(key)
         prior[-1] = value
 
-    def get(self, key, default=None):
+    @overload
+    def get(self, key: str, default: None = ...) -> None:
+        ...
+
+    @overload
+    def get(self, key: str, default: Any = ...) -> Any:
+        ...
+
+    def get(self, key: str, default: Union[Any, None] = None) -> Union[Any, None]:
         return super(_OMD, self).get(key, [default])[-1]
 
-    def getall(self, key):
+    def getall(self, key: str) -> Any:
         return super(_OMD, self).__getitem__(key)
 
-    def items(self):
+    def items(self) -> List[Tuple[str, Any]]:
         """List of (key, last value for key)."""
         return [(k, self[k]) for k in self]
 
-    def items_all(self):
+    def items_all(self) -> List[Tuple[str, List[Any]]]:
         """List of (key, list of values for key)."""
         return [(k, self.getall(k)) for k in self]
 

--- a/git/config.py
+++ b/git/config.py
@@ -124,40 +124,40 @@ class SectionConstraint(object):
     _valid_attrs_ = ("get_value", "set_value", "get", "set", "getint", "getfloat", "getboolean", "has_option",
                      "remove_section", "remove_option", "options")
 
-    def __init__(self, config, section):
+    def __init__(self, config: cp.ConfigParser, section: str) -> None:
         self._config = config
         self._section_name = section
 
-    def __del__(self):
+    def __del__(self) -> None:
         # Yes, for some reason, we have to call it explicitly for it to work in PY3 !
         # Apparently __del__ doesn't get call anymore if refcount becomes 0
         # Ridiculous ... .
         self._config.release()
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         if attr in self._valid_attrs_:
             return lambda *args, **kwargs: self._call_config(attr, *args, **kwargs)
         return super(SectionConstraint, self).__getattribute__(attr)
 
-    def _call_config(self, method, *args, **kwargs):
+    def _call_config(self, method: str, *args: Any, **kwargs: Any) -> Any:
         """Call the configuration at the given method which must take a section name
         as first argument"""
         return getattr(self._config, method)(self._section_name, *args, **kwargs)
 
     @property
-    def config(self):
+    def config(self) -> cp.ConfigParser:
         """return: Configparser instance we constrain"""
         return self._config
 
-    def release(self):
+    def release(self) -> None:
         """Equivalent to GitConfigParser.release(), which is called on our underlying parser instance"""
         return self._config.release()
 
-    def __enter__(self):
+    def __enter__(self) -> 'SectionConstraint':
         self._config.__enter__()
         return self
 
-    def __exit__(self, exception_type, exception_value, traceback):
+    def __exit__(self, exception_type: str, exception_value: str, traceback: str) -> None:
         self._config.__exit__(exception_type, exception_value, traceback)
 
 
@@ -336,10 +336,10 @@ class GitConfigParser(with_metaclass(MetaParserBuilder, cp.RawConfigParser, obje
         self._acquire_lock()
         return self
 
-    def __exit__(self, exception_type, exception_value, traceback):
+    def __exit__(self, exception_type, exception_value, traceback) -> None:
         self.release()
 
-    def release(self):
+    def release(self) -> None:
         """Flush changes and release the configuration write lock. This instance must not be used anymore afterwards.
         In Python 3, it's required to explicitly release locks and flush changes, as __del__ is not called
         deterministically anymore."""

--- a/git/diff.py
+++ b/git/diff.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from .objects.tree import Tree
     from git.repo.base import Repo
 
+    from subprocess import Popen
+
 Lit_change_type = Literal['A', 'D', 'M', 'R', 'T']
 
 # ------------------------------------------------------------------------
@@ -490,7 +492,7 @@ class Diff(object):
         return index
 
     @staticmethod
-    def _handle_diff_line(lines_bytes: bytes, repo: 'Repo', index: TBD) -> None:
+    def _handle_diff_line(lines_bytes: bytes, repo: 'Repo', index: DiffIndex) -> None:
         lines = lines_bytes.decode(defenc)
 
         for line in lines.split(':')[1:]:
@@ -542,14 +544,14 @@ class Diff(object):
             index.append(diff)
 
     @classmethod
-    def _index_from_raw_format(cls, repo: 'Repo', proc: TBD) -> DiffIndex:
+    def _index_from_raw_format(cls, repo: 'Repo', proc: 'Popen') -> 'DiffIndex':
         """Create a new DiffIndex from the given stream which must be in raw format.
         :return: git.DiffIndex"""
         # handles
         # :100644 100644 687099101... 37c5e30c8... M    .gitignore
 
         index = DiffIndex()
-        handle_process_output(proc, lambda bytes: cls._handle_diff_line(
-            bytes, repo, index), None, finalize_process, decode_streams=False)
+        handle_process_output(proc, lambda byt: cls._handle_diff_line(byt, repo, index),
+                              None, finalize_process, decode_streams=False)
 
         return index

--- a/git/exc.py
+++ b/git/exc.py
@@ -91,7 +91,7 @@ class GitCommandError(CommandError):
     """ Thrown if execution of the git command fails with non-zero status code. """
 
     def __init__(self, command: Union[List[str], Tuple[str, ...], str],
-                 status: Union[str, None, Exception] = None,
+                 status: Union[str, int, None, Exception] = None,
                  stderr: Optional[IO[str]] = None,
                  stdout: Optional[IO[str]] = None,
                  ) -> None:

--- a/git/exc.py
+++ b/git/exc.py
@@ -11,7 +11,7 @@ from git.compat import safe_decode
 
 # typing ----------------------------------------------------
 
-from typing import IO, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 from git.types import PathLike
 
 if TYPE_CHECKING:
@@ -49,8 +49,9 @@ class CommandError(GitError):
     _msg = "Cmd('%s') failed%s"
 
     def __init__(self, command: Union[List[str], Tuple[str, ...], str],
-                 status: Union[str, None, Exception] = None,
-                 stderr: Optional[IO[str]] = None, stdout: Optional[IO[str]] = None) -> None:
+                 status: Union[str, int, None, Exception] = None,
+                 stderr: Union[bytes, str, None] = None,
+                 stdout: Union[bytes, str, None] = None) -> None:
         if not isinstance(command, (tuple, list)):
             command = command.split()
         self.command = command
@@ -92,8 +93,8 @@ class GitCommandError(CommandError):
 
     def __init__(self, command: Union[List[str], Tuple[str, ...], str],
                  status: Union[str, int, None, Exception] = None,
-                 stderr: Optional[IO[str]] = None,
-                 stdout: Optional[IO[str]] = None,
+                 stderr: Union[bytes, str, None] = None,
+                 stdout: Union[bytes, str, None] = None,
                  ) -> None:
         super(GitCommandError, self).__init__(command, status, stderr, stdout)
 
@@ -139,7 +140,7 @@ class HookExecutionError(CommandError):
     via standard output"""
 
     def __init__(self, command: Union[List[str], Tuple[str, ...], str], status: Optional[str],
-                 stderr: Optional[IO[str]] = None, stdout: Optional[IO[str]] = None) -> None:
+                 stderr: Optional[str] = None, stdout: Optional[str] = None) -> None:
         super(HookExecutionError, self).__init__(command, status, stderr, stdout)
         self._msg = "Hook('%s') failed%s"
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -34,7 +34,7 @@ import gitdb
 
 # typing ------------------------------------------------------
 
-from git.types import TBD, PathLike, Literal
+from git.types import TBD, PathLike, Lit_config_levels
 from typing import (Any, BinaryIO, Callable, Dict,
                     Iterator, List, Mapping, Optional,
                     TextIO, Tuple, Type, Union,
@@ -45,7 +45,6 @@ if TYPE_CHECKING:  # only needed for types
     from git.refs.symbolic import SymbolicReference
     from git.objects import TagObject, Blob, Tree  # NOQA: F401
 
-Lit_config_levels = Literal['system', 'global', 'user', 'repository']
 
 # -----------------------------------------------------------
 

--- a/git/types.py
+++ b/git/types.py
@@ -12,8 +12,6 @@ else:
     from typing_extensions import Final, Literal  # noqa: F401
 
 
-TBD = Any
-
 if sys.version_info[:2] < (3, 6):
     # os.PathLike (PEP-519) only got introduced with Python 3.6
     PathLike = str
@@ -23,3 +21,7 @@ elif sys.version_info[:2] < (3, 9):
 elif sys.version_info[:2] >= (3, 9):
     # os.PathLike only becomes subscriptable from Python 3.9 onwards
     PathLike = Union[str, os.PathLike[str]]
+
+TBD = Any
+
+Lit_config_levels = Literal['system', 'global', 'user', 'repository']

--- a/git/types.py
+++ b/git/types.py
@@ -20,7 +20,7 @@ elif sys.version_info[:2] < (3, 9):
     PathLike = Union[str, os.PathLike]
 elif sys.version_info[:2] >= (3, 9):
     # os.PathLike only becomes subscriptable from Python 3.9 onwards
-    PathLike = Union[str, os.PathLike[str]]
+    PathLike = Union[str, 'os.PathLike[str]']  # forward ref as pylance complains unless editing with py3.9+
 
 TBD = Any
 

--- a/git/util.py
+++ b/git/util.py
@@ -281,16 +281,6 @@ _cygpath_parsers = (
 )  # type: Tuple[Tuple[Pattern[str], Callable, bool], ...]
 
 
-@overload
-def cygpath(path: str) -> str:
-    ...
-
-
-@overload
-def cygpath(path: PathLike) -> PathLike:
-    ...
-
-
 def cygpath(path: PathLike) -> PathLike:
     """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
     path = str(path)  # ensure is str and not AnyPath.

--- a/git/util.py
+++ b/git/util.py
@@ -374,18 +374,31 @@ def get_user_id() -> str:
     return "%s@%s" % (getpass.getuser(), platform.node())
 
 
-def finalize_process(proc: TBD, **kwargs: Any) -> None:
+def finalize_process(proc: subprocess.Popen, **kwargs: Any) -> None:
     """Wait for the process (clone, fetch, pull or push) and handle its errors accordingly"""
     ## TODO: No close proc-streams??
     proc.wait(**kwargs)
 
 
-def expand_path(p: PathLike, expand_vars: bool = True) -> Optional[PathLike]:
+@overload
+def expand_path(p: None, expand_vars: bool = ...) -> None:
+    ...
+
+
+@overload
+def expand_path(p: PathLike, expand_vars: bool = ...) -> str:
+    ...
+
+
+def expand_path(p: Union[None, PathLike], expand_vars: bool = True) -> Optional[str]:
     try:
-        p = osp.expanduser(p)
-        if expand_vars:
-            p = osp.expandvars(p)
-        return osp.normpath(osp.abspath(p))
+        if p is not None:
+            p_out = osp.expanduser(p)
+            if expand_vars:
+                p_out = osp.expandvars(p_out)
+            return osp.normpath(osp.abspath(p_out))
+        else:
+            return None
     except Exception:
         return None
 

--- a/git/util.py
+++ b/git/util.py
@@ -22,11 +22,13 @@ from urllib.parse import urlsplit, urlunsplit
 # typing ---------------------------------------------------------
 
 from typing import (Any, AnyStr, BinaryIO, Callable, Dict, Generator, IO, Iterator, List,
-                    Optional, Pattern, Sequence, Tuple, Union, cast, TYPE_CHECKING)
+                    Optional, Pattern, Sequence, Tuple, Union, cast, TYPE_CHECKING, overload)
+
+
 if TYPE_CHECKING:
     from git.remote import Remote
     from git.repo.base import Repo
-from .types import PathLike, TBD
+from .types import PathLike, TBD, Literal
 
 # ---------------------------------------------------------------------
 
@@ -279,9 +281,20 @@ _cygpath_parsers = (
 )  # type: Tuple[Tuple[Pattern[str], Callable, bool], ...]
 
 
+@overload
+def cygpath(path: str) -> str:
+    ...
+
+
+@overload
+def cygpath(path: PathLike) -> PathLike:
+    ...
+
+
 def cygpath(path: PathLike) -> PathLike:
     """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
-    path = str(path)  # ensure is str and not AnyPath
+    path = str(path)  # ensure is str and not AnyPath.
+    #Fix to use Paths when 3.5 dropped. or to be just str if only for urls?
     if not path.startswith(('/cygdrive', '//')):
         for regex, parser, recurse in _cygpath_parsers:
             match = regex.match(path)
@@ -314,9 +327,22 @@ def decygpath(path: PathLike) -> str:
 _is_cygwin_cache = {}  # type: Dict[str, Optional[bool]]
 
 
+@overload
+def is_cygwin_git(git_executable: None) -> Literal[False]:
+    ...
+
+
+@overload
 def is_cygwin_git(git_executable: PathLike) -> bool:
+    ...
+
+
+def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
     if not is_win:
         return False
+
+    if git_executable is None:
+        return False  # or raise error?
 
     #from subprocess import check_output
     git_executable = str(git_executable)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 [mypy]
 
 # TODO: enable when we've fully annotated everything
-# disallow_untyped_defs = True
+disallow_untyped_defs = True
 
 # TODO: remove when 'gitdb' is fully annotated
 [mypy-gitdb.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 [mypy]
 
 # TODO: enable when we've fully annotated everything
-disallow_untyped_defs = True
+# disallow_untyped_defs = True
 
 # TODO: remove when 'gitdb' is fully annotated
 [mypy-gitdb.*]


### PR DESCRIPTION
Adding types to config.py and cmd.py
Functions annotated all listed in commit titles.

I had to use a few casts in this one, due to the use of hassattr to distinguish strings from file objects. 
If anyone knows a better way, let me know. (Its an open issue on mypy, and Guido recomends rewriting and doing type checks - a job for the future!) https://github.com/python/mypy/issues/1424#issuecomment-223795437

Some minor logic changes, all for type checks (e.g. because str is a subtype of Sequence, have to check for it before other sequences) or to try to separate strings from bytes.

All check pass and mypy happy. I also ran some basic scripts against it, and no errors.

Might be worth cutting a release after this PR, in case an errors are hiding?
(No rush, I only submitted this one so fast as it was waiting in my fork already)
