### PR TITLE
Fix typing issues with delete_head and Remote.add

### DIFF
--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -129,7 +129,7 @@ class Head(Reference):
     k_config_remote_ref = "merge"           # branch to merge from remote
 
     @classmethod
-    def delete(cls, repo: 'Repo', *heads: 'Head', force: bool = False, **kwargs: Any) -> None:
+    def delete(cls, repo: 'Repo', *heads: 'Union[Head, str]', force: bool = False, **kwargs: Any) -> None:
         """Delete the given heads
 
         :param force:

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -37,8 +37,13 @@ class RemoteReference(Head):
         # super is Reference
         return super(RemoteReference, cls).iter_items(repo, common_path)
 
+    # The Head implementation of delete also accepts strs, but this
+    # implementation does not.  mypy doesn't have a way of representing
+    # tightening the types of arguments in subclasses and recommends Any or
+    # "type: ignore".  (See https://github.com/python/typing/issues/241)
     @ classmethod
-    def delete(cls, repo: 'Repo', *refs: 'RemoteReference', **kwargs: Any) -> None:
+    def delete(cls, repo: 'Repo', *refs: 'RemoteReference',  # type: ignore
+               **kwargs: Any) -> None:
         """Delete the given remote references
 
         :note:

--- a/git/remote.py
+++ b/git/remote.py
@@ -665,7 +665,9 @@ class Remote(LazyMixin, IterableObj):
         return cls(repo, name)
 
     # add is an alias
-    add = create
+    @ classmethod
+    def add(cls, repo: 'Repo', name: str, url: str, **kwargs: Any) -> 'Remote':
+        return cls.create(repo, name, url, **kwargs)
 
     @ classmethod
     def remove(cls, repo: 'Repo', name: str) -> str:

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -429,7 +429,7 @@ class Repo(object):
         :return: newly created Head Reference"""
         return Head.create(self, path, commit, logmsg, force)
 
-    def delete_head(self, *heads: 'Head', **kwargs: Any) -> None:
+    def delete_head(self, *heads: 'Union[str, Head]', **kwargs: Any) -> None:
         """Delete the given heads
 
         :param kwargs: Additional keyword arguments to be passed to git-branch"""


### PR DESCRIPTION
delete_head and Head.delete historically accept either Head objects
or a str name of a head.  Adjust the typing to match.

Using assignment to make add an alias for create unfortunately
confuses mypy, since it loses track of the fact that it's a
classmethod and starts treating it like a staticmethod.  Replace
with a stub wrapper instead.