### PR TITLE
revert util.expand_path() due to regression

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -382,13 +382,10 @@ def expand_path(p: PathLike, expand_vars: bool = ...) -> str:
 
 def expand_path(p: Union[None, PathLike], expand_vars: bool = True) -> Optional[str]:
     try:
-        if p is not None:
-            p_out = osp.expanduser(p)
-            if expand_vars:
-                p_out = osp.expandvars(p_out)
-            return osp.normpath(osp.abspath(p_out))
-        else:
-            return None
+        p = osp.expanduser(p)  # type: ignore
+        if expand_vars:
+            p = osp.expandvars(p)    # type: ignore
+        return osp.normpath(osp.abspath(p))    # type: ignore
     except Exception:
         return None
 


### PR DESCRIPTION
Hopefully to fix #1238. 

The orginal change (commit 39eb0e6) was attempting to get mypy consistant with expand_path(None), as it doesn't like try except blocks without some type narrowing and expanduser doesn't accept None (triggering the Exception). Added mypy ignores for now, to allow CI to pass.

It passes tests either way, so can't be sure, but the traceback points to an overload of cmd.Git.excecute(), wherein cwd = self._working_dir.  
That leads to Git.__init__(), where self._working_dir = expand_user(working_dir)

