### PR TITLE
Revert the use of typing_extensions in py3.8+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gitdb>=4.0.1,<5
-typing-extensions>=3.7.4.3;python_version<"3.10"
+typing-extensions>=3.7.4.3;python_version<"3.8"


### PR DESCRIPTION
The original change requiring py3.10 TypeGuard (and matching
typing_extensions) has been reverted, so revert the requirement
on typing_extensions as well.