### PR TITLE
Fix up the commit trailers functionality

### DIFF
--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -336,24 +336,6 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         return Stats._list_from_string(self.repo, text)
 
     @property
-    def trailers(self) -> Dict[str, str]:
-        """Get the trailers of the message as a dictionary
-
-        Git messages can contain trailer information that are similar to RFC 822
-        e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
-
-        WARNING: This function only returns the latest instance of each trailer key
-        and will be deprecated soon. Please see either ``Commit.trailers_list`` or ``Commit.trailers_dict``.
-
-        :return:
-            Dictionary containing whitespace stripped trailer information.
-            Only the latest instance of each trailer key.
-        """
-        return {
-            k: v[0] for k, v in self.trailers_dict.items()
-        }
-
-    @property
     def trailers_list(self) -> List[str]:
         """Get the trailers of the message as a list
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -336,6 +336,20 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         return Stats._list_from_string(self.repo, text)
 
     @property
+    def trailers(self) -> Dict[str, str]:
+        """Get the trailers of the message as a dictionary
+
+        :note: This property is deprecated, please use either ``Commit.trailers_list`` or ``Commit.trailers_dict``.
+
+        :return:
+            Dictionary containing whitespace stripped trailer information.
+            Only contains the latest instance of each trailer key.
+        """
+        return {
+            k: v[0] for k, v in self.trailers_dict.items()
+        }
+
+    @property
     def trailers_list(self) -> List[Tuple[str, str]]:
         """Get the trailers of the message as a list
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -372,7 +372,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """
         cmd = ["git", "interpret-trailers", "--parse"]
         proc: Git.AutoInterrupt = self.repo.git.execute(cmd, as_process=True, istream=PIPE)  # type: ignore
-        trailer: str = proc.communicate(str(self.message).encode())[0].decode()
+        trailer: str = proc.communicate(str(self.message).encode())[0].decode("utf8")
         trailer = trailer.strip()
 
         if not trailer:

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -523,10 +523,6 @@ JzJMZDRLQLFvnzqZuCjE
                 KEY_1: [VALUE_1_1, VALUE_1_2],
                 KEY_2: [VALUE_2],
             }
-            assert commit.trailers == {
-                KEY_1: VALUE_1_1,
-                KEY_2: VALUE_2,
-            }
 
         # check that trailer stays empty for multiple msg combinations
         msgs = [
@@ -543,14 +539,12 @@ JzJMZDRLQLFvnzqZuCjE
             commit.message = msg
             assert commit.trailers_list == []
             assert commit.trailers_dict == {}
-            assert commit.trailers == {}
 
         # check that only the last key value paragraph is evaluated
         commit = copy.copy(self.rorepo.commit("master"))
         commit.message = f"Subject\n\nMultiline\nBody\n\n{KEY_1}: {VALUE_1_1}\n\n{KEY_2}: {VALUE_2}\n"
         assert commit.trailers_list == [f"{KEY_2}: {VALUE_2}"]
         assert commit.trailers_dict == {KEY_2: [VALUE_2]}
-        assert commit.trailers == {KEY_2: VALUE_2}
 
     def test_commit_co_authors(self):
         commit = copy.copy(self.rorepo.commit("4251bd5"))

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -494,52 +494,63 @@ JzJMZDRLQLFvnzqZuCjE
 
     def test_trailers(self):
         KEY_1 = "Hello"
-        VALUE_1 = "World"
+        VALUE_1_1 = "World"
+        VALUE_1_2 = "Another-World"
         KEY_2 = "Key"
         VALUE_2 = "Value with inner spaces"
 
-        # Check if KEY 1 & 2 with Value 1 & 2 is extracted from multiple msg variations
-        msgs = []
-        msgs.append(f"Subject\n\n{KEY_1}: {VALUE_1}\n{KEY_2}: {VALUE_2}\n")
-        msgs.append(f"Subject\n  \nSome body of a function\n \n{KEY_1}: {VALUE_1}\n{KEY_2}: {VALUE_2}\n")
-        msgs.append(
-            f"Subject\n  \nSome body of a function\n\nnon-key: non-value\n\n{KEY_1}: {VALUE_1}\n{KEY_2}: {VALUE_2}\n"
-        )
-        msgs.append(
-            f"Subject\n  \nSome multiline\n body of a function\n\nnon-key: non-value\n\n{KEY_1}: {VALUE_1}\n{KEY_2} :      {VALUE_2}\n"
-        )
+        # Check the following trailer example is extracted from multiple msg variations
+        TRAILER = f"{KEY_1}: {VALUE_1_1}\n{KEY_2}: {VALUE_2}\n{KEY_1}: {VALUE_1_2}"
+        msgs = [
+            f"Subject\n\n{TRAILER}\n",
+            f"Subject\n  \nSome body of a function\n \n{TRAILER}\n",
+            f"Subject\n  \nSome body of a function\n\nnon-key: non-value\n\n{TRAILER}\n",
+            (
+                # check when trailer has inconsistent whitespace
+                f"Subject\n  \nSome multiline\n body of a function\n\nnon-key: non-value\n\n"
+                f"{KEY_1}:{VALUE_1_1}\n{KEY_2} :      {VALUE_2}\n{KEY_1}:    {VALUE_1_2}\n"
+            ),
+        ]
+        for msg in msgs:
+            commit = copy.copy(self.rorepo.commit("master"))
+            commit.message = msg
+            assert commit.trailers_list == [
+                f"{KEY_1}: {VALUE_1_1}",
+                f"{KEY_2}: {VALUE_2}",
+                f"{KEY_1}: {VALUE_1_2}",
+            ]
+            assert commit.trailers_dict == {
+                KEY_1: [VALUE_1_1, VALUE_1_2],
+                KEY_2: [VALUE_2],
+            }
+            assert commit.trailers == {
+                KEY_1: VALUE_1_1,
+                KEY_2: VALUE_2,
+            }
+
+        # check that trailer stays empty for multiple msg combinations
+        msgs = [
+            f"Subject\n",
+            f"Subject\n\nBody with some\nText\n",
+            f"Subject\n\nBody with\nText\n\nContinuation but\n doesn't contain colon\n",
+            f"Subject\n\nBody with\nText\n\nContinuation but\n only contains one :\n",
+            f"Subject\n\nBody with\nText\n\nKey: Value\nLine without colon\n",
+            f"Subject\n\nBody with\nText\n\nLine without colon\nKey: Value\n",
+        ]
 
         for msg in msgs:
-            commit = self.rorepo.commit("master")
-            commit = copy.copy(commit)
+            commit = copy.copy(self.rorepo.commit("master"))
             commit.message = msg
-            assert KEY_1 in commit.trailers.keys()
-            assert KEY_2 in commit.trailers.keys()
-            assert commit.trailers[KEY_1] == VALUE_1
-            assert commit.trailers[KEY_2] == VALUE_2
-
-        # Check that trailer stays empty for multiple msg combinations
-        msgs = []
-        msgs.append(f"Subject\n")
-        msgs.append(f"Subject\n\nBody with some\nText\n")
-        msgs.append(f"Subject\n\nBody with\nText\n\nContinuation but\n doesn't contain colon\n")
-        msgs.append(f"Subject\n\nBody with\nText\n\nContinuation but\n only contains one :\n")
-        msgs.append(f"Subject\n\nBody with\nText\n\nKey: Value\nLine without colon\n")
-        msgs.append(f"Subject\n\nBody with\nText\n\nLine without colon\nKey: Value\n")
-
-        for msg in msgs:
-            commit = self.rorepo.commit("master")
-            commit = copy.copy(commit)
-            commit.message = msg
-            assert len(commit.trailers.keys()) == 0
+            assert commit.trailers_list == []
+            assert commit.trailers_dict == {}
+            assert commit.trailers == {}
 
         # check that only the last key value paragraph is evaluated
-        commit = self.rorepo.commit("master")
-        commit = copy.copy(commit)
-        commit.message = f"Subject\n\nMultiline\nBody\n\n{KEY_1}: {VALUE_1}\n\n{KEY_2}: {VALUE_2}\n"
-        assert KEY_1 not in commit.trailers.keys()
-        assert KEY_2 in commit.trailers.keys()
-        assert commit.trailers[KEY_2] == VALUE_2
+        commit = copy.copy(self.rorepo.commit("master"))
+        commit.message = f"Subject\n\nMultiline\nBody\n\n{KEY_1}: {VALUE_1_1}\n\n{KEY_2}: {VALUE_2}\n"
+        assert commit.trailers_list == [f"{KEY_2}: {VALUE_2}"]
+        assert commit.trailers_dict == {KEY_2: [VALUE_2]}
+        assert commit.trailers == {KEY_2: VALUE_2}
 
     def test_commit_co_authors(self):
         commit = copy.copy(self.rorepo.commit("4251bd5"))

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -515,9 +515,9 @@ JzJMZDRLQLFvnzqZuCjE
             commit = copy.copy(self.rorepo.commit("master"))
             commit.message = msg
             assert commit.trailers_list == [
-                f"{KEY_1}: {VALUE_1_1}",
-                f"{KEY_2}: {VALUE_2}",
-                f"{KEY_1}: {VALUE_1_2}",
+                (KEY_1, VALUE_1_1),
+                (KEY_2, VALUE_2),
+                (KEY_1, VALUE_1_2),
             ]
             assert commit.trailers_dict == {
                 KEY_1: [VALUE_1_1, VALUE_1_2],
@@ -543,7 +543,7 @@ JzJMZDRLQLFvnzqZuCjE
         # check that only the last key value paragraph is evaluated
         commit = copy.copy(self.rorepo.commit("master"))
         commit.message = f"Subject\n\nMultiline\nBody\n\n{KEY_1}: {VALUE_1_1}\n\n{KEY_2}: {VALUE_2}\n"
-        assert commit.trailers_list == [f"{KEY_2}: {VALUE_2}"]
+        assert commit.trailers_list == [(KEY_2, VALUE_2)]
         assert commit.trailers_dict == {KEY_2: [VALUE_2]}
 
     def test_commit_co_authors(self):


### PR DESCRIPTION
Add trailers_dict and trailers_list methods to fix the commit trailers functionality.

I left the existing method as is to not break any existing code using it, leaving a comment about how it's incorrect.

Also updated the trailers tests.

Work here resolves issue https://github.com/gitpython-developers/GitPython/issues/1533