### PR TITLE
Fix CVE-2023-41040

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -168,6 +168,8 @@ class SymbolicReference(object):
         """Return: (str(sha), str(target_ref_path)) if available, the sha the file at
         rela_path points to, or None. target_ref_path is the reference we
         point to, or None"""
+        if ".." in str(ref_path):
+            raise ValueError(f"Invalid reference '{ref_path}'")
         tokens: Union[None, List[str], Tuple[str, str]] = None
         repodir = _git_dir(repo, ref_path)
         try:


### PR DESCRIPTION
This change adds a check during reference resolving to see if the requested reference is inside the current repository folder. If it's ouside, it raises an exception.

This fixes [CVE-2023-41040](https://github.com/advisories/GHSA-cwvm-v4w8-q58c), which allows an attacker to access files outside the repository's directory.

This closes https://github.com/gitpython-developers/GitPython/issues/1638.