### PR TITLE
Fix trailing whitespace and incorrect overload

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -710,12 +710,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return self._read_only
 
     @overload
-    def get_value(self, section: str, option: str, default: None = None) -> str: ...
+    def get_value(self, section: str, option: str, default: None = None) -> Union[int, float, str, bool]: ...
 
     @overload
     def get_value(self, section: str, option: str, default: str) -> str: ...
 
-    @overload 
+    @overload
     def get_value(self, section: str, option: str, default: float) -> float: ...
 
     def get_value(self, section: str, option: str, default: Union[int, float, str, bool, None] = None


### PR DESCRIPTION
CI fails on master due to extra whitespace. The annotation is also incorrect, as if "1" is read from the config it will be converted to an integer, not a string.