### PR TITLE
Block insecure non-multi options in clone/clone_from

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1203,6 +1203,8 @@ class Repo(object):
 
         if not allow_unsafe_protocols:
             Git.check_unsafe_protocols(str(url))
+        if not allow_unsafe_options:
+            Git.check_unsafe_options(options=list(kwargs.keys()), unsafe_options=cls.unsafe_git_clone_options)
         if not allow_unsafe_options and multi_options:
             Git.check_unsafe_options(options=multi_options, unsafe_options=cls.unsafe_git_clone_options)
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -282,6 +282,17 @@ class TestRepo(TestBase):
                     rw_repo.clone(tmp_dir, multi_options=[unsafe_option])
                 assert not tmp_file.exists()
 
+            unsafe_options = [
+                {"upload-pack": f"touch {tmp_file}"},
+                {"u": f"touch {tmp_file}"},
+                {"config": "protocol.ext.allow=always"},
+                {"c": "protocol.ext.allow=always"},
+            ]
+            for unsafe_option in unsafe_options:
+                with self.assertRaises(UnsafeOptionError):
+                    rw_repo.clone(tmp_dir, **unsafe_option)
+                assert not tmp_file.exists()
+
     @with_rw_repo("HEAD")
     def test_clone_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:
@@ -339,6 +350,17 @@ class TestRepo(TestBase):
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
                     Repo.clone_from(rw_repo.working_dir, tmp_dir, multi_options=[unsafe_option])
+                assert not tmp_file.exists()
+
+            unsafe_options = [
+                {"upload-pack": f"touch {tmp_file}"},
+                {"u": f"touch {tmp_file}"},
+                {"config": "protocol.ext.allow=always"},
+                {"c": "protocol.ext.allow=always"},
+            ]
+            for unsafe_option in unsafe_options:
+                with self.assertRaises(UnsafeOptionError):
+                    Repo.clone_from(rw_repo.working_dir, tmp_dir, **unsafe_option)
                 assert not tmp_file.exists()
 
     @with_rw_repo("HEAD")


### PR DESCRIPTION
I'm part of the Debian LTS (Long Term Support) Team and I'm working on integrating the fix for CVE-2022-24439 for GitPython in Debian.

After contacting @Byron privately we determined that #1521 would need a follow-up fix, which I hereby propose in this PR.

I also modified 2 tests to validate the change, but I'm not sure if we want to double-check (multi/non-multi) all the currenttt clone/clone_from tests, so I didn't, but I can do so if necessary.