### PR TITLE
Fix 'Tree' object has no attribute '_name' when submodule path is normal path

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1402,6 +1402,10 @@ class Submodule(IndexObject, TraversableIterableObj):
                 # END handle keyerror
             # END handle critical error
 
+            # Make sure we are looking at a submodule object
+            if type(sm) != git.objects.submodule.base.Submodule:
+                continue
+
             # fill in remaining info - saves time as it doesn't have to be parsed again
             sm._name = n
             if pc != repo.commit():


### PR DESCRIPTION
When a repository have a `.gitmodules` file and the actual path defined in the git repository is not related to submodule, GitPython still assumes its a submodule.

To replicate:
```bash
# In a temp directory
mkdir test
cd test
git init
mkdir DbConnector
touch DbConnector/readme.md
touch .gitmodules
# Put the context of the next segment in .gitmodules
git add .
git commit -m "test"
```

```ini
[submodule "DbConnector"]
    path = DbConnector
    url = https://github.com/chaconinc/DbConnector
```

Then in a python section
```python
from git.repo import Repo
r = Repo('.')
r.submodules
```

the following error occurs
```
In [3]: r.submodules
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 r.submodules

File ~/.local/share/virtualenvs/GitPython-yvdsleke/lib/python3.11/site-packages/git/repo/base.py:423, in Repo.submodules(self)
    418 @property
    419 def submodules(self) -> "IterableList[Submodule]":
    420     """
    421     :return: git.IterableList(Submodule, ...) of direct submodules
    422         available from the current head"""
--> 423     return Submodule.list_items(self)

File ~/.local/share/virtualenvs/GitPython-yvdsleke/lib/python3.11/site-packages/git/util.py:1184, in IterableObj.list_items(cls, repo, *args, **kwargs)
   1175 """
   1176 Find all items of this type - subclasses can specify args and kwargs differently.
   1177 If no args are given, subclasses are obliged to return all items if no additional
   (...)
   1181
   1182 :return: list(Item,...) list of item instances"""
   1183 out_list: IterableList = IterableList(cls._id_attribute_)
-> 1184 out_list.extend(cls.iter_items(repo, *args, **kwargs))
   1185 return out_list

File ~/.local/share/virtualenvs/GitPython-yvdsleke/lib/python3.11/site-packages/git/objects/submodule/base.py:1406, in Submodule.iter_items(cls, repo, parent_commit, *Args, **kwargs)
   1401         continue
   1402     # END handle keyerror
   1403 # END handle critical error
   1404
   1405 # fill in remaining info - saves time as it doesn't have to be parsed again
-> 1406 sm._name = n
   1407 if pc != repo.commit():
   1408     sm._parent_commit = pc

AttributeError: 'Tree' object has no attribute '_name'
```

Fixed by adding an additional check when determining whether the object is a submodule. Doing so makes sure only `Submodule` but not `Blob` or `Tree` instances of the `IndexObjUnion` is considered a submodule.

PS: An example real project with this issue [https://github.com/ChaoticOnyx/OnyxForum](https://github.com/ChaoticOnyx/OnyxForum)