### PR TITLE
import unittest adds 0.250s to script launch time

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -3,8 +3,6 @@ from io import BytesIO
 import logging
 import os
 import stat
-
-from unittest import SkipTest
 import uuid
 
 import git
@@ -934,6 +932,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                         rmtree(str(wtd))
                     except Exception as ex:
                         if HIDE_WINDOWS_KNOWN_ERRORS:
+                            from unittest import SkipTest
                             raise SkipTest("FIXME: fails with: PermissionError\n  {}".format(ex)) from ex
                         raise
                 # END delete tree if possible
@@ -945,6 +944,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     rmtree(git_dir)
                 except Exception as ex:
                     if HIDE_WINDOWS_KNOWN_ERRORS:
+                        from unittest import SkipTest
                         raise SkipTest(f"FIXME: fails with: PermissionError\n  {ex}") from ex
                     else:
                         raise

--- a/git/util.py
+++ b/git/util.py
@@ -20,7 +20,6 @@ import shutil
 import stat
 from sys import maxsize
 import time
-from unittest import SkipTest
 from urllib.parse import urlsplit, urlunsplit
 import warnings
 
@@ -130,6 +129,7 @@ def rmtree(path: PathLike) -> None:
             func(path)  # Will scream if still not possible to delete.
         except Exception as ex:
             if HIDE_WINDOWS_KNOWN_ERRORS:
+                from unittest import SkipTest
                 raise SkipTest("FIXME: fails with: PermissionError\n  {}".format(ex)) from ex
             raise
 


### PR DESCRIPTION
This should not be imported at root level, since it adds a lot of initialization overhead without need.