### PR TITLE
Use the Git class type definition within Repo classmethods

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1042,7 +1042,7 @@ class Repo(object):
             os.makedirs(path, 0o755)
 
         # git command automatically chdir into the directory
-        git = Git(path)
+        git = cls.GitCommandWrapperType(path)
         git.init(**kwargs)
         return cls(path, odbt=odbt)
 
@@ -1142,7 +1142,7 @@ class Repo(object):
         :param multi_options: See ``clone`` method
         :param kwargs: see the ``clone`` method
         :return: Repo instance pointing to the cloned directory"""
-        git = Git(os.getcwd())
+        git = cls.GitCommandWrapperType(os.getcwd())
         if env is not None:
             git.update_environment(**env)
         return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)


### PR DESCRIPTION
Allow the GitCommandWrapperType definition to be used within the Repo
classmethods. This change follows the intended purpose as stated in
the code, "Subclasses may easily bring in their own custom types by
placing a constructor or type here."

The usecase that prompted this change has to do with
`GIT_SSH_COMMAND`. The goal is to setup a custom `Git` class with
knowledge of the value, something like as follows

```python
from git import Git as BaseGit, Repo as BaseRepo

class Git(BaseGit):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        # For example, assign the SSH command using the current flask
        # app's configured setting.
        self.update_environment(GIT_SSH_COMMAND=current_app.config['GIT_SSH_COMMAND'])

class Repo(BaseRepo):
    GitCommandWrapperType = _Git
```

With this change, the above example will allow the developer to use
`Repo.clone_from(...)` with the intended outcome. Otherwise the
developer will have two differing result when using `Repo(...)` vs
`Repo.clone_from(...)`.
