### PR TITLE
Suggested fixes by iCR, OpenRefactory, Inc.

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -4,6 +4,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
+from ast import Delete
 import glob
 from io import BytesIO
 import os
@@ -351,7 +352,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         # tmp file created in git home directory to be sure renaming
         # works - /tmp/ dirs could be on another device
-        tmp_index = tempfile.mktemp("", "", repo.git_dir)
+
+        # OpenRefactory Warning: The method 'tempfile.mktemp' creates temporary file in an insecure way.
+        # use 'NamedTemporaryFile' instead of using 'mktemp' to create temporary file
+        tmp_index = tempfile.NamedTemporaryFile("", "", repo.git_dir).name
         arg_list.append("--index-output=%s" % tmp_index)
         arg_list.extend(treeish)
 

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -40,7 +40,9 @@ class TemporaryFileSwap(object):
 
     def __init__(self, file_path: PathLike) -> None:
         self.file_path = file_path
-        self.tmp_file_path = str(self.file_path) + tempfile.mktemp("", "", "")
+        # OpenRefactory Warning: The method 'tempfile.mktemp' creates temporary file in an insecure way.
+        # use 'NamedTemporaryFile' instead of using 'mktemp' to create temporary file
+        self.tmp_file_path = str(self.file_path) + tempfile.NamedTemporaryFile("", "", "").name
         # it may be that the source does not exist
         try:
             os.rename(self.file_path, self.tmp_file_path)


### PR DESCRIPTION
This issue was detected in branch `main` of `GitPython` project on the version with commit hash `73bde1`. This is an instance of an improper method call


**Fixes for improper method call:** 
In file: `base.py`, there is a method `from_tree` that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation. ](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)**iCR** suggested that a temporary file should be created using `NamedTemporaryFile` which is a [a safe API. ](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile)**iCR** replaced the usage of `mktemp` with `NamedTemporaryFile`.

In file: `util.py`, there is a method `__init__` that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation. ](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)**iCR** suggested that a temporary file should be created using `NamedTemporaryFile` which is a [a safe API. ](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile)**iCR** replaced the usage of `mktemp` with `NamedTemporaryFile`.


This issue was detected by **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. More info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)
