### PR TITLE
Fix incomplete typehinting for PathLike

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,4 +46,5 @@ Contributors are:
 -Robert Westman <robert _at_ byteflux.io>
 -Hugo van Kemenade
 -Hiroki Tokunaga <tokusan441 _at_ gmail.com>
+-Julien Mauroy <pro.julien.mauroy _at_ gmail.com>
 Portions derived from other open source works and are clearly marked.

--- a/git/types.py
+++ b/git/types.py
@@ -40,10 +40,10 @@ else:
 
 
 if sys.version_info[:2] < (3, 9):
-    PathLike = Union[str, os.PathLike[str]]
+    PathLike = Union[str, os.PathLike]
 else:
     # os.PathLike only becomes subscriptable from Python 3.9 onwards
-    PathLike = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
+    PathLike = Union[str, os.PathLike[str]]
 
 if TYPE_CHECKING:
     from git.repo import Repo

--- a/git/types.py
+++ b/git/types.py
@@ -40,7 +40,7 @@ else:
 
 
 if sys.version_info[:2] < (3, 9):
-    PathLike = Union[str, bytes, os.PathLike]
+    PathLike = Union[str, os.PathLike[str]]
 else:
     # os.PathLike only becomes subscriptable from Python 3.9 onwards
     PathLike = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]

--- a/git/types.py
+++ b/git/types.py
@@ -6,22 +6,18 @@
 import os
 import sys
 from typing import (
-    Callable,
     Dict,
     NoReturn,
     Sequence,
     Tuple,
     Union,
     Any,
-    Iterator,  # noqa: F401
-    NamedTuple,
     TYPE_CHECKING,
     TypeVar,
 )  # noqa: F401
 
 if sys.version_info[:2] >= (3, 8):
     from typing import (
-        Final,
         Literal,
         SupportsIndex,
         TypedDict,
@@ -30,7 +26,6 @@ if sys.version_info[:2] >= (3, 8):
     )  # noqa: F401
 else:
     from typing_extensions import (
-        Final,
         Literal,
         SupportsIndex,  # noqa: F401
         TypedDict,
@@ -45,10 +40,10 @@ else:
 
 
 if sys.version_info[:2] < (3, 9):
-    PathLike = Union[str, os.PathLike]
-elif sys.version_info[:2] >= (3, 9):
+    PathLike = Union[str, bytes, os.PathLike]
+else:
     # os.PathLike only becomes subscriptable from Python 3.9 onwards
-    PathLike = Union[str, os.PathLike]
+    PathLike = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
 
 if TYPE_CHECKING:
     from git.repo import Repo
@@ -92,8 +87,6 @@ def assert_never(inp: NoReturn, raise_error: bool = True, exc: Union[Exception, 
             raise ValueError(f"An unhandled Literal ({inp}) in an if/else chain was found")
         else:
             raise exc
-    else:
-        pass
 
 
 class Files_TD(TypedDict):


### PR DESCRIPTION
This adds a more rich type hinting for the `git.types.PathLike` class.
Closes #1473.

Also remove unused imports in this file.