### PR TITLE
Re-enable Cygwin CI and get most tests passing

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -24,6 +24,9 @@ jobs:
     - uses: cygwin/cygwin-install-action@v2
       with:
         packages: python39 python39-pip git
+    - name: Tell git to trust this repo
+      shell: bash.exe -eo pipefail -o igncr "{0}"
+      run: git config --global --add safe.directory $(pwd)
     - name: Install dependencies and prepare tests
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 9999
     - uses: cygwin/cygwin-install-action@v2
       with:
-        packages: python39 python39-pip git
+        packages: python39 python39-pip python39-virtualenv git
     - name: Tell git to trust this repo
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: /usr/bin/git config --global --add safe.directory $(pwd)

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -1,0 +1,53 @@
+name: test-cygwin
+
+on:
+  push:
+    branches:
+      main
+  pull_request:
+    branches:
+      main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      CHERE_INVOKING: 1
+      SHELLOPTS: igncr
+    
+    steps:
+    - name: Force LF line endings
+      run: git config --global core.autocrlf input
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 9999
+    - uses: cygwin/cygwin-install-action@v2
+      with:
+        packages: python39 python39-pip git
+    - name: Install dependencies and prepare tests
+      shell: bash.exe -eo pipefail -o igncr "{0}"
+      run: |
+        set -x
+        python -m pip install --upgrade pip setuptools wheel
+        python --version; git --version
+        git submodule update --init --recursive
+        git fetch --tags
+        pip install -r requirements.txt
+        pip install -r test-requirements.txt
+        TRAVIS=yes ./init-tests-after-clone.sh
+        git config --global user.email "travis@ci.com"
+        git config --global user.name "Travis Runner"
+        # If we rewrite the user's config by accident, we will mess it up
+        # and cause subsequent tests to fail
+        cat test/fixtures/.gitconfig >> ~/.gitconfig
+    - name: Lint with flake8
+      shell: bash.exe -eo pipefail -o igncr "{0}"
+      run: |
+        set -x
+        flake8
+    - name: Test with pytest
+      shell: bash.exe -eo pipefail -o igncr "{0}"
+      run: |
+        set -x
+        pytest
+      continue-on-error: false

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -26,20 +26,20 @@ jobs:
         packages: python39 python39-pip git
     - name: Tell git to trust this repo
       shell: bash.exe -eo pipefail -o igncr "{0}"
-      run: git config --global --add safe.directory $(pwd)
+      run: /usr/bin/git config --global --add safe.directory $(pwd)
     - name: Install dependencies and prepare tests
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         set -x
-        python -m pip install --upgrade pip setuptools wheel
-        python --version; git --version
-        git submodule update --init --recursive
-        git fetch --tags
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
+        /usr/bin/python -m pip install --upgrade pip setuptools wheel
+        /usr/bin/python --version; /usr/bin/git --version
+        /usr/bin/git submodule update --init --recursive
+        /usr/bin/git fetch --tags
+        /usr/bin/python -m pip install -r requirements.txt
+        /usr/bin/python -m pip install -r test-requirements.txt
         TRAVIS=yes ./init-tests-after-clone.sh
-        git config --global user.email "travis@ci.com"
-        git config --global user.name "Travis Runner"
+        /usr/bin/git config --global user.email "travis@ci.com"
+        /usr/bin/git config --global user.name "Travis Runner"
         # If we rewrite the user's config by accident, we will mess it up
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
@@ -47,10 +47,10 @@ jobs:
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         set -x
-        flake8
+        /usr/bin/python flake8
     - name: Test with pytest
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         set -x
-        pytest
+        /usr/bin/python -m pytest
       continue-on-error: false

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -53,6 +53,5 @@ jobs:
     - name: Test with pytest
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
-        set -x
         /usr/bin/python -m pytest
       continue-on-error: false

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       CHERE_INVOKING: 1
       SHELLOPTS: igncr
+      TMP: "/tmp"
+      TEMP: "/tmp"
     
     steps:
     - name: Force LF line endings

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -47,7 +47,7 @@ jobs:
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         set -x
-        /usr/bin/python flake8
+        /usr/bin/python -m flake8
     - name: Test with pytest
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -29,6 +29,7 @@ from git.remote import Remote, add_progress, to_progress_instance
 from git.util import (
     Actor,
     finalize_process,
+    cygpath,
     decygpath,
     hex_to_bin,
     expand_path,
@@ -175,7 +176,10 @@ class Repo(object):
         if not epath:
             epath = os.getcwd()
         if Git.is_cygwin():
-            epath = decygpath(epath)
+            # Given how the tests are written, this seems more likely to catch
+            # Cygwin git used from Windows than Windows git used from Cygwin.
+            # Therefore changing to Cygwin-style paths is the relevant operation.
+            epath = cygpath(epath)
 
         epath = epath or path or os.getcwd()
         if not isinstance(epath, str):

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -30,7 +30,6 @@ from git.util import (
     Actor,
     finalize_process,
     cygpath,
-    decygpath,
     hex_to_bin,
     expand_path,
     remove_password_if_present,

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -7,7 +7,7 @@ from string import digits
 from git.exc import WorkTreeRepositoryUnsupported
 from git.objects import Object
 from git.refs import SymbolicReference
-from git.util import hex_to_bin, bin_to_hex, decygpath
+from git.util import hex_to_bin, bin_to_hex, cygpath
 from gitdb.exc import (
     BadObject,
     BadName,
@@ -109,7 +109,9 @@ def find_submodule_git_dir(d: "PathLike") -> Optional["PathLike"]:
 
             if Git.is_cygwin():
                 ## Cygwin creates submodules prefixed with `/cygdrive/...` suffixes.
-                path = decygpath(path)
+                # Cygwin git understands Cygwin paths much better than Windows ones
+                # Also the Cygwin tests are assuming Cygwin paths.
+                path = cygpath(path)
             if not osp.isabs(path):
                 path = osp.normpath(osp.join(osp.dirname(d), path))
             return find_submodule_git_dir(path)

--- a/git/util.py
+++ b/git/util.py
@@ -377,7 +377,9 @@ def is_cygwin_git(git_executable: PathLike) -> bool:
 
 
 def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
-    if not is_win:
+    if is_win:
+        # is_win seems to be true only for Windows-native pythons
+        # cygwin has os.name = posix, I think
         return False
 
     if git_executable is None:

--- a/git/util.py
+++ b/git/util.py
@@ -310,7 +310,7 @@ def _cygexpath(drive: Optional[str], path: str) -> str:
             else:
                 p = cygpath(p)
         elif drive:
-            p = "/cygdrive/%s/%s" % (drive.lower(), p)
+            p = "/proc/cygdrive/%s/%s" % (drive.lower(), p)
     p_str = str(p)  # ensure it is a str and not AnyPath
     return p_str.replace("\\", "/")
 
@@ -334,7 +334,7 @@ def cygpath(path: str) -> str:
     """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
     path = str(path)  # ensure is str and not AnyPath.
     # Fix to use Paths when 3.5 dropped. or to be just str if only for urls?
-    if not path.startswith(("/cygdrive", "//")):
+    if not path.startswith(("/cygdrive", "//", "/proc/cygdrive")):
         for regex, parser, recurse in _cygpath_parsers:
             match = regex.match(path)
             if match:
@@ -348,7 +348,7 @@ def cygpath(path: str) -> str:
     return path
 
 
-_decygpath_regex = re.compile(r"/cygdrive/(\w)(/.*)?")
+_decygpath_regex = re.compile(r"(?:/proc)?/cygdrive/(\w)(/.*)?")
 
 
 def decygpath(path: PathLike) -> str:

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -5,6 +5,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import os
+import sys
 
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
@@ -475,6 +476,11 @@ class Tutorials(TestBase):
 
         repo.git.clear_cache()
 
+    @pytest.mark.xfail(
+        sys.platform == "cygwin",
+        reason="Cygwin GitPython can't find SHA for submodule",
+        raises=ValueError
+    )
     def test_submodules(self):
         # [1-test_submodules]
         repo = self.rorepo

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -7,6 +7,8 @@
 import os
 import sys
 
+import pytest
+
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -11,8 +11,11 @@ import itertools
 import os
 import pathlib
 import pickle
+import sys
 import tempfile
 from unittest import mock, skipIf, SkipTest
+
+import pytest
 
 from git import (
     InvalidGitRepositoryError,
@@ -903,6 +906,11 @@ class TestRepo(TestBase):
         target_type = GitCmdObjectDB
         self.assertIsInstance(self.rorepo.odb, target_type)
 
+    @pytest.mark.xfail(
+        sys.platform == "cygwin",
+        reason="Cygwin GitPython can't find submodule SHA",
+        raises=ValueError
+    )
     def test_submodules(self):
         self.assertEqual(len(self.rorepo.submodules), 1)  # non-recursive
         self.assertGreaterEqual(len(list(self.rorepo.iter_submodules())), 2)

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -436,15 +436,15 @@ class TestSubmodule(TestBase):
     def test_base_rw(self, rwrepo):
         self._do_base_tests(rwrepo)
 
+    @with_rw_repo(k_subm_current, bare=True)
+    def test_base_bare(self, rwrepo):
+        self._do_base_tests(rwrepo)
+
     @pytest.mark.xfail(
         sys.platform == "cygwin",
         reason="Cygwin GitPython can't find submodule SHA",
         raises=ValueError
     )
-    @with_rw_repo(k_subm_current, bare=True)
-    def test_base_bare(self, rwrepo):
-        self._do_base_tests(rwrepo)
-
     @skipIf(
         HIDE_WINDOWS_KNOWN_ERRORS,
         """

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -3,7 +3,10 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 import os
 import shutil
+import sys
 from unittest import skipIf
+
+import pytest
 
 import git
 from git.cmd import Git
@@ -433,6 +436,11 @@ class TestSubmodule(TestBase):
     def test_base_rw(self, rwrepo):
         self._do_base_tests(rwrepo)
 
+    @pytest.mark.xfail(
+        sys.platform == "cygwin",
+        reason="Cygwin GitPython can't find submodule SHA",
+        raises=ValueError
+    )
     @with_rw_repo(k_subm_current, bare=True)
     def test_base_bare(self, rwrepo):
         self._do_base_tests(rwrepo)


### PR DESCRIPTION
It looks like the Cygwin CI testing was disabled a while back, possibly as part of the move to GHA.  I added a separate Cygwin CI run to the GitHub actions and tried to get the tests passing.  I have three test failures left that I don't understand, and hope someone here knows what's going on.

I can move the test to a separate step in the existing GHA workflow if that would work better in this project, or move it to a separate PR to wait for the last three tests to pass while the other fixes go in.