### PR TITLE
Warn when working tree is empty on non-bare repos

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -219,6 +219,9 @@ class Repo(object):
         # in the first place
         if self._bare:
             self._working_tree_dir = None
+
+        if not self._bare and self._working_tree_dir is None:
+            log.warning('No tree found. Is this a git repository?')
         # END working dir handling
 
         self.working_dir: Optional[PathLike] = self._working_tree_dir or self.common_dir


### PR DESCRIPTION
When loading an empty repo by accident and iterating through commits lead to suprprising results. It should be warned while loading the non-bare repo that this does not appear to be a repo.