### PR TITLE
Fix ignored

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -873,8 +873,15 @@ class Repo(object):
         """
         try:
             proc: str = self.git.check_ignore(*paths)
-        except GitCommandError:
-            return []
+        except GitCommandError as err:
+            # If return code is 1, this means none of the items in *paths
+            # are ignored by Git, so return an empty list.  Raise the
+            # exception on all other return codes.
+            if err.status == 1:
+                return []
+            else:
+                raise
+
         return proc.replace("\\\\", "\\").replace('"', "").split("\n")
 
     @property

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1400,3 +1400,14 @@ class TestRepo(TestBase):
             assert temp_repo.ignored(['ignored_file.txt']) == ['ignored_file.txt']
             assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt']) == ['ignored_file.txt']
             assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt', 'included_dir/file.txt', 'ignored_dir/file.txt']) == ['ignored_file.txt', 'ignored_dir/file.txt']
+
+    def test_ignored_raises_error_w_symlink(self):
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp_dir = pathlib.Path(tdir)
+            temp_repo = Repo.init(tmp_dir / "repo")
+
+            os.mkdir(tmp_dir / "target")
+            os.symlink(tmp_dir / "target", tmp_dir / "symlink")
+
+            with pytest.raises(GitCommandError):
+                temp_repo.ignored(tmp_dir / "symlink/file.txt")

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1384,3 +1384,19 @@ class TestRepo(TestBase):
                 rw_repo.clone_from(payload, temp_repo.common_dir)
 
             assert not unexpected_file.exists()
+
+    def test_ignored_items_reported(self):
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp_dir = pathlib.Path(tdir)
+            temp_repo = Repo.init(tmp_dir / "repo")
+
+            gi = tmp_dir / "repo" / ".gitignore"
+
+            with open(gi, 'w') as file:
+                file.write('ignored_file.txt\n')
+                file.write('ignored_dir/\n')
+
+            assert temp_repo.ignored(['included_file.txt', 'included_dir/file.txt']) == []
+            assert temp_repo.ignored(['ignored_file.txt']) == ['ignored_file.txt']
+            assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt']) == ['ignored_file.txt']
+            assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt', 'included_dir/file.txt', 'ignored_dir/file.txt']) == ['ignored_file.txt', 'ignored_dir/file.txt']


### PR DESCRIPTION
* Add test to sanity-check basic behavior of `ignored()` method
* Add test to verify GitCommandError is raised if `git check-ignore` returns any error code other than 1
* Modify `ignred()` method to raise GitCommandError if `git check-ignore` returns any error code other than 1