### PR TITLE
tests: Use `command -v` instead of third-party `which` program

### DIFF
--- a/test/test_git.py
+++ b/test/test_git.py
@@ -169,7 +169,7 @@ class TestGit(TestBase):
         self.assertRaises(GitCommandNotFound, refresh, "yada")
 
         # test a good path refresh
-        which_cmd = "where" if is_win else "which"
+        which_cmd = "where" if is_win else "command -v"
         path = os.popen("{0} git".format(which_cmd)).read().strip().split("\n")[0]
         refresh(path)
 


### PR DESCRIPTION
Use `command -v` to locate the git executable instead of `which`. The former is guaranteed to always be available according to POSIX, while which(1) is a redundant third-party tool that is slowly being phased out from Linux distributions.  In particular, Gentoo no longer installs it by default.