### PR TITLE
Allow `Repo.create_head`'s `commit` arg to be a `SymbolicReference`

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -420,7 +420,8 @@ class Repo(object):
         else:
             return TagReference._common_path_default + '/' + path_str
 
-    def create_head(self, path: PathLike, commit: str = 'HEAD',
+    def create_head(self, path: PathLike,
+                    commit: Union['SymbolicReference', 'str'] = 'HEAD',
                     force: bool = False, logmsg: Optional[str] = None
                     ) -> 'Head':
         """Create a new head within the repository.


### PR DESCRIPTION
This propagates the type of `Head.create`'s `reference` argument. That `create` function is inherited from `SymbolicReference`.

Mypy doesn't pass on my machine, but as far as I can see it reports no new errors compared to the CI runs on the main branch.