### PR TITLE
Close .git/index file descriptor

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -138,6 +138,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             stream = file_contents_ro(fd, stream=True, allow_mmap=True)
 
             self._deserialize(stream)
+            os.close(fd)
         else:
             super(IndexFile, self)._set_cache_(attr)
 


### PR DESCRIPTION
The index fd is not closed, which makes it fail on Windows with PermissionError:
```
E PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_commit_in_root_repo_with_0\\.git\\index'
```

and sometimes with not much information when using APIs that interact with git binary:
```
fatal: Unable to write new index file
```

Also see https://github.com/iterative/scmrepo/issues/27 and https://github.com/conda-forge/gitpython-feedstock/issues/62.

This regression was introduced on #1391 (specifically on https://github.com/gitpython-developers/GitPython/commit/d79d20d28b1f9324193309cffd2ab79e0edae925, and released on 3.1.25). 