### PR TITLE
Added test for PR #1645 submodule path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,4 +51,5 @@ Contributors are:
 -Luke Twist <itsluketwist@gmail.com>
 -Joseph Hale <me _at_ jhale.dev>
 -Santos Gallegos <stsewd _at_ proton.me>
+-Wenhan Zhu <wzhu.cosmos _at_ gmail.com>
 Portions derived from other open source works and are clearly marked.

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ See [Issue #525](https://github.com/gitpython-developers/GitPython/issues/525).
 
 ### RUNNING TESTS
 
-_Important_: Right after cloning this repository, please be sure to have executed
-the `./init-tests-after-clone.sh` script in the repository root. Otherwise
-you will encounter test failures.
+_Important_: Right after cloning this repository, please be sure to have
+executed `git fetch --tags` followed by the `./init-tests-after-clone.sh`
+script in the repository root. Otherwise you will encounter test failures.
 
 On _Windows_, make sure you have `git-daemon` in your PATH. For MINGW-git, the `git-daemon.exe`
 exists in `Git\mingw64\libexec\git-core\`; CYGWIN has no daemon, but should get along fine

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -907,6 +907,28 @@ class TestSubmodule(TestBase):
         # end for each dry-run mode
 
     @with_rw_directory
+    def test_ignore_non_submodule_file(self, rwdir):
+        parent = git.Repo.init(rwdir)
+
+        smp = osp.join(rwdir, "module")
+        os.mkdir(smp)
+
+        with open(osp.join(smp, "a"), "w", encoding="utf-8") as f:
+            f.write('test\n')
+
+        with open(osp.join(rwdir, ".gitmodules"), "w", encoding="utf-8") as f:
+            f.write("[submodule \"a\"]\n")
+            f.write("    path = module\n")
+            f.write("    url = https://github.com/chaconinc/DbConnector\n")
+
+        parent.git.add(Git.polish_url(osp.join(smp, "a")))
+        parent.git.add(Git.polish_url(osp.join(rwdir, ".gitmodules")))
+
+        parent.git.commit(message='test')
+
+        assert len(parent.submodules) == 0
+
+    @with_rw_directory
     def test_remove_norefs(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))
         sm_name = "mymodules/myname"


### PR DESCRIPTION
Following from here: https://github.com/gitpython-developers/GitPython/pull/1645#issuecomment-1708908630, I've added a test in the corresponding position.

Meanwhile, I've noticed there are test failures related to [CVE-2022-39253](https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html). I did a quick fix in place by adding git configs in the Cmd.

Since I also had the chance to do a fresh start on testing, I updated the docs on where it was unclear to me and caused issues. Particularly, I highlighted that `git fetch --tags` should be ran first otherwise it would cause test failures regarding version `0.1.6` something something.

Each small change in clearly separated by commits, so if there is any change you don't like, it can be easily cherry picked.

Lastly, I would like to thank you for being so responsive in maintaining this wonderful project 😄 