### PR TITLE
Only make config more permissive in tests that need it

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -12,7 +12,7 @@ jobs:
       SHELLOPTS: igncr
       TMP: "/tmp"
       TEMP: "/tmp"
-    
+
     steps:
     - name: Force LF line endings
       run: git config --global core.autocrlf input
@@ -24,8 +24,8 @@ jobs:
         packages: python39 python39-pip python39-virtualenv git
     - name: Tell git to trust this repo
       shell: bash.exe -eo pipefail -o igncr "{0}"
-      run: | 
-          /usr/bin/git config --global --add safe.directory $(pwd)
+      run: |
+          /usr/bin/git config --global --add safe.directory "$(pwd)"
           /usr/bin/git config --global protocol.file.allow always
     - name: Install dependencies and prepare tests
       shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -46,8 +46,4 @@ jobs:
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         /usr/bin/python -m pytest
-      env:
-        GIT_CONFIG_COUNT: "1"
-        GIT_CONFIG_KEY_0: protocol.file.allow
-        GIT_CONFIG_VALUE_0: always
       continue-on-error: false

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -26,7 +26,6 @@ jobs:
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
           /usr/bin/git config --global --add safe.directory "$(pwd)"
-          /usr/bin/git config --global protocol.file.allow always
     - name: Install dependencies and prepare tests
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
@@ -47,4 +46,8 @@ jobs:
       shell: bash.exe -eo pipefail -o igncr "{0}"
       run: |
         /usr/bin/python -m pytest
+      env:
+        GIT_CONFIG_COUNT: "1"
+        GIT_CONFIG_KEY_0: protocol.file.allow
+        GIT_CONFIG_VALUE_0: always
       continue-on-error: false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -56,10 +56,6 @@ jobs:
       run: |
         set -x
         pytest
-      env:
-        GIT_CONFIG_COUNT: "1"
-        GIT_CONFIG_KEY_0: protocol.file.allow
-        GIT_CONFIG_VALUE_0: always
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,14 +52,14 @@ jobs:
         set -x
         mypy -p git
 
-    - name: Tell git to allow file protocol even for submodules
-      run: |
-          /usr/bin/git config --global protocol.file.allow always
-
     - name: Test with pytest
       run: |
         set -x
         pytest
+      env:
+        GIT_CONFIG_COUNT: "1"
+        GIT_CONFIG_KEY_0: protocol.file.allow
+        GIT_CONFIG_VALUE_0: always
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,9 +52,8 @@ jobs:
         set -x
         mypy -p git
 
-    - name: Tell git to trust this repo
-      run: | 
-          /usr/bin/git config --global --add safe.directory $(pwd)
+    - name: Tell git to allow file protocol even for submodules
+      run: |
           /usr/bin/git config --global protocol.file.allow always
 
     - name: Test with pytest

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -33,16 +33,16 @@ import os.path as osp
 
 
 @contextlib.contextmanager
-def _allow_file_protocol():
-    """Temporarily set protocol.file.allow to always, using environment variables."""
+def _patch_git_config(name, value):
+    """Temporarily add a git config name-value pair, using environment variables."""
     pair_index = int(os.getenv("GIT_CONFIG_COUNT", "0"))
 
     # This is recomputed each time the context is entered, for compatibility with
     # existing GIT_CONFIG_* environment variables, even if changed in this process.
     patcher = mock.patch.dict(os.environ, {
         "GIT_CONFIG_COUNT": str(pair_index + 1),
-        f"GIT_CONFIG_KEY_{pair_index}": "protocol.file.allow",
-        f"GIT_CONFIG_VALUE_{pair_index}": "always",
+        f"GIT_CONFIG_KEY_{pair_index}": name,
+        f"GIT_CONFIG_VALUE_{pair_index}": value,
     })
 
     with patcher:
@@ -727,7 +727,7 @@ class TestSubmodule(TestBase):
         # end for each checkout mode
 
     @with_rw_directory
-    @_allow_file_protocol()
+    @_patch_git_config("protocol.file.allow", "always")
     def test_list_only_valid_submodules(self, rwdir):
         repo_path = osp.join(rwdir, "parent")
         repo = git.Repo.init(repo_path)
@@ -756,7 +756,7 @@ class TestSubmodule(TestBase):
                 """,
     )
     @with_rw_directory
-    @_allow_file_protocol()
+    @_patch_git_config("protocol.file.allow", "always")
     def test_git_submodules_and_add_sm_with_new_commit(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))
         parent.git.submodule("add", self._small_repo_url(), "module")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
+import contextlib
 import os
 import shutil
 import tempfile
 from pathlib import Path
 import sys
-from unittest import skipIf
+from unittest import mock, skipIf
 
 import pytest
 
@@ -29,6 +30,23 @@ from test.lib import with_rw_directory
 from git.util import HIDE_WINDOWS_KNOWN_ERRORS
 from git.util import to_native_path_linux, join_path_native
 import os.path as osp
+
+
+@contextlib.contextmanager
+def _allow_file_protocol():
+    """Temporarily set protocol.file.allow to always, using environment variables."""
+    pair_index = int(os.getenv("GIT_CONFIG_COUNT", "0"))
+
+    # This is recomputed each time the context is entered, for compatibility with
+    # existing GIT_CONFIG_* environment variables, even if changed in this process.
+    patcher = mock.patch.dict(os.environ, {
+        "GIT_CONFIG_COUNT": str(pair_index + 1),
+        f"GIT_CONFIG_KEY_{pair_index}": "protocol.file.allow",
+        f"GIT_CONFIG_VALUE_{pair_index}": "always",
+    })
+
+    with patcher:
+        yield
 
 
 class TestRootProgress(RootUpdateProgress):
@@ -709,6 +727,7 @@ class TestSubmodule(TestBase):
         # end for each checkout mode
 
     @with_rw_directory
+    @_allow_file_protocol()
     def test_list_only_valid_submodules(self, rwdir):
         repo_path = osp.join(rwdir, "parent")
         repo = git.Repo.init(repo_path)
@@ -737,6 +756,7 @@ class TestSubmodule(TestBase):
                 """,
     )
     @with_rw_directory
+    @_allow_file_protocol()
     def test_git_submodules_and_add_sm_with_new_commit(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))
         parent.git.submodule("add", self._small_repo_url(), "module")


### PR DESCRIPTION
Closes #1544

**Edit:** When making this PR, I didn't notice #1647, which was recently opened (but opened before this PR; #1647 came first). That PR includes an alternative to the approach taken here. It uses a GitPython feature to set `protocol.file.allow` in `git` command-like arguments, while this patches `GIT_CONFIG_*` environment variables. Both approaches are specific and, I believe, robust. The approach in this PR avoids using more GitPython features that are not conceptually under test in the submodule tests. But the approach in #1647 is significantly more compact, which might be considered the more important benefit. I will not mind if this is closed in preference for #1647! At this time, both #1647 and this PR also contain changes beyond those that directly address #1544, and another option, if the approach in #1647 is chosen, would be for me to narrow this PR to make only CI changes, after #1647 is accepted.

(The original description of the changes in this PR, and the rationale for them, follows.)

### protocol.file.allow

This eliminates the need for users running the test suite to set [`protocol.file.allow`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolltnamegtallow) to `always` in the global git configuration. Setting it globally to `always` has security implications, as alluded to in #1544, and as noted in the description in [git release notes](https://lore.kernel.org/git/xmqq4jw1uku5.fsf@gitster.g/T/) of how [CVE-2022-39253](https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85) was fixed, and in https://github.com/git/git/commit/a1d4f67c12ac172f835e6d5e4e0a197075e2146b where its default value was changed from `always` to `user`.

On CI, this was not directly a problem, because the CI runner is isolated and not being used to clone unrelated less-trusted repositories. But users are likely to be looking at the CI workflows to figure out how to overcome the `fatal: transport 'file' not allowed` error locally. Furthermore, by having the test suite make the change automatically and temporarily by modifying process environment variables, the needed setup is simplified for everyone.

The approach taken here is inspired by https://github.com/gitpython-developers/GitPython/issues/1544#issuecomment-1399887101 and makes use of [`GIT_CONFIG_*` environment variables](https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGCOUNT). But it is more specific than suggested there, instead temporarily patching the environment only during the runs of the two specific tests that require it, `test_list_only_valid_submodules` and `test_git_submodules_and_add_sm_with_new_commit`. This is done without much code duplication, so it can be applied easily to any future test cases that require it. (I think this probably won't ever be needed outside `test_submodule.py`, because Git's default value of `protocol.file.allow` is `user`, not `never`.)

I patched `GIT_CONFIG_*` variables in such a way that existing assignments to `GIT_CONFIG_*` variables, if present, are still used, rather than being replaced or causing an error. I considered patching [`GIT_ALLOW_PROTOCOL`](https://www.git-scm.com/docs/git#Documentation/git.txt-codeGITALLOWPROTOCOLcode) instead, but I decided against it because it may be useful for people running the tests to be able to change what other protocols are allowed/disallowed. Patching `GIT_ALLOW_PROTOCOL` in a way that respected that would be more complicated than patching `GIT_CONFIG_*` variables.

### safe.directory

`protocol.file.allow` is one of two security-related configuration options that were set on CI. The other is [`safe.directory`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory). This is not needed in the `pythonpackage.yml` workflow, because the cloned repository's files are always owned by the same user that is running `pytest` and thus `git`, so I removed it from there. The `cygwin-test.yml` workflow does currently need it, and I [shell-quoted](https://www.gnu.org/software/bash/manual/bash.html#Double-Quotes) `$(pwd)` there, which is slightly more robust and better expresses the intent that no splitting or globbing be performed, but otherwise retained it.

I was unsure if I should include changes related to `safe.directory` in this PR, or open a separate PR. The `protocol.file.allow` and `safe.directory` customizations were presented as closely related in the workflows. More importantly, to decide where to put the fixture/helper used for patching `protocol.file.allow` in `test_submodule.py`, I checked that it would not be needed elsewhere, by verifying that no test cases inherently require `safe.directory` to be set (but that it just works around a Cygwin-specific issue). For the same reason, it seems to me that the changes may be easier to *review* together than separately, as well. However, I would be pleased to make any requested changes to this PR, including splitting out `safe.directory`-related changes to a separate PR if desired.