### PR TITLE
Fix CVE-2023-40590

### DIFF
--- a/test/test_git.py
+++ b/test/test_git.py
@@ -4,10 +4,12 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
+import contextlib
 import os
+import shutil
 import subprocess
 import sys
-from tempfile import TemporaryFile
+from tempfile import TemporaryDirectory, TemporaryFile
 from unittest import mock
 
 from git import Git, refresh, GitCommandError, GitCommandNotFound, Repo, cmd
@@ -18,6 +20,17 @@ from git.util import finalize_process
 import os.path as osp
 
 from git.compat import is_win
+
+
+@contextlib.contextmanager
+def _chdir(new_dir):
+    """Context manager to temporarily change directory. Not reentrant."""
+    old_dir = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)
 
 
 class TestGit(TestBase):
@@ -74,6 +87,23 @@ class TestGit(TestBase):
 
     def test_it_executes_git_to_shell_and_returns_result(self):
         self.assertRegex(self.git.execute(["git", "version"]), r"^git version [\d\.]{2}.*$")
+
+    def test_it_executes_git_not_from_cwd(self):
+        with TemporaryDirectory() as tmpdir:
+            if is_win:
+                # Copy an actual binary executable that is not git.
+                other_exe_path = os.path.join(os.getenv("WINDIR"), "system32", "hostname.exe")
+                impostor_path = os.path.join(tmpdir, "git.exe")
+                shutil.copy(other_exe_path, impostor_path)
+            else:
+                # Create a shell script that doesn't do anything.
+                impostor_path = os.path.join(tmpdir, "git")
+                with open(impostor_path, mode="w", encoding="utf-8") as file:
+                    print("#!/bin/sh", file=file)
+                os.chmod(impostor_path, 0o755)
+
+            with _chdir(tmpdir):
+                self.assertRegex(self.git.execute(["git", "version"]), r"^git version [\d\.]{2}.*$")
 
     def test_it_accepts_stdin(self):
         filename = fixture_path("cat_file_blob")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -103,7 +103,7 @@ class TestGit(TestBase):
                 os.chmod(impostor_path, 0o755)
 
             with _chdir(tmpdir):
-                self.assertRegex(self.git.execute(["git", "version"]), r"^git version [\d\.]{2}.*$")
+                self.assertRegex(self.git.execute(["git", "version"]), r"^git version\b")
 
     def test_it_accepts_stdin(self):
         filename = fixture_path("cat_file_blob")


### PR DESCRIPTION
Fixes #1635

This fixes the path search bug where the current directory is included on Windows, by setting `NoDefaultCurrentDirectoryInExePath` for the caller. (Setting for the callee env would not work.)

This sets it only on Windows, only for the duration of the `Popen` call, and then automatically unsets it or restores its old value.

`NoDefaultCurrentDirectoryInExePath` is documented in [NeedCurrentDirectoryForExePathW function (processenv.h)](https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepathw). See also [this SO post by Mofi](https://stackoverflow.com/a/50118548/1038860).

It automatically affects the behavior of `subprocess.Popen` on Windows, due to the way `Popen` uses the Windows API. (In contrast, it does not, at least currently on CPython, affect the behavior of `shutil.which`. But `shutil.which` is not being used to find `git.exe`.)

I have tested this by naming a hello world program `git.exe` and placing it in the current directory, verifying that `import git` produces an expected error (my hello world program does not provide Git operations), then applying this change and verifying that `import git` works as it should.