### PR TITLE
Proposed change to get_values behavior

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -796,6 +796,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :raise TypeError: in case the value could not be understood
             Otherwise the exceptions known to the ConfigParser will be raised."""
         try:
+            self.sections()
             lst = self._sections[section].getall(option)
         except Exception:
             if default is not None:


### PR DESCRIPTION
get_values() did not load existing sections before checking the `_sections` property.

**NOTE:** Haven't written a test to check for this yet.