### PR TITLE
Fixed setting ref with non-ascii in path

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -352,7 +352,7 @@ class SymbolicReference(object):
         fd = lfd.open(write=True, stream=True)
         ok = True
         try:
-            fd.write(write_value.encode('ascii') + b'\n')
+            fd.write(write_value.encode('utf-8') + b'\n')
             lfd.commit()
             ok = True
         finally:


### PR DESCRIPTION
Have faced the issue when trying to set a reference to a branch with non-ASCII symbols in the path. [Snippet](<https://github.com/openvinotoolkit/cvat/blob/dd60b2d8e0693772bc637b99a4f6684df887de30/cvat/apps/dataset_repo/dataset_repo.py#L131>).  I guess, this fix would resolve it.