### PR TITLE
Use NUL character to extract meta and path from git diff

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -509,9 +509,9 @@ class Diff(object):
     def _handle_diff_line(lines_bytes: bytes, repo: 'Repo', index: DiffIndex) -> None:
         lines = lines_bytes.decode(defenc)
 
-        for line in lines.split(':')[1:]:
-            meta, _, path = line.partition('\x00')
-            path = path.rstrip('\x00')
+        it = iter(lines.split('\x00'))
+        for meta, path in zip(it, it):
+            meta = meta[1:]
             a_blob_id: Optional[str]
             b_blob_id: Optional[str]
             old_mode, new_mode, a_blob_id, b_blob_id, _change_type = meta.split(None, 4)


### PR DESCRIPTION
Use NUL character instead of semicolon to extract meta and path. Avoid errors in during git diff when dealing with filenames containing semicolons
Re-submit (https://github.com/gitpython-developers/GitPython/pull/1387#issuecomment-1007079621)