### PR TITLE
Revert "Replace wildcard imports with concrete imports"

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -5,7 +5,7 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 # flake8: noqa
 #@PydevCodeAnalysisIgnore
-from git.exc import GitError, GitCommandError, GitCommandNotFound, UnmergedEntriesError, CheckoutError, InvalidGitRepositoryError, NoSuchPathError, BadName                       # @NoMove @IgnorePep8
+from git.exc import *                       # @NoMove @IgnorePep8
 import inspect
 import os
 import sys
@@ -39,16 +39,16 @@ _init_externals()
 #{ Imports
 
 try:
-    from git.config import GitConfigParser                                                         # @NoMove @IgnorePep8
-    from git.objects import Blob, Commit, Object, Submodule, Tree                                  # @NoMove @IgnorePep8
-    from git.refs import Head, Reference, RefLog, RemoteReference, SymbolicReference, TagReference # @NoMove @IgnorePep8
-    from git.diff import Diff, DiffIndex, NULL_TREE                                                # @NoMove @IgnorePep8
-    from git.db import GitCmdObjectDB, GitDB                                                       # @NoMove @IgnorePep8
-    from git.cmd import Git                                                                        # @NoMove @IgnorePep8
-    from git.repo import Repo                                                                      # @NoMove @IgnorePep8
-    from git.remote import FetchInfo, PushInfo, Remote, RemoteProgress                             # @NoMove @IgnorePep8
-    from git.index import BlobFilter, IndexEntry, IndexFile                                        # @NoMove @IgnorePep8
-    from git.util import (                                                                         # @NoMove @IgnorePep8
+    from git.config import GitConfigParser  # @NoMove @IgnorePep8
+    from git.objects import *               # @NoMove @IgnorePep8
+    from git.refs import *                  # @NoMove @IgnorePep8
+    from git.diff import *                  # @NoMove @IgnorePep8
+    from git.db import *                    # @NoMove @IgnorePep8
+    from git.cmd import Git                 # @NoMove @IgnorePep8
+    from git.repo import Repo               # @NoMove @IgnorePep8
+    from git.remote import *                # @NoMove @IgnorePep8
+    from git.index import *                 # @NoMove @IgnorePep8
+    from git.util import (                  # @NoMove @IgnorePep8
         LockFile,
         BlockingLockFile,
         Stats,

--- a/git/exc.py
+++ b/git/exc.py
@@ -5,7 +5,8 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 """ Module containing all exceptions thrown throughout the git package, """
 
-from gitdb.exc import BadName, BadObject  # NOQA @UnusedWildImport skipcq: PYL-W0401, PYL-W0614
+from gitdb.exc import BadName  # NOQA @UnusedWildImport skipcq: PYL-W0401, PYL-W0614
+from gitdb.exc import *     # NOQA @UnusedWildImport skipcq: PYL-W0401, PYL-W0614
 from git.compat import safe_decode
 
 # typing ----------------------------------------------------

--- a/git/index/__init__.py
+++ b/git/index/__init__.py
@@ -1,4 +1,4 @@
 """Initialize the index package"""
 # flake8: noqa
-from .base import IndexFile
-from .typ import IndexEntry, BlobFilter
+from .base import *
+from .typ import *

--- a/git/objects/__init__.py
+++ b/git/objects/__init__.py
@@ -4,14 +4,14 @@ Import all submodules main classes into the package space
 # flake8: noqa
 import inspect
 
-from .base import Object, IndexObject
-from .blob import Blob
-from .commit import Commit
+from .base import *
+from .blob import *
+from .commit import *
 from .submodule import util as smutil
-from .submodule.base import Submodule, UpdateProgress
-from .submodule.root import RootModule, RootUpdateProgress
-from .tag import TagObject
-from .tree import Tree
+from .submodule.base import *
+from .submodule.root import *
+from .tag import *
+from .tree import *
 # Fix import dependency - add IndexObject to the util module, so that it can be
 # imported by the submodule.base
 smutil.IndexObject = IndexObject  # type: ignore[attr-defined]

--- a/git/refs/__init__.py
+++ b/git/refs/__init__.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 # import all modules in order, fix the names they require
-from .symbolic import SymbolicReference
-from .reference import Reference
-from .head import HEAD, Head
-from .tag import TagReference
-from .remote import RemoteReference
+from .symbolic import *
+from .reference import *
+from .head import *
+from .tag import *
+from .remote import *
 
-from .log import RefLogEntry, RefLog
+from .log import *

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -4,12 +4,9 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
+# flake8: noqa
 import inspect
-
-from .helper import (GIT_DAEMON_PORT, SkipTest, StringProcessAdapter, TestBase,
-                     TestCase, fixture, fixture_path,
-                     with_rw_and_rw_remote_repo, with_rw_directory,
-                     with_rw_repo)
+from .helper import *
 
 __all__ = [name for name, obj in locals().items()
            if not (name.startswith('_') or inspect.ismodule(obj))]


### PR DESCRIPTION
This reverts commit 53d94b8091b36847bb9e495c76bb5a3ec2a2fdb5.

The reason for the revert is that the commit in question introduced a
regression where certain modules, functions and classes that were
exposed before were no longer exposed.

See https://github.com/gitpython-developers/GitPython/pull/1352#issuecomment-932757204
for additional information.