### PR TITLE
Surface fetch/pull/push kill_after_timeout and reset default to None

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -79,7 +79,7 @@ def handle_process_output(process: 'Git.AutoInterrupt' | Popen,
                           finalizer: Union[None,
                                            Callable[[Union[subprocess.Popen, 'Git.AutoInterrupt']], None]] = None,
                           decode_streams: bool = True,
-                          timeout: float = 60.0) -> None:
+                          timeout: Union[None, float] = None) -> None:
     """Registers for notifications to learn that process output is ready to read, and dispatches lines to
     the respective line handlers.
     This function returns once the finalizer returns

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -79,7 +79,7 @@ def handle_process_output(process: 'Git.AutoInterrupt' | Popen,
                           finalizer: Union[None,
                                            Callable[[Union[subprocess.Popen, 'Git.AutoInterrupt']], None]] = None,
                           decode_streams: bool = True,
-                          timeout: float = 10.0) -> None:
+                          timeout: float = 60.0) -> None:
     """Registers for notifications to learn that process output is ready to read, and dispatches lines to
     the respective line handlers.
     This function returns once the finalizer returns

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -94,7 +94,7 @@ def handle_process_output(process: 'Git.AutoInterrupt' | Popen,
         their contents to handlers.
         Set it to False if `universal_newline == True` (then streams are in text-mode)
         or if decoding must happen later (i.e. for Diffs).
-    :param timeout: float, timeout to pass to t.join() in case it hangs. Default = 10.0 seconds
+    :param timeout: float, or None timeout to pass to t.join() in case it hangs. Default = None.
     """
     # Use 2 "pump" threads and wait for both to finish.
     def pump_stream(cmdline: List[str], name: str, stream: Union[BinaryIO, TextIO], is_decode: bool,

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -168,7 +168,7 @@ def handle_process_output(process: 'Git.AutoInterrupt' | Popen,
                     error_str = cast(str, error_str)
                     error_str = error_str.encode()
                 # We ignore typing on the next line because mypy does not like
-                # the way we infered that stderr takes str of bytes
+                # the way we inferred that stderr takes str or bytes
                 stderr_handler(error_str)  # type: ignore
 
     if finalizer:

--- a/git/remote.py
+++ b/git/remote.py
@@ -795,6 +795,8 @@ class Remote(LazyMixin, IterableObj):
         try:
             proc.wait(stderr=stderr_text)
         except Exception:
+            # This is different than fetch (which fails if there is any std_err
+            # even if there is an output)
             if not output:
                 raise
             elif stderr_text:

--- a/git/remote.py
+++ b/git/remote.py
@@ -708,7 +708,7 @@ class Remote(LazyMixin, IterableObj):
 
     def _get_fetch_info_from_stderr(self, proc: 'Git.AutoInterrupt',
                                     progress: Union[Callable[..., Any], RemoteProgress, None],
-                                    timeout: float = 60.0
+                                    timeout: Union[None, float] = None,
                                     ) -> IterableList['FetchInfo']:
 
         progress = to_progress_instance(progress)
@@ -772,7 +772,7 @@ class Remote(LazyMixin, IterableObj):
 
     def _get_push_info(self, proc: 'Git.AutoInterrupt',
                        progress: Union[Callable[..., Any], RemoteProgress, None],
-                       timeout: float = 60.0) -> IterableList[PushInfo]:
+                       timeout: Union[None, float] = None) -> IterableList[PushInfo]:
         progress = to_progress_instance(progress)
 
         # read progress information from stderr
@@ -817,7 +817,7 @@ class Remote(LazyMixin, IterableObj):
 
     def fetch(self, refspec: Union[str, List[str], None] = None,
               progress: Union[RemoteProgress, None, 'UpdateProgress'] = None,
-              verbose: bool = True, timeout: float = 60.0,
+              verbose: bool = True, timeout: Union[None, float] = None,
               **kwargs: Any) -> IterableList[FetchInfo]:
         """Fetch the latest changes for this remote
 
@@ -865,7 +865,7 @@ class Remote(LazyMixin, IterableObj):
 
     def pull(self, refspec: Union[str, List[str], None] = None,
              progress: Union[RemoteProgress, 'UpdateProgress', None] = None,
-             timeout: float = 60.0,
+             timeout: Union[None, float] = None,
              **kwargs: Any) -> IterableList[FetchInfo]:
         """Pull changes from the given branch, being the same as a fetch followed
         by a merge of branch with your local branch.
@@ -887,7 +887,7 @@ class Remote(LazyMixin, IterableObj):
 
     def push(self, refspec: Union[str, List[str], None] = None,
              progress: Union[RemoteProgress, 'UpdateProgress', Callable[..., RemoteProgress], None] = None,
-             timeout: float = 60.0, **kwargs: Any) -> IterableList[PushInfo]:
+             timeout: Union[None, float] = None, **kwargs: Any) -> IterableList[PushInfo]:
         """Push changes from source branch in refspec to target branch in refspec.
 
         :param refspec: see 'fetch' method

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -658,7 +658,7 @@ class TestRemote(TestBase):
 class TestTimeouts(TestBase):
     @with_rw_repo('HEAD', bare=False)
     def test_timeout_funcs(self, repo):
-        for function in ["pull"]: #"can't get fetch and push to reliably timeout
+        for function in ["pull"]:  # can't get fetch and push to reliably timeout
             f = getattr(repo.remotes.origin, function)
             assert f is not None  # Make sure these functions exist
             _ = f() # Make sure the function runs

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -406,7 +406,7 @@ class TestRemote(TestBase):
         # cleanup - delete created tags and branches as we are in an innerloop on
         # the same repository
         TagReference.delete(rw_repo, new_tag, other_tag)
-        remote.push(":%s" % other_tag.path)
+        remote.push(":%s" % other_tag.path, timeout=10.0)
 
     @skipIf(HIDE_WINDOWS_FREEZE_ERRORS, "FIXME: Freezes!")
     @with_rw_and_rw_remote_repo('0.1.6')

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -401,7 +401,7 @@ class TestRemote(TestBase):
         res = remote.push(all=True)
         self._do_test_push_result(res, remote)
 
-        remote.pull('master')
+        remote.pull('master', timeout=10.0)
 
         # cleanup - delete created tags and branches as we are in an innerloop on
         # the same repository
@@ -467,7 +467,7 @@ class TestRemote(TestBase):
             # Only for remotes - local cases are the same or less complicated
             # as additional progress information will never be emitted
             if remote.name == "daemon_origin":
-                self._do_test_fetch(remote, rw_repo, remote_repo)
+                self._do_test_fetch(remote, rw_repo, remote_repo, timeout=10.0)
                 ran_fetch_test = True
             # END fetch test
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -663,5 +663,5 @@ class TestTimeouts(TestBase):
             assert f is not None  # Make sure these functions exist
             _ = f() # Make sure the function runs
             with pytest.raises(GitCommandError,
-                               match="kill_after_timeout=0 s"):
-                f(kill_after_timeout=0)
+                               match="kill_after_timeout=0.001 s"):
+                f(kill_after_timeout=0.001)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -661,7 +661,7 @@ class TestTimeouts(TestBase):
         for function in ["pull", "fetch"]: #"can't get push to reliably timeout
             f = getattr(repo.remotes.origin, function)
             assert f is not None  # Make sure these functions exist
-
-            with self.assertRaisesRegex(GitCommandError,
-                                        "kill_after_timeout=0.01 s"):
+            _ = f() # Make sure the function runs
+            with pytest.raises(GitCommandError,
+                               match="kill_after_timeout=0.01 s"):
                 f(kill_after_timeout=0.01)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -663,5 +663,5 @@ class TestTimeouts(TestBase):
             assert f is not None  # Make sure these functions exist
             _ = f() # Make sure the function runs
             with pytest.raises(GitCommandError,
-                               match="kill_after_timeout=0.01 s"):
-                f(kill_after_timeout=0.01)
+                               match="kill_after_timeout=0 s"):
+                f(kill_after_timeout=0)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -658,7 +658,7 @@ class TestRemote(TestBase):
 class TestTimeouts(TestBase):
     @with_rw_repo('HEAD', bare=False)
     def test_timeout_funcs(self, repo):
-        for function in ["pull", "fetch"]: #"can't get push to reliably timeout
+        for function in ["pull"]: #"can't get fetch and push to reliably timeout
             f = getattr(repo.remotes.origin, function)
             assert f is not None  # Make sure these functions exist
             _ = f() # Make sure the function runs

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -164,7 +164,7 @@ class TestRemote(TestBase):
         index.commit("Committing %s" % new_file)
         return new_file
 
-    def _do_test_fetch(self, remote, rw_repo, remote_repo):
+    def _do_test_fetch(self, remote, rw_repo, remote_repo, **kwargs):
         # specialized fetch testing to de-clutter the main test
         self._do_test_fetch_info(rw_repo)
 
@@ -183,7 +183,7 @@ class TestRemote(TestBase):
         # put remote head to master as it is guaranteed to exist
         remote_repo.head.reference = remote_repo.heads.master
 
-        res = fetch_and_test(remote)
+        res = fetch_and_test(remote, **kwargs)
         # all up to date
         for info in res:
             self.assertTrue(info.flags & info.HEAD_UPTODATE)


### PR DESCRIPTION
(hopefully) closes #1339 
This PR does as of  e058c4c  :

- renames `timeout` to `kill_after_timeout` and set default to `None` instead of `10 s`
- Surfaces `kill_after_timeout` to user facing functions (`remote. pull/push/fetch`)
- refactor `AutoInterrupt` so we can `._terminate()` the underlying process and grab status codes from terminated processes
- Add a class variable `AutoInterrupt._status_code_if_terminate`; if non-zero it overrides any status code from the process in `_terminate`. This can be used to prevent race conditions in tests, [as described in this comment](https://github.com/gitpython-developers/GitPython/pull/1340#issuecomment-919148742)


Some history of the commits (while trying a different strategy):

aafb300 changes the default timeout to 60 s
1d26515 allows `push`, `pull` and `fetch` keyword `timeout` that will be propagated down
febd4fe alters some tests to use the old 10 s timeout for `fetch` and `pull`
4113d01 also alters a test call to `pull` to add a timeout  of 10s
c55a8e3 fixes the test suite
7df33f3e sets the default timeout to `None`

if the current default is too lose, users can now give their own timeout