### PR TITLE
Fix type hint on create_tag

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -482,7 +482,7 @@ class Repo(object):
     def create_tag(
         self,
         path: PathLike,
-        ref: str = "HEAD",
+        ref: Union[str, 'SymbolicReference'] = "HEAD",
         message: Optional[str] = None,
         force: bool = False,
         **kwargs: Any,


### PR DESCRIPTION
pycharm yells at me without this