### PR TITLE
feat: If `core.autocrlf` is enabled, replace CRLF with LF when adding to index

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -617,11 +617,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         paths = []
         entries = []
         # if it is a string put in list
-        if isinstance(items, str):
+        if isinstance(items, (str, os.PathLike)):
             items = [items]
 
         for item in items:
-            if isinstance(item, str):
+            if isinstance(item, (str, os.PathLike)):
                 paths.append(self._to_relative_path(item))
             elif isinstance(item, (Blob, Submodule)):
                 entries.append(BaseIndexEntry.from_blob(item))

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -37,6 +37,8 @@ from gitdb.base import IStream
 import os.path as osp
 from git.cmd import Git
 
+from pathlib import Path
+
 HOOKS_SHEBANG = "#!/usr/bin/env sh\n"
 
 is_win_without_bash = is_win and not shutil.which("bash.exe")
@@ -943,3 +945,12 @@ class TestIndex(TestBase):
                 assert str(err)
         else:
             raise AssertionError("Should have caught a HookExecutionError")
+
+    @with_rw_repo('HEAD')
+    def test_index_add_pathlike(self, rw_repo):
+        git_dir = Path(rw_repo.git_dir)
+
+        file = git_dir / "file.txt"
+        file.touch()
+
+        rw_repo.index.add(file)


### PR DESCRIPTION
This is to mimic the same behaviour the standard git command has. 

Apart for the blackification, relevant lines are the definition of the class `_FileStore`, the addition of the method `_autocrlf`, and the adaptations in `add()` to use the `_FileStore` contextmanager.

The logic here is to replace `\r\n` with `\n` when adding to the index, then reset the local file to the original content. 