### PR TITLE
Fix RecursionError when iterating streams

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -701,8 +701,7 @@ class Git(LazyMixin):
 
             return line
 
-        def next(self) -> bytes:
-            return next(self)
+        next = __next__
 
         def __del__(self) -> None:
             bytes_left = self._size - self._nbr

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -695,14 +695,14 @@ class Git(LazyMixin):
             return self
 
         def __next__(self) -> bytes:
-            return next(self)
-
-        def next(self) -> bytes:
             line = self.readline()
             if not line:
                 raise StopIteration
 
             return line
+
+        def next(self) -> bytes:
+            return next(self)
 
         def __del__(self) -> None:
             bytes_left = self._size - self._nbr


### PR DESCRIPTION
`next(self)` was previously just a recursive call that does nothing.

This now implements `__next__` using the actual implementation, and lets the python2-compatibility `next()` just wrap it.