### PR TITLE
feat(cmd): add the `strip_newline` flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,4 +45,5 @@ Contributors are:
 -Alba Mendez <me _at_ alba.sh>
 -Robert Westman <robert _at_ byteflux.io>
 -Hugo van Kemenade
+-Hiroki Tokunaga <tokusan441 _at_ gmail.com>
 Portions derived from other open source works and are clearly marked.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -812,7 +812,7 @@ class Git(LazyMixin):
             render the repository incapable of accepting changes until the lock is manually
             removed.
         :param strip_newline_in_stdout:
-            Whether to strip the trailing '\n' of the command stdout.
+            Whether to strip the trailing `\n` of the command stdout.
 
         :return:
             * str(output) if extended_output = False (Default)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -813,7 +813,6 @@ class Git(LazyMixin):
             removed.
         :param strip_newline_in_stdout:
             Whether to strip the trailing `\n` of the command stdout.
-
         :return:
             * str(output) if extended_output = False (Default)
             * tuple(int(status), str(stdout), str(stderr)) if extended_output = True

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 execute_kwargs = {'istream', 'with_extended_output',
                   'with_exceptions', 'as_process', 'stdout_as_string',
                   'output_stream', 'with_stdout', 'kill_after_timeout',
-                  'universal_newlines', 'shell', 'env', 'max_chunk_size', 'strip_newline'}
+                  'universal_newlines', 'shell', 'env', 'max_chunk_size', 'strip_newline_in_stdout'}
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -738,7 +738,7 @@ class Git(LazyMixin):
                 shell: Union[None, bool] = None,
                 env: Union[None, Mapping[str, str]] = None,
                 max_chunk_size: int = io.DEFAULT_BUFFER_SIZE,
-                strip_newline: bool = True,
+                strip_newline_in_stdout: bool = True,
                 **subprocess_kwargs: Any
                 ) -> Union[str, bytes, Tuple[int, Union[str, bytes], str], AutoInterrupt]:
         """Handles executing the command on the shell and consumes and returns
@@ -811,8 +811,8 @@ class Git(LazyMixin):
             effects on a repository. For example, stale locks in case of git gc could
             render the repository incapable of accepting changes until the lock is manually
             removed.
-        :param strip_newline:
-            Whether to strip the trailing '\n' of the command output.
+        :param strip_newline_in_stdout:
+            Whether to strip the trailing '\n' of the command stdout.
 
         :return:
             * str(output) if extended_output = False (Default)
@@ -947,7 +947,7 @@ class Git(LazyMixin):
                         if not universal_newlines:
                             stderr_value = stderr_value.encode(defenc)
                 # strip trailing "\n"
-                if stdout_value.endswith(newline) and strip_newline:  # type: ignore
+                if stdout_value.endswith(newline) and strip_newline_in_stdout:  # type: ignore
                     stdout_value = stdout_value[:-1]
                 if stderr_value.endswith(newline):  # type: ignore
                     stderr_value = stderr_value[:-1]

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 execute_kwargs = {'istream', 'with_extended_output',
                   'with_exceptions', 'as_process', 'stdout_as_string',
                   'output_stream', 'with_stdout', 'kill_after_timeout',
-                  'universal_newlines', 'shell', 'env', 'max_chunk_size'}
+                  'universal_newlines', 'shell', 'env', 'max_chunk_size', 'strip_newline'}
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -738,6 +738,7 @@ class Git(LazyMixin):
                 shell: Union[None, bool] = None,
                 env: Union[None, Mapping[str, str]] = None,
                 max_chunk_size: int = io.DEFAULT_BUFFER_SIZE,
+                strip_newline: bool = True,
                 **subprocess_kwargs: Any
                 ) -> Union[str, bytes, Tuple[int, Union[str, bytes], str], AutoInterrupt]:
         """Handles executing the command on the shell and consumes and returns
@@ -810,6 +811,8 @@ class Git(LazyMixin):
             effects on a repository. For example, stale locks in case of git gc could
             render the repository incapable of accepting changes until the lock is manually
             removed.
+        :param strip_newline:
+            Whether to strip the trailing '\n' of the command output.
 
         :return:
             * str(output) if extended_output = False (Default)
@@ -944,7 +947,7 @@ class Git(LazyMixin):
                         if not universal_newlines:
                             stderr_value = stderr_value.encode(defenc)
                 # strip trailing "\n"
-                if stdout_value.endswith(newline):  # type: ignore
+                if stdout_value.endswith(newline) and strip_newline:  # type: ignore
                     stdout_value = stdout_value[:-1]
                 if stderr_value.endswith(newline):  # type: ignore
                     stderr_value = stderr_value[:-1]

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1100,11 +1100,11 @@ class TestRepo(TestBase):
         self.assertEqual(r.currently_rebasing_on(), commitSpanish)
 
     @with_rw_directory
-    def test_do_not_strip_newline(self, rw_dir):
+    def test_do_not_strip_newline_in_stdout(self, rw_dir):
         r = Repo.init(rw_dir)
         fp = osp.join(rw_dir, 'hello.txt')
         with open(fp, 'w') as fs:
             fs.write("hello\n")
         r.git.add(Git.polish_url(fp))
         r.git.commit(message="init")
-        self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline=False), 'hello\n')
+        self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline_in_stdout=False), 'hello\n')

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1098,3 +1098,13 @@ class TestRepo(TestBase):
         except GitCommandError:
             pass
         self.assertEqual(r.currently_rebasing_on(), commitSpanish)
+
+    @with_rw_directory
+    def test_do_not_strip_newline(self, rw_dir):
+        r = Repo.init(rw_dir)
+        fp = osp.join(rw_dir, 'hello.txt')
+        with open(fp, 'w') as fs:
+            fs.write("hello\n")
+        r.git.add(Git.polish_url(fp))
+        r.git.commit(message="init")
+        self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline=False), 'hello\n')


### PR DESCRIPTION
This PR adds the `strip_newline` flag to the `Git.execute` method. When this flag is set to `True`, it will trim the trailing `\n`. The default value is `True` for backward compatibility. Setting it to `False` is helpful for, e.g., the `git show` output, especially with the binary file, as the missing `\n` may invalidate the file.

Looking at the first some bytes and checking if the output is binary or not is another option to prevent making an invalid binary file. Still, I chose to add a parameter because it is easy to implement, is fully backward compatible, and doesn't add many lines to the source code.

Fixes: #1377

By the way, do we need to handle stderr too?