### PR TITLE
Improve docs 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,4 +47,5 @@ Contributors are:
 -Hugo van Kemenade
 -Hiroki Tokunaga <tokusan441 _at_ gmail.com>
 -Julien Mauroy <pro.julien.mauroy _at_ gmail.com>
+-Patrick Gerard
 Portions derived from other open source works and are clearly marked.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -858,6 +858,8 @@ class Repo(object):
     @property
     def active_branch(self) -> Head:
         """The name of the currently active branch.
+
+        :raises	TypeError: If HEAD is detached
         :return: Head to the active branch"""
         # reveal_type(self.head.reference)  # => Reference
         return self.head.reference


### PR DESCRIPTION
related to: [#1479 ](https://github.com/gitpython-developers/GitPython/issues/1479)

this PR adds a `TypeError`-hint to the documentation in case the HEAD is detached and used in the `active_branch` of the `Repo` class.

This will help users to understand that there's no error on their side.