### PR TITLE
Let remote.push return a PushInfoList

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -122,14 +122,14 @@ class PushInfoList(IterableList):
 
     def __init__(self) -> None:
         super().__init__('push_infos')
-        self.exception = None
+        self.error = None
 
-    def raise_on_error(self):
+    def raise_if_error(self):
         """
         Raise an exception if any ref failed to push.
         """
-        if self.exception:
-            raise self.exception
+        if self.error:
+            raise self.error
 
 
 class PushInfo(IterableObj, object):
@@ -819,7 +819,7 @@ class Remote(LazyMixin, IterableObj):
                 raise
             elif stderr_text:
                 log.warning("Error lines received while fetching: %s", stderr_text)
-                output.exception = e
+                output.error = e
 
         return output
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -117,14 +117,15 @@ def to_progress_instance(progress: Union[Callable[..., Any], RemoteProgress, Non
 
 
 class PushInfoList(IterableList):
-    def __new__(cls) -> 'IterableList[IterableObj]':
-        return super(IterableList, cls).__new__(cls, 'push_infos')
+    def __new__(cls) -> 'PushInfoList':
+        base = super().__new__(cls, 'push_infos')
+        return cast(PushInfoList, base)
 
     def __init__(self) -> None:
         super().__init__('push_infos')
         self.error = None
 
-    def raise_if_error(self):
+    def raise_if_error(self) -> None:
         """
         Raise an exception if any ref failed to push.
         """

--- a/git/remote.py
+++ b/git/remote.py
@@ -116,23 +116,6 @@ def to_progress_instance(progress: Union[Callable[..., Any], RemoteProgress, Non
     return progress
 
 
-class PushInfoList(IterableList):
-    def __new__(cls) -> 'PushInfoList':
-        base = super().__new__(cls, 'push_infos')
-        return cast(PushInfoList, base)
-
-    def __init__(self) -> None:
-        super().__init__('push_infos')
-        self.error: Optional[Exception] = None
-
-    def raise_if_error(self) -> None:
-        """
-        Raise an exception if any ref failed to push.
-        """
-        if self.error:
-            raise self.error
-
-
 class PushInfo(IterableObj, object):
     """
     Carries information about the result of a push operation of a single head::
@@ -250,6 +233,22 @@ class PushInfo(IterableObj, object):
     def iter_items(cls, repo: 'Repo', *args: Any, **kwargs: Any
                    ) -> NoReturn:  # -> Iterator['PushInfo']:
         raise NotImplementedError
+
+
+class PushInfoList(IterableList[PushInfo]):
+    def __new__(cls) -> 'PushInfoList':
+        return cast(PushInfoList, IterableList.__new__(cls, 'push_infos'))
+
+    def __init__(self) -> None:
+        super().__init__('push_infos')
+        self.error: Optional[Exception] = None
+
+    def raise_if_error(self) -> None:
+        """
+        Raise an exception if any ref failed to push.
+        """
+        if self.error:
+            raise self.error
 
 
 class FetchInfo(IterableObj, object):

--- a/git/remote.py
+++ b/git/remote.py
@@ -123,7 +123,7 @@ class PushInfoList(IterableList):
 
     def __init__(self) -> None:
         super().__init__('push_infos')
-        self.error = None
+        self.error: Optional[Exception] = None
 
     def raise_if_error(self) -> None:
         """

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -393,7 +393,8 @@ class Tutorials(TestBase):
         origin.rename('new_origin')
         # push and pull behaves similarly to `git push|pull`
         origin.pull()
-        origin.push()
+        origin.push()  # attempt push, ignore errors
+        origin.push().raise_if_error()  # push and raise error if it fails
         # assert not empty_repo.delete_remote(origin).exists()     # create and delete remotes
         # ![25-test_references_and_objects]
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -154,6 +154,12 @@ class TestRemote(TestBase):
             # END error checking
         # END for each info
 
+        if any([info.flags & info.ERROR for info in results]):
+            self.assertRaises(GitCommandError, results.raise_if_error)
+        else:
+            # No errors, so this should do nothing
+            results.raise_if_error()
+
     def _do_test_fetch_info(self, repo):
         self.assertRaises(ValueError, FetchInfo._from_line, repo, "nonsense", '')
         self.assertRaises(

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -30,7 +30,7 @@ from test.lib import (
     fixture,
     GIT_DAEMON_PORT
 )
-from git.util import rmtree, HIDE_WINDOWS_FREEZE_ERRORS
+from git.util import rmtree, HIDE_WINDOWS_FREEZE_ERRORS, IterableList
 import os.path as osp
 
 
@@ -128,6 +128,9 @@ class TestRemote(TestBase):
         # END for each info
 
     def _do_test_push_result(self, results, remote):
+        self.assertIsInstance(results, list)
+        self.assertIsInstance(results, IterableList)
+
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], PushInfo)
         for info in results:


### PR DESCRIPTION
List-like, so that it's backward compatible. But it has a new method
raise_on_error, that throws an exception if anything failed to push.

Related to #621

This is more of a proposal for this design. Is this actually backward-compatible? Should we check the flags of all PushInfos in `raise_on_error`? Is this better than a new method `push_really_or_else_raise()` or `push(raise=True)`? What if a `PushInfo` is missing from the result because it totally failed?