### PR TITLE
Fix get_values() so it correctly loads section names

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -796,6 +796,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :raise TypeError: in case the value could not be understood
             Otherwise the exceptions known to the ConfigParser will be raised."""
         try:
+            self.sections()
             lst = self._sections[section].getall(option)
         except Exception:
             if default is not None:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -398,6 +398,17 @@ class TestBase(TestCase):
         with self.assertRaises(cp.NoOptionError):
             cr.get_value("color", "ui")
 
+    def test_get_values_works_without_requiring_any_other_calls_first(self):
+        file_obj = self._to_memcache(fixture_path("git_config_multiple"))
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section0", "option0"), ["value0"])
+        file_obj.seek(0)
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section1", "option1"), ["value1a", "value1b"])
+        file_obj.seek(0)
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section1", "other_option1"), ["other_value1"])
+
     def test_multiple_values(self):
         file_obj = self._to_memcache(fixture_path("git_config_multiple"))
         with GitConfigParser(file_obj, read_only=False) as cw:


### PR DESCRIPTION
As described in https://github.com/gitpython-developers/GitPython/issues/1534, some calls to GitConfigParser().get_values() fail in main with a `KeyError` about a missing section name even though the named sections do exist within the config file.

Add a test that calls get_values() before anything else to catch this failure. Update the get_values() function to work, even if it's the first call after creating the GitConfigParser, by eagerly load the section names before trying to access them. This passes the new test.