### PR TITLE
Catch OSError to handle gevent monkey patching errors

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -546,7 +546,7 @@ class Git(LazyMixin):
                 if stream:
                     try:
                         return stderr_b + force_bytes(stream.read())
-                    except ValueError:
+                    except (OSError, ValueError):
                         return stderr_b or b""
                 else:
                     return stderr_b or b""


### PR DESCRIPTION
gevent.monkey.patch_all() patches stderr to be gevent._fileobjectcommon._ClosedIO object, which raises its own FileObjectClosed(IOError).
This PR robustly handles OSError which IOError / FileObjectClosed error inherits from.
Fixes #1336 