### PR TITLE
Fix bug in TagReference.create that would duplicate the message

### DIFF
--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -113,10 +113,12 @@ class TagReference(Reference):
         if "ref" in kwargs and kwargs["ref"]:
             reference = kwargs["ref"]
 
+        if "message" in kwargs and kwargs["message"]:
+            kwargs["m"] = kwargs["message"]
+            del kwargs["message"]
+
         if logmsg:
             kwargs["m"] = logmsg
-        elif "message" in kwargs and kwargs["message"]:
-            kwargs["m"] = kwargs["message"]
 
         if force:
             kwargs["f"] = True

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -572,6 +572,23 @@ class TestRefs(TestBase):
 
         # END for each path
 
+    @with_rw_repo("0.1.6")
+    def test_tag_message(self, rw_repo):
+        tag_ref = TagReference.create(rw_repo, "test-message-1", message="test")
+        assert tag_ref.tag.message == "test"
+
+        tag_ref = TagReference.create(rw_repo, "test-message-2", logmsg="test")
+        assert tag_ref.tag.message == "test"
+
+        tag_ref = TagReference.create(
+            rw_repo,
+            "test-message-3",
+            # Logmsg should take precedence over "message".
+            message="test1",
+            logmsg="test2",
+        )
+        assert tag_ref.tag.message == "test2"
+
     def test_dereference_recursive(self):
         # for now, just test the HEAD
         assert SymbolicReference.dereference_recursive(self.rorepo, "HEAD")


### PR DESCRIPTION
Previously if you passed the `message` kwarg, that would cause a `--message` argument to `git tag`, but then the code also added a `-m`, which caused the message to appear in the tag twice. Fix that by deleting `message` from the kwargs if we set `-m`.