### PR TITLE
Add flake8-typing-imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -31,3 +31,5 @@ exclude = .tox,.venv,build,dist,doc,git/ext/,test
 
 rst-roles =  # for flake8-RST-docstrings
     attr,class,func,meth,mod,obj,ref,term,var  # used by sphinx
+
+min-python-version = 3.7.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ mypy
 flake8
 flake8-bugbear
 flake8-comprehensions
+flake8-typing-imports
 
 virtualenv
 


### PR DESCRIPTION
The idea to include this plugin comes from #1095 . In short, flake8-typing-imports checks if a import from `typing` is possible in a certain python version.

I ran the plugin in your code base, and it's **NOT** compatible with <= 3.6.2. You use NamingTuple with defaults and NoReturn which were added in later patches of 3.6. To let in still run I set the minimum version to 3.7.0.

This means, that either we should fix the issues or gitpython needs to drop the support for this version which is anyway deprecated.
This plugin will hopefully prevent that any new issues are added