### PR TITLE
Add datetime.datetime type to commit_date and author_date

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -4,6 +4,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
+import datetime
 import glob
 from io import BytesIO
 import os
@@ -1032,8 +1033,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         head: bool = True,
         author: Union[None, "Actor"] = None,
         committer: Union[None, "Actor"] = None,
-        author_date: Union[str, None] = None,
-        commit_date: Union[str, None] = None,
+        author_date: Union[datetime.datetime, str, None] = None,
+        commit_date: Union[datetime.datetime, str, None] = None,
         skip_hooks: bool = False,
     ) -> Commit:
         """Commit the current default index file, creating a commit object.

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -435,8 +435,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         head: bool = False,
         author: Union[None, Actor] = None,
         committer: Union[None, Actor] = None,
-        author_date: Union[None, str] = None,
-        commit_date: Union[None, str] = None,
+        author_date: Union[None, str, datetime.datetime] = None,
+        commit_date: Union[None, str, datetime.datetime] = None,
     ) -> "Commit":
         """Commit the given tree, creating a commit object.
 


### PR DESCRIPTION
Update type hints to match acceptable date types.

Passing a `datetime.datetime` object for `author_date` or `commit_date` causes a mypy type error, these dates are passed to `parse_date` in `git.objects.util`, which does accept a `datetime.datetime` object.