### PR TITLE
fix files list on file rename

### DIFF
--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -324,14 +324,14 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
         :return: git.Stats"""
         if not self.parents:
-            text = self.repo.git.diff_tree(self.hexsha, "--", numstat=True, root=True)
+            text = self.repo.git.diff_tree(self.hexsha, "--", numstat=True, no_renames=True, root=True)
             text2 = ""
             for line in text.splitlines()[1:]:
                 (insertions, deletions, filename) = line.split("\t")
                 text2 += "%s\t%s\t%s\n" % (insertions, deletions, filename)
             text = text2
         else:
-            text = self.repo.git.diff(self.parents[0].hexsha, self.hexsha, "--", numstat=True)
+            text = self.repo.git.diff(self.parents[0].hexsha, self.hexsha, "--", numstat=True, no_renames=True)
         return Stats._list_from_string(self.repo, text)
 
     @property


### PR DESCRIPTION
GitPython parses the output of `git diff --no-renames` to get the files changed in a commit.
This breaks when a commit contains a file rename, because the output of `git diff` is different than expected.
This is the output of a normal commit:
```
$ git diff --numstat 6ab9810cfe6c^ 6ab9810cfe6c
5       2       drivers/clk/zynqmp/divider.c
```
And this a commit containing a rename:
```
$ git diff --numstat db401875f438^ db401875f438
1       1       tools/testing/selftests/drivers/net/mlxsw/{spectrum-2 => }/devlink_trap_tunnel_ipip6.sh
```
This can be triggered by this code:
```python
for commit in repo.iter_commits():
    print(commit.hexsha)
        for file in commit.stats.files:
            print(file)
```
Which will print for the normal commit:
```
6ab9810cfe6c8f3d8b8750c827d7870abd3751b9
'drivers/clk/zynqmp/divider.c'
```
And when there is a rename:
```
db401875f438168c5804b295b93a28c7730bb57a
('tools/testing/selftests/drivers/net/mlxsw/{spectrum-2 => '
'}/devlink_trap_tunnel_ipip6.sh')
```
Fix this by pasing the --no-renames option to `git diff` which ignores renames and print the same output as if the file was deleted from the old path and created in the new one:
```
$ git diff --numstat --no-renames db401875f438^ db401875f438
250     0       tools/testing/selftests/drivers/net/mlxsw/devlink_trap_tunnel_ipip6.sh
0       250     tools/testing/selftests/drivers/net/mlxsw/spectrum-2/devlink_trap_tunnel_ipip6.sh
````