### PR TITLE
Ignore empty info in diff line

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -574,6 +574,9 @@ class Diff(object):
         _, _, lines = lines.partition(":")
 
         for line in lines.split("\x00:"):
+            if not line:
+                # The line data is empty, skip
+                continue
             meta, _, path = line.partition("\x00")
             path = path.rstrip("\x00")
             a_blob_id: Optional[str]

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -240,6 +240,12 @@ class TestDiff(TestBase):
         output = fixture("diff_file_with_colon")
         res = []
         Diff._handle_diff_line(output, None, res)
+        self.assertEqual(len(res), 3)
+
+    def test_empty_diff(self):
+        res = []
+        Diff._handle_diff_line(b"", None, res)
+        self.assertEqual(res, [])
 
     def test_diff_initial_commit(self):
         initial_commit = self.rorepo.commit("33ebe7acec14b25c5f84f35a664803fcab2f7781")


### PR DESCRIPTION
In some cases, the git diff command does not return any output, this results in an exception in the diff line handling code.

```
  File "../lib/python3.8/site-packages/git/diff.py", line 502, in _handle_diff_line
    old_mode, new_mode, a_blob_id, b_blob_id, _change_type = meta.split(None, 4)
ValueError: not enough values to unpack (expected 5, got 1)
```

This fix ignores empty diff lines.
