### PR TITLE
Quote URLs in Repo.clone_from()

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.7.5, 3.7.12, 3.8, 3.8.0, 3.8.11, 3.8, 3.9, 3.9.0, 3.9.7, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/git/exc.py
+++ b/git/exc.py
@@ -37,6 +37,10 @@ class NoSuchPathError(GitError, OSError):
     """Thrown if a path could not be access by the system."""
 
 
+class UnsafeOptionsUsedError(GitError):
+    """Thrown if unsafe protocols or options are passed without overridding."""
+
+
 class CommandError(GitError):
     """Base class for exceptions thrown at every stage of `Popen()` execution.
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -21,7 +21,12 @@ from git.compat import (
 )
 from git.config import GitConfigParser
 from git.db import GitCmdObjectDB
-from git.exc import InvalidGitRepositoryError, NoSuchPathError, GitCommandError
+from git.exc import (
+    GitCommandError,
+    InvalidGitRepositoryError,
+    NoSuchPathError,
+    UnsafeOptionsUsedError,
+)
 from git.index import IndexFile
 from git.objects import Submodule, RootModule, Commit
 from git.refs import HEAD, Head, Reference, TagReference
@@ -128,6 +133,7 @@ class Repo(object):
     re_envvars = re.compile(r"(\$(\{\s?)?[a-zA-Z_]\w*(\}\s?)?|%\s?[a-zA-Z_]\w*\s?%)")
     re_author_committer_start = re.compile(r"^(author|committer)")
     re_tab_full_line = re.compile(r"^\t(.*)$")
+    re_config_protocol_option = re.compile(r"-[-]?c(|onfig)\s+protocol\.", re.I)
 
     # invariants
     # represents the configuration level of a configuration file
@@ -1214,11 +1220,27 @@ class Repo(object):
         # END handle remote repo
         return repo
 
+    @classmethod
+    def unsafe_options(
+        cls,
+        url: str,
+        multi_options: Optional[List[str]] = None,
+    ) -> bool:
+        if "ext::" in url:
+            return True
+        if multi_options is not None:
+            if any(["--upload-pack" in m for m in multi_options]):
+                return True
+            if any([re.match(cls.re_config_protocol_option, m) for m in multi_options]):
+                return True
+        return False
+
     def clone(
         self,
         path: PathLike,
         progress: Optional[Callable] = None,
         multi_options: Optional[List[str]] = None,
+        unsafe_protocols: bool = False,
         **kwargs: Any,
     ) -> "Repo":
         """Create a clone from this repository.
@@ -1229,12 +1251,15 @@ class Repo(object):
             option per list item which is passed exactly as specified to clone.
             For example ['--config core.filemode=false', '--config core.ignorecase',
             '--recurse-submodule=repo1_path', '--recurse-submodule=repo2_path']
+        :param unsafe_protocols: Allow unsafe protocols to be used, like ext
         :param kwargs:
             * odbt = ObjectDatabase Type, allowing to determine the object database
               implementation used by the returned Repo instance
             * All remaining keyword arguments are given to the git-clone command
 
         :return: ``git.Repo`` (the newly cloned repo)"""
+        if not unsafe_protocols and self.unsafe_options(path, multi_options):
+            raise UnsafeOptionsUsedError(f"{path} requires unsafe_protocols flag")
         return self._clone(
             self.git,
             self.common_dir,
@@ -1253,6 +1278,7 @@ class Repo(object):
         progress: Optional[Callable] = None,
         env: Optional[Mapping[str, str]] = None,
         multi_options: Optional[List[str]] = None,
+        unsafe_protocols: bool = False,
         **kwargs: Any,
     ) -> "Repo":
         """Create a clone from the given URL
@@ -1267,11 +1293,14 @@ class Repo(object):
             If you want to unset some variable, consider providing empty string
             as its value.
         :param multi_options: See ``clone`` method
+        :param unsafe_protocols: Allow unsafe protocols to be used, like ext
         :param kwargs: see the ``clone`` method
         :return: Repo instance pointing to the cloned directory"""
         git = cls.GitCommandWrapperType(os.getcwd())
         if env is not None:
             git.update_environment(**env)
+        if not unsafe_protocols and cls.unsafe_options(url, multi_options):
+            raise UnsafeOptionsUsedError(f"{url} requires unsafe_protocols flag")
         return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
 
     def archive(


### PR DESCRIPTION
Since the URL is passed directly to git clone, and the remote-ext helper will happily execute shell commands, so by default qoute URLs unless a (undocumented, on purpose) kwarg is passed. (CVE-2022-24439)

Fixes #1515