### PR TITLE
Fix typing of Head.create_head

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -422,7 +422,7 @@ class Repo(object):
 
     def create_head(self, path: PathLike, commit: str = 'HEAD',
                     force: bool = False, logmsg: Optional[str] = None
-                    ) -> 'SymbolicReference':
+                    ) -> Head:
         """Create a new head within the repository.
         For more documentation, please see the Head.create method.
 


### PR DESCRIPTION
After creating a `Head` via `Head.create_head()`, mypy complains if I try to do head-like things with it:

```
error: "SymbolicReference" has no attribute "checkout"  
error: "SymbolicReference" has no attribute "set_tracking_branch"
```