### PR TITLE
Fix various typos

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -69,7 +69,7 @@ https://github.com/gitpython-developers/gitpython/milestone/53?closed=1
   
   - Make Protocol classes ABCs at runtime due to new behaviour/bug in 3.9.7 & 3.10.0-rc1
   
-  - Remove use of typing.TypeGuard until later release, to allow dependant libs time to update.
+  - Remove use of typing.TypeGuard until later release, to allow dependent libs time to update.
   
   - Tracking issue: https://github.com/gitpython-developers/GitPython/issues/1095
 
@@ -134,7 +134,7 @@ https://github.com/gitpython-developers/gitpython/milestone/48?closed=1
 3.1.15 (YANKED)
 ===============
 
-* add deprectation warning for python 3.5
+* add deprecation warning for python 3.5
 
 See the following for details:
 https://github.com/gitpython-developers/gitpython/milestone/47?closed=1
@@ -595,7 +595,7 @@ It follows the `semantic version scheme <http://semver.org>`_, and thus will not
   - Renamed `ignore_tree_extension_data` keyword argument in `IndexFile.write(...)` to `ignore_extension_data`
 * If the git command executed during `Remote.push(...)|fetch(...)` returns with an non-zero exit code and GitPython didn't
   obtain any head-information, the corresponding `GitCommandError` will be raised. This may break previous code which expected
-  these operations to never raise. However, that behavious is undesirable as it would effectively hide the fact that there
+  these operations to never raise. However, that behaviour is undesirable as it would effectively hide the fact that there
   was an error. See `this issue <https://github.com/gitpython-developers/GitPython/issues/271>`__ for more information.
 
 * If the git executable can't be found in the PATH or at the path provided by `GIT_PYTHON_GIT_EXECUTABLE`, this is made

--- a/git/config.py
+++ b/git/config.py
@@ -71,7 +71,7 @@ CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbr
 
 
 class MetaParserBuilder(abc.ABCMeta):
-    """Utlity class wrapping base-class methods into decorators that assure read-only properties"""
+    """Utility class wrapping base-class methods into decorators that assure read-only properties"""
     def __new__(cls, name: str, bases: Tuple, clsdict: Dict[str, Any]) -> 'MetaParserBuilder':
         """
         Equip all base-class methods with a needs_values decorator, and all non-const methods

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -579,7 +579,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     def _to_relative_path(self, path: PathLike) -> PathLike:
         """
         :return: Version of path relative to our git directory or raise ValueError
-            if it is not within our git direcotory"""
+            if it is not within our git directory"""
         if not osp.isabs(path):
             return path
         if self.repo.bare:
@@ -682,7 +682,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 into the object database.
 
                 PathStrings may contain globs, such as 'lib/__init__*' or can be directories
-                like 'lib', the latter ones will add all the files within the dirctory and
+                like 'lib', the latter ones will add all the files within the directory and
                 subdirectories.
 
                 This equals a straight git-add.
@@ -779,7 +779,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     "At least one Entry has a null-mode - please use index.remove to remove files for clarity")
             # END null mode should be remove
 
-            # HANLDE ENTRY OBJECT CREATION
+            # HANDLE ENTRY OBJECT CREATION
             # create objects if required, otherwise go with the existing shas
             null_entries_indices = [i for i, e in enumerate(entries) if e.binsha == Object.NULL_BIN_SHA]
             if null_entries_indices:
@@ -813,7 +813,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     fprogress(entry.path, False, entry)
                     fprogress(entry.path, True, entry)
                 # END handle progress
-            # END for each enty
+            # END for each entry
             entries_added.extend(entries)
         # END if there are base entries
 

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -314,7 +314,7 @@ def write_tree_from_cache(entries: List[IndexEntry], odb: 'GitCmdObjectDB', sl: 
 
     # finally create the tree
     sio = BytesIO()
-    tree_to_stream(tree_items, sio.write)  # writes to stream as bytes, but doesnt change tree_items
+    tree_to_stream(tree_items, sio.write)  # writes to stream as bytes, but doesn't change tree_items
     sio.seek(0)
 
     istream = odb.store(IStream(str_tree_type, len(sio.getvalue()), sio))

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -32,7 +32,7 @@ IndexObjUnion = Union['Tree', 'Blob', 'Submodule']
 # --------------------------------------------------------------------------
 
 
-_assertion_msg_format = "Created object %r whose python type %r disagrees with the acutual git object type %r"
+_assertion_msg_format = "Created object %r whose python type %r disagrees with the actual git object type %r"
 
 __all__ = ("Object", "IndexObject")
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -322,7 +322,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         Git messages can contain trailer information that are similar to RFC 822
         e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
 
-        This funcions calls ``git interpret-trailers --parse`` onto the message
+        This functions calls ``git interpret-trailers --parse`` onto the message
         to extract the trailer information. The key value pairs are stripped of
         leading and trailing whitespaces before they get saved into a dictionary.
 
@@ -461,7 +461,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         # * Environment variables override configuration values
         # * Sensible defaults are set according to the git documentation
 
-        # COMMITER AND AUTHOR INFO
+        # COMMITTER AND AUTHOR INFO
         cr = repo.config_reader()
         env = os.environ
 

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -338,7 +338,7 @@ class RootModule(Submodule):
             sm.update(recursive=False, init=init, to_latest_revision=to_latest_revision,
                       progress=progress, dry_run=dry_run, force=force_reset, keep_going=keep_going)
 
-            # update recursively depth first - question is which inconsitent
+            # update recursively depth first - question is which inconsistent
             # state will be better in case it fails somewhere. Defective branch
             # or defective depth. The RootSubmodule type will never process itself,
             # which was done in the previous expression

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from .submodule.base import Submodule
     from git.types import Protocol, runtime_checkable
 else:
-    # Protocol = Generic[_T]  # NNeeded for typing bug #572?
+    # Protocol = Generic[_T]  # Needed for typing bug #572?
     Protocol = ABC
 
     def runtime_checkable(f):
@@ -359,7 +359,7 @@ class Traversable(Protocol):
             out: IterableList[Union['Commit', 'Submodule', 'Tree', 'Blob']] = IterableList(id)
             out.extend(self.traverse(as_edge=as_edge, *args, **kwargs))
             return out
-            # overloads in subclasses (mypy does't allow typing self: subclass)
+            # overloads in subclasses (mypy doesn't allow typing self: subclass)
             # Union[IterableList['Commit'], IterableList['Submodule'], IterableList[Union['Submodule', 'Tree', 'Blob']]]
         else:
             # Raise deprecationwarning, doesn't make sense to use this

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -298,7 +298,7 @@ class SymbolicReference(object):
                       logmsg: Union[str, None] = None) -> 'SymbolicReference':
         """Set ourselves to the given ref. It will stay a symbol if the ref is a Reference.
         Otherwise an Object, given as Object instance or refspec, is assumed and if valid,
-        will be set which effectively detaches the refererence if it was a purely
+        will be set which effectively detaches the reference if it was a purely
         symbolic one.
 
         :param ref: SymbolicReference instance, Object instance or refspec string

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -36,7 +36,7 @@ class TagReference(Reference):
     _common_path_default = Reference._common_path_default + "/" + _common_default
 
     @property
-    def commit(self) -> 'Commit':  # type: ignore[override]  # LazyMixin has unrelated comit method
+    def commit(self) -> 'Commit':  # type: ignore[override]  # LazyMixin has unrelated commit method
         """:return: Commit object the tag ref points to
 
         :raise ValueError: if the tag points to a tree or blob"""
@@ -91,7 +91,7 @@ class TagReference(Reference):
 
         :param message:
             Synonym for :param logmsg:
-            Included for backwards compatability. :param logmsg is used in preference if both given.
+            Included for backwards compatibility. :param logmsg is used in preference if both given.
 
         :param force:
             If True, to force creation of a tag even though that tag already exists.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -711,7 +711,7 @@ class Repo(object):
             index or the working copy have changes."""
         if self._bare:
             # Bare repositories with no associated working directory are
-            # always consired to be clean.
+            # always considered to be clean.
             return False
 
         # start from the one which is fastest to evaluate
@@ -760,7 +760,7 @@ class Repo(object):
                                untracked_files=True,
                                as_process=True,
                                **kwargs)
-        # Untracked files preffix in porcelain mode
+        # Untracked files prefix in porcelain mode
         prefix = "?? "
         untracked_files = []
         for line in proc.stdout:

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -266,7 +266,7 @@ def rev_parse(repo: 'Repo', rev: str) -> Union['Commit', 'Tag', 'Tree', 'Blob']:
                 # END handle tag
             elif token == '@':
                 # try single int
-                assert ref is not None, "Requre Reference to access reflog"
+                assert ref is not None, "Require Reference to access reflog"
                 revlog_index = None
                 try:
                     # transform reversed index into the format of our revlog

--- a/git/types.py
+++ b/git/types.py
@@ -54,7 +54,7 @@ ConfigLevels_Tup = Tuple[Literal['system'], Literal['user'], Literal['global'], 
 
 def assert_never(inp: NoReturn, raise_error: bool = True, exc: Union[Exception, None] = None) -> None:
     """For use in exhaustive checking of literal or Enum in if/else chain.
-    Should only be reached if all memebers not handled OR attempt to pass non-members through chain.
+    Should only be reached if all members not handled OR attempt to pass non-members through chain.
 
     If all members handled, type is Empty. Otherwise, will cause mypy error.
     If non-members given, should cause mypy error at variable creation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 python_files = 'test_*.py'
-testpaths = 'test'  # space seperated list of paths from root e.g test tests doc/testing
+testpaths = 'test'  # space separated list of paths from root e.g test tests doc/testing
 addopts = '--cov=git --cov-report=term --maxfail=10 --force-sugar --disable-warnings'
 filterwarnings = 'ignore::DeprecationWarning'
 # --cov   coverage

--- a/test/fixtures/diff_p
+++ b/test/fixtures/diff_p
@@ -397,7 +397,7 @@ index 1d5251d40fb65ac89184ec662a3e1b04d0c24861..98eeddda5ed2b0e215e21128112393bd
        self.git_dir = git_dir
      end
      
--    # Converstion hash from Ruby style options to git command line
+-    # Conversion hash from Ruby style options to git command line
 -    # style options
 -    TRANSFORM = {:max_count => "--max-count=",
 -                 :skip => "--skip=",

--- a/test/fixtures/git_config
+++ b/test/fixtures/git_config
@@ -28,7 +28,7 @@
 [branch "mainline_performance"]
 	remote = mainline
 	merge = refs/heads/master
-# section with value defined before include to be overriden
+# section with value defined before include to be overridden
 [sec]
     var0 = value0_main
 [include]

--- a/test/fixtures/rev_list_bisect_all
+++ b/test/fixtures/rev_list_bisect_all
@@ -40,7 +40,7 @@ committer David Aguilar <davvid@gmail.com> 1220418344 -0700
     commit: handle --bisect-all output in Commit.list_from_string
     
     Rui Abreu Ferrerira pointed out that "git rev-list --bisect-all"
-    returns a slightly different format which we can easily accomodate
+    returns a slightly different format which we can easily accommodate
     by changing the way we parse rev-list output.
     
     http://groups.google.com/group/git-python/browse_thread/thread/aed1d5c4b31d5027

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -175,7 +175,7 @@ class TestBase(TestCase):
         assert num_sections and num_options
         assert r_config._is_initialized is True
 
-        # get value which doesnt exist, with default
+        # get value which doesn't exist, with default
         default = "my default value"
         assert r_config.get_value("doesnt", "exist", default) == default
 

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -273,7 +273,7 @@ class TestDiff(TestBase):
         self.assertEqual(res[13].b_path, 'b/"with even more quotes"')
 
     def test_diff_patch_format(self):
-        # test all of the 'old' format diffs for completness - it should at least
+        # test all of the 'old' format diffs for completeness - it should at least
         # be able to deal with it
         fixtures = ("diff_2", "diff_2f", "diff_f", "diff_i", "diff_mode_only",
                     "diff_new_mode", "diff_numstat", "diff_p", "diff_rename",

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -135,7 +135,7 @@ class Tutorials(TestBase):
         for fetch_info in origin.fetch(progress=MyProgressPrinter()):
             print("Updated %s to %s" % (fetch_info.ref, fetch_info.commit))
         # create a local branch at the latest fetched master. We specify the name statically, but you have all
-        # information to do it programatically as well.
+        # information to do it programmatically as well.
         bare_master = bare_repo.create_head('master', origin.refs.master)
         bare_repo.head.set_reference(bare_master)
         assert not bare_repo.delete_remote(origin).exists()

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -159,7 +159,7 @@ class TestGit(TestBase):
         prev_cmd = self.git.GIT_PYTHON_GIT_EXECUTABLE
         exc = GitCommandNotFound
         try:
-            # set it to something that doens't exist, assure it raises
+            # set it to something that doesn't exist, assure it raises
             type(self.git).GIT_PYTHON_GIT_EXECUTABLE = osp.join(
                 "some", "path", "which", "doesn't", "exist", "gitbinary")
             self.assertRaises(exc, self.git.version)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -936,4 +936,4 @@ class TestIndex(TestBase):
                 self.assertEqual(err.stderr, "\n  stderr: 'stderr\n'")
                 assert str(err)
         else:
-            raise AssertionError("Should have cought a HookExecutionError")
+            raise AssertionError("Should have caught a HookExecutionError")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -546,7 +546,7 @@ class TestSubmodule(TestBase):
         assert nsm.module().head.commit.hexsha == nsm.hexsha
         nsm.module().index.add([nsm])
         nsm.module().index.commit("added new file")
-        rm.update(recursive=False, dry_run=True, progress=prog)  # would not change head, and thus doens't fail
+        rm.update(recursive=False, dry_run=True, progress=prog)  # would not change head, and thus doesn't fail
         # Everything we can do from now on will trigger the 'future' check, so no is_dirty() check will even run
         # This would only run if our local branch is in the past and we have uncommitted changes
 
@@ -730,7 +730,7 @@ class TestSubmodule(TestBase):
         assert parent.head.commit.tree[sm.path].binsha == sm.binsha
         assert sm_too.binsha == sm.binsha, "cached submodule should point to the same commit as updated one"
 
-        added_bies = parent.index.add([sm])  # addded base-index-entries
+        added_bies = parent.index.add([sm])  # added base-index-entries
         assert len(added_bies) == 1
         parent.index.commit("add same submodule entry")
         commit_sm = parent.head.commit.tree[sm.path]


### PR DESCRIPTION
Found via `codespell -q 3 -S ./git/ext/gitdb,./test/fixtures/reflog_master,./test/fixtures/diff_mode_only,./test/fixtures/reflog_HEAD`