### PR TITLE
Fix bug where colons in paths raise a `ValueError` on `diff()` calls.

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -570,7 +570,10 @@ class Diff(object):
     def _handle_diff_line(lines_bytes: bytes, repo: "Repo", index: DiffIndex) -> None:
         lines = lines_bytes.decode(defenc)
 
-        for line in lines.split(":")[1:]:
+        # Discard everything before the first colon, and the colon itself.
+        _, _, lines = lines.partition(":")
+
+        for line in lines.split("\x00:"):
             meta, _, path = line.partition("\x00")
             path = path.rstrip("\x00")
             a_blob_id: Optional[str]

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -236,7 +236,6 @@ class TestDiff(TestBase):
             res[0].b_path,
         )
 
-    @unittest.skip("This currently fails and would need someone to improve diff parsing")
     def test_diff_file_with_colon(self):
         output = fixture("diff_file_with_colon")
         res = []


### PR DESCRIPTION
This commit introduces a potential fix for #1490 and #1483, in which an `invalid literal for int() with base 10: 'n'` exception was raised within a diff operation. Within `_handle_diff_line()`, we split the output of `git diff-tree` on colons (`:` characters), under the assumption that there are no colons within the paths of the files being diffed. On POSIX systems this is not a valid assumption. The fix is to split on `\x00:`, since a null character always precedes the colons we actually need to split on.

A test already existed for this case (`test_diff_file_with_colon()`), but it was marked as skipped.

* Split on `\x00:` instead of `:` in `_handle_diff_line()`.
* Unskip `test_diff_file_with_colon()`.