### PR TITLE
Do not call get_user_id if it is not needed

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -708,12 +708,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return self._read_only
 
     @overload
-    def get_value(self, section: str, option: str, default: str
+    def get_value(self, section: str, option: str, default: Optional[str]
                   ) -> str:
         ...
 
     @overload
-    def get_value(self, section: str, option: str, default: float
+    def get_value(self, section: str, option: str, default: Optional[float]
                   ) -> float:
         ...
 

--- a/git/config.py
+++ b/git/config.py
@@ -708,12 +708,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return self._read_only
 
     @overload
-    def get_value(self, section: str, option: str, default: Optional[str]
+    def get_value(self, section: str, option: str, default: Optional[str] = None
                   ) -> str:
         ...
 
     @overload
-    def get_value(self, section: str, option: str, default: Optional[float]
+    def get_value(self, section: str, option: str, default: Optional[float] = None
                   ) -> float:
         ...
 

--- a/git/util.py
+++ b/git/util.py
@@ -706,7 +706,7 @@ class Actor(object):
             except KeyError:
                 if config_reader is not None:
                     try:
-                        val = config_reader.get_value('user', cvar)
+                        val = config_reader.get('user', cvar)
                     except Exception:
                         val = default()
                     setattr(actor, attr, val)

--- a/git/util.py
+++ b/git/util.py
@@ -704,7 +704,11 @@ class Actor(object):
                 setattr(actor, attr, val)
             except KeyError:
                 if config_reader is not None:
-                    setattr(actor, attr, config_reader.get_value('user', cvar, default()))
+                    try:
+                        val = config_reader.get_value('user', cvar)
+                    except Exception:
+                        val = default()
+                    setattr(actor, attr, val)
                 # END config-reader handling
                 if not getattr(actor, attr):
                     setattr(actor, attr, default())

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -22,7 +22,10 @@ from git.objects.util import (
     parse_date,
     tzoffset,
     from_timestamp)
-from test.lib import TestBase
+from test.lib import (
+    TestBase,
+    with_rw_repo,
+)
 from git.util import (
     LockFile,
     BlockingLockFile,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -238,16 +238,16 @@ class TestUtils(TestBase):
     @mock.patch("getpass.getuser")
     def test_actor_get_uid_laziness_called(self, mock_get_uid):
         mock_get_uid.return_value = "user"
-        for cr in (None, self.rorepo.config_reader()):
-            committer = Actor.committer(cr)
-            author = Actor.author(cr)
-            if cr is None:  # otherwise, use value from config_reader
-                self.assertEqual(committer.name, 'user')
-                self.assertTrue(committer.email.startswith('user@'))
-                self.assertEqual(author.name, 'user')
-                self.assertTrue(committer.email.startswith('user@'))
+        committer = Actor.committer(None)
+        author = Actor.author(None)
+        # We can't test with `self.rorepo.config_reader()` here, as the uuid laziness
+        # depends on whether the user running the test has their user.name config set.
+        self.assertEqual(committer.name, 'user')
+        self.assertTrue(committer.email.startswith('user@'))
+        self.assertEqual(author.name, 'user')
+        self.assertTrue(committer.email.startswith('user@'))
         self.assertTrue(mock_get_uid.called)
-        self.assertEqual(mock_get_uid.call_count, 4)
+        self.assertEqual(mock_get_uid.call_count, 2)
 
     def test_actor_from_string(self):
         self.assertEqual(Actor._from_string("name"), Actor("name", None))


### PR DESCRIPTION
On systems without any environment variables (such as sandboxed CI runs) and no `pwd` module (such as windows), GitPython crashes.

This is just a logic error - there is no reason to fallback to `pwd` until the config lookup has actually failed. The implementation of `ConfigWriter.get_value` is to catch `Exception`, so this patch doesn't attempt to work out a more specific exception than what was used before.

This fixes #356