### PR TITLE
Block insecure options and protocols by default

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,4 +50,5 @@ Contributors are:
 -Patrick Gerard
 -Luke Twist <itsluketwist@gmail.com>
 -Joseph Hale <me _at_ jhale.dev>
+-Santos Gallegos <stsewd _at_ proton.me>
 Portions derived from other open source works and are clearly marked.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -488,12 +488,12 @@ class Git(LazyMixin):
         """
         # Options can be of the form `foo` or `--foo bar` `--foo=bar`,
         # so we need to check if they start with "--foo" or if they are equal to "foo".
-        bare_options = [
+        bare_unsafe_options = [
             option.lstrip("-")
             for option in unsafe_options
         ]
         for option in options:
-            for unsafe_option, bare_option in zip(unsafe_options, bare_options):
+            for unsafe_option, bare_option in zip(unsafe_options, bare_unsafe_options):
                 if option.startswith(unsafe_option) or option == bare_option:
                     raise UnsafeOptionError(
                         f"{unsafe_option} is not allowed, use `allow_unsafe_options=True` to allow it."
@@ -1193,12 +1193,12 @@ class Git(LazyMixin):
         return args
 
     @classmethod
-    def __unpack_args(cls, arg_list: Sequence[str]) -> List[str]:
+    def _unpack_args(cls, arg_list: Sequence[str]) -> List[str]:
 
         outlist = []
         if isinstance(arg_list, (list, tuple)):
             for arg in arg_list:
-                outlist.extend(cls.__unpack_args(arg))
+                outlist.extend(cls._unpack_args(arg))
         else:
             outlist.append(str(arg_list))
 
@@ -1283,7 +1283,7 @@ class Git(LazyMixin):
         # Prepare the argument list
 
         opt_args = self.transform_kwargs(**opts_kwargs)
-        ext_args = self.__unpack_args([a for a in args if a is not None])
+        ext_args = self._unpack_args([a for a in args if a is not None])
 
         if insert_after_this_arg is None:
             args_list = opt_args + ext_args

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -4,6 +4,7 @@
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 from __future__ import annotations
+import re
 from contextlib import contextmanager
 import io
 import logging
@@ -24,7 +25,7 @@ from git.compat import (
 from git.exc import CommandError
 from git.util import is_cygwin_git, cygpath, expand_path, remove_password_if_present
 
-from .exc import GitCommandError, GitCommandNotFound
+from .exc import GitCommandError, GitCommandNotFound, UnsafeOptionError, UnsafeProtocolError
 from .util import (
     LazyMixin,
     stream_copy,
@@ -262,6 +263,8 @@ class Git(LazyMixin):
 
     _excluded_ = ("cat_file_all", "cat_file_header", "_version_info")
 
+    re_unsafe_protocol = re.compile("(.+)::.+")
+
     def __getstate__(self) -> Dict[str, Any]:
         return slots_to_dict(self, exclude=self._excluded_)
 
@@ -453,6 +456,48 @@ class Git(LazyMixin):
                 url = os.path.expanduser(url)
             url = url.replace("\\\\", "\\").replace("\\", "/")
         return url
+
+    @classmethod
+    def check_unsafe_protocols(cls, url: str) -> None:
+        """
+        Check for unsafe protocols.
+
+        Apart from the usual protocols (http, git, ssh),
+        Git allows "remote helpers" that have the form `<transport>::<address>`,
+        one of these helpers (`ext::`) can be used to invoke any arbitrary command.
+
+        See:
+
+        - https://git-scm.com/docs/gitremote-helpers
+        - https://git-scm.com/docs/git-remote-ext
+        """
+        match = cls.re_unsafe_protocol.match(url)
+        if match:
+            protocol = match.group(1)
+            raise UnsafeProtocolError(
+                f"The `{protocol}::` protocol looks suspicious, use `allow_unsafe_protocols=True` to allow it."
+            )
+
+    @classmethod
+    def check_unsafe_options(cls, options: List[str], unsafe_options: List[str]) -> None:
+        """
+        Check for unsafe options.
+
+        Some options that are passed to `git <command>` can be used to execute
+        arbitrary commands, this are blocked by default.
+        """
+        # Options can be of the form `foo` or `--foo bar` `--foo=bar`,
+        # so we need to check if they start with "--foo" or if they are equal to "foo".
+        bare_options = [
+            option.lstrip("-")
+            for option in unsafe_options
+        ]
+        for option in options:
+            for unsafe_option, bare_option in zip(unsafe_options, bare_options):
+                if option.startswith(unsafe_option) or option == bare_option:
+                    raise UnsafeOptionError(
+                        f"{unsafe_option} is not allowed, use `allow_unsafe_options=True` to allow it."
+                    )
 
     class AutoInterrupt(object):
         """Kill/Interrupt the stored process instance once this instance goes out of scope. It is

--- a/git/exc.py
+++ b/git/exc.py
@@ -37,8 +37,12 @@ class NoSuchPathError(GitError, OSError):
     """Thrown if a path could not be access by the system."""
 
 
-class UnsafeOptionsUsedError(GitError):
-    """Thrown if unsafe protocols or options are passed without overridding."""
+class UnsafeProtocolError(GitError):
+    """Thrown if unsafe protocols are passed without being explicitly allowed."""
+
+
+class UnsafeOptionError(GitError):
+    """Thrown if unsafe options are passed without being explicitly allowed."""
 
 
 class CommandError(GitError):

--- a/git/exc.py
+++ b/git/exc.py
@@ -37,6 +37,10 @@ class NoSuchPathError(GitError, OSError):
     """Thrown if a path could not be access by the system."""
 
 
+class UnsafeOptionsUsedError(GitError):
+    """Thrown if unsafe protocols or options are passed without overridding."""
+
+
 class CommandError(GitError):
     """Base class for exceptions thrown at every stage of `Popen()` execution.
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -272,7 +272,16 @@ class Submodule(IndexObject, TraversableIterableObj):
         # end
 
     @classmethod
-    def _clone_repo(cls, repo: "Repo", url: str, path: PathLike, name: str, **kwargs: Any) -> "Repo":
+    def _clone_repo(
+        cls,
+        repo: "Repo",
+        url: str,
+        path: PathLike,
+        name: str,
+        allow_unsafe_options: bool = False,
+        allow_unsafe_protocols: bool = False,
+        **kwargs: Any,
+    ) -> "Repo":
         """:return: Repo instance of newly cloned repository
         :param repo: our parent repository
         :param url: url to clone from
@@ -289,7 +298,13 @@ class Submodule(IndexObject, TraversableIterableObj):
             module_checkout_path = osp.join(str(repo.working_tree_dir), path)
         # end
 
-        clone = git.Repo.clone_from(url, module_checkout_path, **kwargs)
+        clone = git.Repo.clone_from(
+            url,
+            module_checkout_path,
+            allow_unsafe_options=allow_unsafe_options,
+            allow_unsafe_protocols=allow_unsafe_protocols,
+            **kwargs,
+        )
         if cls._need_gitfile_submodules(repo.git):
             cls._write_git_file_and_module_config(module_checkout_path, module_abspath)
         # end
@@ -359,6 +374,8 @@ class Submodule(IndexObject, TraversableIterableObj):
         depth: Union[int, None] = None,
         env: Union[Mapping[str, str], None] = None,
         clone_multi_options: Union[Sequence[TBD], None] = None,
+        allow_unsafe_options: bool = False,
+        allow_unsafe_protocols: bool = False,
     ) -> "Submodule":
         """Add a new submodule to the given repository. This will alter the index
         as well as the .gitmodules file, but will not create a new commit.
@@ -475,7 +492,16 @@ class Submodule(IndexObject, TraversableIterableObj):
                 kwargs["multi_options"] = clone_multi_options
 
             # _clone_repo(cls, repo, url, path, name, **kwargs):
-            mrepo = cls._clone_repo(repo, url, path, name, env=env, **kwargs)
+            mrepo = cls._clone_repo(
+                repo,
+                url,
+                path,
+                name,
+                env=env,
+                allow_unsafe_options=allow_unsafe_options,
+                allow_unsafe_protocols=allow_unsafe_protocols,
+                **kwargs,
+            )
         # END verify url
 
         ## See #525 for ensuring git urls in config-files valid under Windows.
@@ -520,6 +546,8 @@ class Submodule(IndexObject, TraversableIterableObj):
         keep_going: bool = False,
         env: Union[Mapping[str, str], None] = None,
         clone_multi_options: Union[Sequence[TBD], None] = None,
+        allow_unsafe_options: bool = False,
+        allow_unsafe_protocols: bool = False,
     ) -> "Submodule":
         """Update the repository of this submodule to point to the checkout
         we point at with the binsha of this instance.
@@ -643,6 +671,8 @@ class Submodule(IndexObject, TraversableIterableObj):
                         n=True,
                         env=env,
                         multi_options=clone_multi_options,
+                        allow_unsafe_options=allow_unsafe_options,
+                        allow_unsafe_protocols=allow_unsafe_protocols,
                     )
                 # END handle dry-run
                 progress.update(

--- a/git/remote.py
+++ b/git/remote.py
@@ -535,6 +535,23 @@ class Remote(LazyMixin, IterableObj):
     __slots__ = ("repo", "name", "_config_reader")
     _id_attribute_ = "name"
 
+    unsafe_git_fetch_options = [
+        # This option allows users to execute arbitrary commands.
+        # https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---upload-packltupload-packgt
+        "--upload-pack",
+    ]
+    unsafe_git_pull_options = [
+        # This option allows users to execute arbitrary commands.
+        # https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---upload-packltupload-packgt
+        "--upload-pack"
+    ]
+    unsafe_git_push_options = [
+        # This option allows users to execute arbitrary commands.
+        # https://git-scm.com/docs/git-push#Documentation/git-push.txt---execltgit-receive-packgt
+        "--receive-pack",
+        "--exec",
+    ]
+
     def __init__(self, repo: "Repo", name: str) -> None:
         """Initialize a remote instance
 
@@ -611,7 +628,9 @@ class Remote(LazyMixin, IterableObj):
             yield Remote(repo, section[lbound + 1 : rbound])
         # END for each configuration section
 
-    def set_url(self, new_url: str, old_url: Optional[str] = None, **kwargs: Any) -> "Remote":
+    def set_url(
+        self, new_url: str, old_url: Optional[str] = None, allow_unsafe_protocols: bool = False, **kwargs: Any
+    ) -> "Remote":
         """Configure URLs on current remote (cf command git remote set_url)
 
         This command manages URLs on the remote.
@@ -620,15 +639,17 @@ class Remote(LazyMixin, IterableObj):
         :param old_url: when set, replaces this URL with new_url for the remote
         :return: self
         """
+        if not allow_unsafe_protocols:
+            Git.check_unsafe_protocols(new_url)
         scmd = "set-url"
         kwargs["insert_kwargs_after"] = scmd
         if old_url:
-            self.repo.git.remote(scmd, self.name, new_url, old_url, **kwargs)
+            self.repo.git.remote(scmd, "--", self.name, new_url, old_url, **kwargs)
         else:
-            self.repo.git.remote(scmd, self.name, new_url, **kwargs)
+            self.repo.git.remote(scmd, "--", self.name, new_url, **kwargs)
         return self
 
-    def add_url(self, url: str, **kwargs: Any) -> "Remote":
+    def add_url(self, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
         """Adds a new url on current remote (special case of git remote set_url)
 
         This command adds new URLs to a given remote, making it possible to have
@@ -637,6 +658,8 @@ class Remote(LazyMixin, IterableObj):
         :param url: string being the URL to add as an extra remote URL
         :return: self
         """
+        if not allow_unsafe_protocols:
+            Git.check_unsafe_protocols(url)
         return self.set_url(url, add=True)
 
     def delete_url(self, url: str, **kwargs: Any) -> "Remote":
@@ -729,7 +752,7 @@ class Remote(LazyMixin, IterableObj):
         return out_refs
 
     @classmethod
-    def create(cls, repo: "Repo", name: str, url: str, **kwargs: Any) -> "Remote":
+    def create(cls, repo: "Repo", name: str, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
         """Create a new remote to the given repository
         :param repo: Repository instance that is to receive the new remote
         :param name: Desired name of the remote
@@ -739,7 +762,10 @@ class Remote(LazyMixin, IterableObj):
         :raise GitCommandError: in case an origin with that name already exists"""
         scmd = "add"
         kwargs["insert_kwargs_after"] = scmd
-        repo.git.remote(scmd, name, Git.polish_url(url), **kwargs)
+        url = Git.polish_url(url)
+        if not allow_unsafe_protocols:
+            Git.check_unsafe_protocols(url)
+        repo.git.remote(scmd, "--", name, url, **kwargs)
         return cls(repo, name)
 
     # add is an alias
@@ -921,6 +947,8 @@ class Remote(LazyMixin, IterableObj):
         progress: Union[RemoteProgress, None, "UpdateProgress"] = None,
         verbose: bool = True,
         kill_after_timeout: Union[None, float] = None,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> IterableList[FetchInfo]:
         """Fetch the latest changes for this remote
@@ -963,6 +991,14 @@ class Remote(LazyMixin, IterableObj):
         else:
             args = [refspec]
 
+        if not allow_unsafe_protocols:
+            for ref in args:
+                if ref:
+                    Git.check_unsafe_protocols(ref)
+
+        if not allow_unsafe_options:
+            Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=self.unsafe_git_fetch_options)
+
         proc = self.repo.git.fetch(
             "--", self, *args, as_process=True, with_stdout=False, universal_newlines=True, v=verbose, **kwargs
         )
@@ -976,6 +1012,8 @@ class Remote(LazyMixin, IterableObj):
         refspec: Union[str, List[str], None] = None,
         progress: Union[RemoteProgress, "UpdateProgress", None] = None,
         kill_after_timeout: Union[None, float] = None,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> IterableList[FetchInfo]:
         """Pull changes from the given branch, being the same as a fetch followed
@@ -990,6 +1028,16 @@ class Remote(LazyMixin, IterableObj):
             # No argument refspec, then ensure the repo's config has a fetch refspec.
             self._assert_refspec()
         kwargs = add_progress(kwargs, self.repo.git, progress)
+
+        if not allow_unsafe_protocols and refspec:
+            if isinstance(refspec, str):
+                Git.check_unsafe_protocols(refspec)
+            else:
+                for ref in refspec:
+                    Git.check_unsafe_protocols(ref)
+        if not allow_unsafe_options:
+            Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=self.unsafe_git_pull_options)
+
         proc = self.repo.git.pull(
             "--", self, refspec, with_stdout=False, as_process=True, universal_newlines=True, v=True, **kwargs
         )
@@ -1003,6 +1051,8 @@ class Remote(LazyMixin, IterableObj):
         refspec: Union[str, List[str], None] = None,
         progress: Union[RemoteProgress, "UpdateProgress", Callable[..., RemoteProgress], None] = None,
         kill_after_timeout: Union[None, float] = None,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> IterableList[PushInfo]:
         """Push changes from source branch in refspec to target branch in refspec.
@@ -1033,6 +1083,17 @@ class Remote(LazyMixin, IterableObj):
             If the operation fails completely, the length of the returned IterableList will
             be 0."""
         kwargs = add_progress(kwargs, self.repo.git, progress)
+
+        if not allow_unsafe_protocols and refspec:
+            if isinstance(refspec, str):
+                Git.check_unsafe_protocols(refspec)
+            else:
+                for ref in refspec:
+                    Git.check_unsafe_protocols(ref)
+
+        if not allow_unsafe_options:
+            Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=self.unsafe_git_push_options)
+
         proc = self.repo.git.push(
             "--",
             self,

--- a/git/remote.py
+++ b/git/remote.py
@@ -1029,12 +1029,11 @@ class Remote(LazyMixin, IterableObj):
             self._assert_refspec()
         kwargs = add_progress(kwargs, self.repo.git, progress)
 
-        if not allow_unsafe_protocols and refspec:
-            if isinstance(refspec, str):
-                Git.check_unsafe_protocols(refspec)
-            else:
-                for ref in refspec:
-                    Git.check_unsafe_protocols(ref)
+        refspec = Git._unpack_args(refspec or [])
+        if not allow_unsafe_protocols:
+            for ref in refspec:
+                Git.check_unsafe_protocols(ref)
+
         if not allow_unsafe_options:
             Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=self.unsafe_git_pull_options)
 
@@ -1084,12 +1083,10 @@ class Remote(LazyMixin, IterableObj):
             be 0."""
         kwargs = add_progress(kwargs, self.repo.git, progress)
 
-        if not allow_unsafe_protocols and refspec:
-            if isinstance(refspec, str):
-                Git.check_unsafe_protocols(refspec)
-            else:
-                for ref in refspec:
-                    Git.check_unsafe_protocols(ref)
+        refspec = Git._unpack_args(refspec or [])
+        if not allow_unsafe_protocols:
+            for ref in refspec:
+                Git.check_unsafe_protocols(ref)
 
         if not allow_unsafe_options:
             Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=self.unsafe_git_push_options)

--- a/git/remote.py
+++ b/git/remote.py
@@ -658,9 +658,7 @@ class Remote(LazyMixin, IterableObj):
         :param url: string being the URL to add as an extra remote URL
         :return: self
         """
-        if not allow_unsafe_protocols:
-            Git.check_unsafe_protocols(url)
-        return self.set_url(url, add=True)
+        return self.set_url(url, add=True, allow_unsafe_protocols=allow_unsafe_protocols)
 
     def delete_url(self, url: str, **kwargs: Any) -> "Remote":
         """Deletes a new url on current remote (special case of git remote set_url)

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -25,7 +25,6 @@ from git.exc import (
     GitCommandError,
     InvalidGitRepositoryError,
     NoSuchPathError,
-    UnsafeOptionsUsedError,
 )
 from git.index import IndexFile
 from git.objects import Submodule, RootModule, Commit
@@ -133,7 +132,18 @@ class Repo(object):
     re_envvars = re.compile(r"(\$(\{\s?)?[a-zA-Z_]\w*(\}\s?)?|%\s?[a-zA-Z_]\w*\s?%)")
     re_author_committer_start = re.compile(r"^(author|committer)")
     re_tab_full_line = re.compile(r"^\t(.*)$")
-    re_config_protocol_option = re.compile(r"-[-]?c(|onfig)\s+protocol\.", re.I)
+
+    unsafe_git_clone_options = [
+        # This option allows users to execute arbitrary commands.
+        # https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---upload-packltupload-packgt
+        "--upload-pack",
+        "-u",
+        # Users can override configuration variables
+        # like `protocol.allow` or `core.gitProxy` to execute arbitrary commands.
+        # https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---configltkeygtltvaluegt
+        "--config",
+        "-c",
+    ]
 
     # invariants
     # represents the configuration level of a configuration file
@@ -961,7 +971,7 @@ class Repo(object):
         file: str,
         incremental: bool = False,
         rev_opts: Optional[List[str]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> List[List[Commit | List[str | bytes] | None]] | Iterator[BlameEntry] | None:
         """The blame information for the given file at the given revision.
 
@@ -1152,6 +1162,8 @@ class Repo(object):
         odb_default_type: Type[GitCmdObjectDB],
         progress: Union["RemoteProgress", "UpdateProgress", Callable[..., "RemoteProgress"], None] = None,
         multi_options: Optional[List[str]] = None,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> "Repo":
         odbt = kwargs.pop("odbt", odb_default_type)
@@ -1173,6 +1185,12 @@ class Repo(object):
         multi = None
         if multi_options:
             multi = shlex.split(" ".join(multi_options))
+
+        if not allow_unsafe_protocols:
+            Git.check_unsafe_protocols(str(url))
+        if not allow_unsafe_options and multi_options:
+            Git.check_unsafe_options(options=multi_options, unsafe_options=cls.unsafe_git_clone_options)
+
         proc = git.clone(
             multi,
             "--",
@@ -1221,27 +1239,13 @@ class Repo(object):
         # END handle remote repo
         return repo
 
-    @classmethod
-    def unsafe_options(
-        cls,
-        url: str,
-        multi_options: Optional[List[str]] = None,
-    ) -> bool:
-        if "ext::" in url:
-            return True
-        if multi_options is not None:
-            if any(["--upload-pack" in m for m in multi_options]):
-                return True
-            if any([re.match(cls.re_config_protocol_option, m) for m in multi_options]):
-                return True
-        return False
-
     def clone(
         self,
         path: PathLike,
         progress: Optional[Callable] = None,
         multi_options: Optional[List[str]] = None,
-        unsafe_protocols: bool = False,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> "Repo":
         """Create a clone from this repository.
@@ -1259,8 +1263,6 @@ class Repo(object):
             * All remaining keyword arguments are given to the git-clone command
 
         :return: ``git.Repo`` (the newly cloned repo)"""
-        if not unsafe_protocols and self.unsafe_options(path, multi_options):
-            raise UnsafeOptionsUsedError(f"{path} requires unsafe_protocols flag")
         return self._clone(
             self.git,
             self.common_dir,
@@ -1268,6 +1270,8 @@ class Repo(object):
             type(self.odb),
             progress,
             multi_options,
+            allow_unsafe_protocols=allow_unsafe_protocols,
+            allow_unsafe_options=allow_unsafe_options,
             **kwargs,
         )
 
@@ -1279,7 +1283,8 @@ class Repo(object):
         progress: Optional[Callable] = None,
         env: Optional[Mapping[str, str]] = None,
         multi_options: Optional[List[str]] = None,
-        unsafe_protocols: bool = False,
+        allow_unsafe_protocols: bool = False,
+        allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> "Repo":
         """Create a clone from the given URL
@@ -1300,9 +1305,17 @@ class Repo(object):
         git = cls.GitCommandWrapperType(os.getcwd())
         if env is not None:
             git.update_environment(**env)
-        if not unsafe_protocols and cls.unsafe_options(url, multi_options):
-            raise UnsafeOptionsUsedError(f"{url} requires unsafe_protocols flag")
-        return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
+        return cls._clone(
+            git,
+            url,
+            to_path,
+            GitCmdObjectDB,
+            progress,
+            multi_options,
+            allow_unsafe_protocols=allow_unsafe_protocols,
+            allow_unsafe_options=allow_unsafe_options,
+            **kwargs,
+        )
 
     def archive(
         self,

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -39,12 +39,12 @@ class TestGit(TestBase):
         self.assertEqual(git.call_args, ((["git", "version"],), {}))
 
     def test_call_unpack_args_unicode(self):
-        args = Git._Git__unpack_args("Unicode€™")
+        args = Git._unpack_args("Unicode€™")
         mangled_value = "Unicode\u20ac\u2122"
         self.assertEqual(args, [mangled_value])
 
     def test_call_unpack_args(self):
-        args = Git._Git__unpack_args(["git", "log", "--", "Unicode€™"])
+        args = Git._unpack_args(["git", "log", "--", "Unicode€™"])
         mangled_value = "Unicode\u20ac\u2122"
         self.assertEqual(args, ["git", "log", "--", mangled_value])
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -694,84 +694,107 @@ class TestRemote(TestBase):
 
     @with_rw_repo("HEAD")
     def test_set_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 remote.set_url(url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_set_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             remote.set_url(url, allow_unsafe_protocols=True)
             assert list(remote.urls)[-1] == url
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_add_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 remote.add_url(url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_add_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             remote.add_url(url, allow_unsafe_protocols=True)
             assert list(remote.urls)[-1] == url
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_create_remote_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 Remote.create(rw_repo, "origin", url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_create_remote_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for i, url in enumerate(urls):
             remote = Remote.create(rw_repo, f"origin{i}", url, allow_unsafe_protocols=True)
             assert remote.url == url
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_fetch_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 remote.fetch(url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_fetch_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
@@ -779,6 +802,7 @@ class TestRemote(TestBase):
             # fail since we don't have that protocol enabled in the Git config file.
             with self.assertRaises(GitCommandError):
                 remote.fetch(url, allow_unsafe_protocols=True)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_fetch_unsafe_options(self, rw_repo):
@@ -789,6 +813,7 @@ class TestRemote(TestBase):
         for unsafe_option in unsafe_options:
             with self.assertRaises(UnsafeOptionError):
                 remote.fetch(**unsafe_option)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_fetch_unsafe_options_allowed(self, rw_repo):
@@ -798,25 +823,32 @@ class TestRemote(TestBase):
         unsafe_options = [{"upload-pack": f"touch {tmp_file}"}]
         for unsafe_option in unsafe_options:
             # The options will be allowed, but the command will fail.
+            assert not tmp_file.exists()
             with self.assertRaises(GitCommandError):
                 remote.fetch(**unsafe_option, allow_unsafe_options=True)
+            assert tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_pull_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 remote.pull(url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_pull_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
@@ -824,6 +856,7 @@ class TestRemote(TestBase):
             # fail since we don't have that protocol enabled in the Git config file.
             with self.assertRaises(GitCommandError):
                 remote.pull(url, allow_unsafe_protocols=True)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_pull_unsafe_options(self, rw_repo):
@@ -834,6 +867,7 @@ class TestRemote(TestBase):
         for unsafe_option in unsafe_options:
             with self.assertRaises(UnsafeOptionError):
                 remote.pull(**unsafe_option)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_pull_unsafe_options_allowed(self, rw_repo):
@@ -843,25 +877,32 @@ class TestRemote(TestBase):
         unsafe_options = [{"upload-pack": f"touch {tmp_file}"}]
         for unsafe_option in unsafe_options:
             # The options will be allowed, but the command will fail.
+            assert not tmp_file.exists()
             with self.assertRaises(GitCommandError):
                 remote.pull(**unsafe_option, allow_unsafe_options=True)
+            assert tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_push_unsafe_url(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
             with self.assertRaises(UnsafeProtocolError):
                 remote.push(url)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_push_unsafe_url_allowed(self, rw_repo):
+        tmp_dir = Path(tempfile.mkdtemp())
+        tmp_file = tmp_dir / "pwn"
         remote = rw_repo.remote("origin")
         urls = [
-            "ext::sh -c touch% /tmp/pwn",
+            f"ext::sh -c touch% {tmp_file}",
             "fd::17/foo",
         ]
         for url in urls:
@@ -869,6 +910,7 @@ class TestRemote(TestBase):
             # fail since we don't have that protocol enabled in the Git config file.
             with self.assertRaises(GitCommandError):
                 remote.push(url, allow_unsafe_protocols=True)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_push_unsafe_options(self, rw_repo):
@@ -882,8 +924,10 @@ class TestRemote(TestBase):
             }
         ]
         for unsafe_option in unsafe_options:
+            assert not tmp_file.exists()
             with self.assertRaises(UnsafeOptionError):
                 remote.push(**unsafe_option)
+            assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")
     def test_push_unsafe_options_allowed(self, rw_repo):
@@ -898,8 +942,11 @@ class TestRemote(TestBase):
         ]
         for unsafe_option in unsafe_options:
             # The options will be allowed, but the command will fail.
+            assert not tmp_file.exists()
             with self.assertRaises(GitCommandError):
                 remote.push(**unsafe_option, allow_unsafe_options=True)
+            assert tmp_file.exists()
+            tmp_file.unlink()
 
 
 class TestTimeouts(TestBase):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -38,7 +38,8 @@ from git import (
 )
 from git.exc import (
     BadObject,
-    UnsafeOptionsUsedError,
+    UnsafeOptionError,
+    UnsafeProtocolError,
 )
 from git.repo.fun import touch
 from test.lib import TestBase, with_rw_repo, fixture
@@ -281,7 +282,7 @@ class TestRepo(TestBase):
         self.assertTrue(Repo.unsafe_options("", ["--config protocol.foo"]))
 
     def test_clone_from_forbids_helper_urls_by_default(self):
-        with self.assertRaises(UnsafeOptionsUsedError):
+        with self.assertRaises(UnsafeOptionError):
             Repo.clone_from("ext::sh -c touch% /tmp/foo", "tmp")
 
     @with_rw_repo("HEAD")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1026,7 +1026,7 @@ class TestSubmodule(TestBase):
         )
 
         # Act
-        sm.update(init=True, clone_multi_options=["--config core.eol=true"])
+        sm.update(init=True, clone_multi_options=["--config core.eol=true"], allow_unsafe_options=True)
 
         # Assert
         sm_config = GitConfigParser(file_or_files=osp.join(parent.git_dir, "modules", sm_name, "config"))
@@ -1070,6 +1070,7 @@ class TestSubmodule(TestBase):
             sm_name,
             url=self._small_repo_url(),
             clone_multi_options=["--config core.eol=true"],
+            allow_unsafe_options=True,
         )
 
         # Assert


### PR DESCRIPTION
This got a little longer than expected :face_exhaling:, there were other places where git accepted `ext::` URLs, like `git pull/push/fetch <URL>` https://git-scm.com/docs/git-remote-ext#_examples

And there are other config options that can be harmful, so I think we should just forbid the `--config` option, if anyone is relying on that option, they can opt-out with `allow_unsafe_options=True`.

`--*-pack` and `--exec` are the options that I found that could lead to RCE, but anyone allowing users to pass arbitrary options should be aware that it may be more of these, don't know.

This is still missing adding/updating tests.


This is on top of https://github.com/gitpython-developers/GitPython/pull/1516
Fixes https://github.com/gitpython-developers/GitPython/issues/1515
