### PR TITLE
Fix command injection

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.7.5, 3.7.12, 3.8, 3.8.0, 3.8.11, 3.8, 3.9, 3.9.0, 3.9.7, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/git/remote.py
+++ b/git/remote.py
@@ -964,7 +964,7 @@ class Remote(LazyMixin, IterableObj):
             args = [refspec]
 
         proc = self.repo.git.fetch(
-            self, *args, as_process=True, with_stdout=False, universal_newlines=True, v=verbose, **kwargs
+            "--", self, *args, as_process=True, with_stdout=False, universal_newlines=True, v=verbose, **kwargs
         )
         res = self._get_fetch_info_from_stderr(proc, progress, kill_after_timeout=kill_after_timeout)
         if hasattr(self.repo.odb, "update_cache"):
@@ -991,7 +991,7 @@ class Remote(LazyMixin, IterableObj):
             self._assert_refspec()
         kwargs = add_progress(kwargs, self.repo.git, progress)
         proc = self.repo.git.pull(
-            self, refspec, with_stdout=False, as_process=True, universal_newlines=True, v=True, **kwargs
+            "--", self, refspec, with_stdout=False, as_process=True, universal_newlines=True, v=True, **kwargs
         )
         res = self._get_fetch_info_from_stderr(proc, progress, kill_after_timeout=kill_after_timeout)
         if hasattr(self.repo.odb, "update_cache"):
@@ -1034,6 +1034,7 @@ class Remote(LazyMixin, IterableObj):
             be 0."""
         kwargs = add_progress(kwargs, self.repo.git, progress)
         proc = self.repo.git.push(
+            "--",
             self,
             refspec,
             porcelain=True,

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1169,6 +1169,7 @@ class Repo(object):
             multi = shlex.split(" ".join(multi_options))
         proc = git.clone(
             multi,
+            "--",
             Git.polish_url(str(url)),
             clone_path,
             with_extended_output=True,
@@ -1305,7 +1306,7 @@ class Repo(object):
         if not isinstance(path, (tuple, list)):
             path = [path]
         # end assure paths is list
-        self.git.archive(treeish, *path, **kwargs)
+        self.git.archive("--", treeish, *path, **kwargs)
         return self
 
     def has_separate_working_tree(self) -> bool:


### PR DESCRIPTION
Add `--` in some commands that receive user input
and if interpreted as options could lead to remote code execution (RCE).

There may be more commands that could benefit from `--` so the input is never interpreted as an option,
but most of those aren't dangerous.

Fixed commands:

- push
- pull
- fetch
- clone/clone_from and friends
- archive (not sure if this one can be exploited, but it doesn't hurt adding `--` :))

For anyone using GitPython and exposing any of the GitPython methods to users, make sure to always validate the input (like if starts with `--`). And for anyone allowing users to pass arbitrary options, be aware that some options may lead to RCE, like `--exc`, `--upload-pack`, `--receive-pack`, `--config` (https://github.com/gitpython-developers/GitPython/pull/1516).

Ref https://github.com/gitpython-developers/GitPython/issues/1517