### PR TITLE
util: close lockfile after opening successfully

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -935,7 +935,8 @@ class LockFile(object):
             )
 
         try:
-            open(lock_file, mode='w', closefd=True)
+            with open(lock_file, mode='w'):
+                pass
         except OSError as e:
             raise IOError(str(e)) from e
 


### PR DESCRIPTION
Otherwise, this will leak file handles and can be a problem in Windows. Also, `closefd=true` is the default here, so no need to pass it explicitly.

Regression from #1619.

I noticed after [our tests started raising `ResourceWarning`][1] after 3.1.33 release.

```python
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/git/util.py", line 938, in _obtain_lock_or_raise
    open(lock_file, mode='w', closefd=True)
ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-runner/pytest-0/popen-gw0/external0/project.git/.git/config.lock' mode='w' encoding='UTF-8'>
```

[1]: https://github.com/iterative/dvc/actions/runs/6055520480/job/16434544764#step:6:869