### PR TITLE
Fix Windows environment variable upcasing bug

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -158,6 +158,20 @@ def cwd(new_dir: PathLike) -> Generator[PathLike, None, None]:
         os.chdir(old_dir)
 
 
+@contextlib.contextmanager
+def patch_env(name: str, value: str) -> Generator[None, None, None]:
+    """Context manager to temporarily patch an environment variable."""
+    old_value = os.getenv(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            del os.environ[name]
+        else:
+            os.environ[name] = old_value
+
+
 def rmtree(path: PathLike) -> None:
     """Remove the given recursively.
 
@@ -935,7 +949,7 @@ class LockFile(object):
             )
 
         try:
-            with open(lock_file, mode='w'):
+            with open(lock_file, mode="w"):
                 pass
         except OSError as e:
             raise IOError(str(e)) from e

--- a/git/util.py
+++ b/git/util.py
@@ -150,6 +150,7 @@ def unbare_repo(func: Callable[..., T]) -> Callable[..., T]:
 
 @contextlib.contextmanager
 def cwd(new_dir: PathLike) -> Generator[PathLike, None, None]:
+    """Context manager to temporarily change directory. Not reentrant."""
     old_dir = os.getcwd()
     os.chdir(new_dir)
     try:

--- a/test/fixtures/env_case.py
+++ b/test/fixtures/env_case.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+import git
+
+
+_, working_dir, env_var_name = sys.argv
+
+# Importing git should be enough, but this really makes sure Git.execute is called.
+repo = git.Repo(working_dir)  # Hold the reference.
+git.Git(repo.working_dir).execute(["git", "version"])
+
+print(subprocess.check_output(["set", env_var_name], shell=True, text=True))

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -112,16 +112,12 @@ class TestGit(TestBase):
             raise RuntimeError("test bug or strange locale: old_name invariant under upcasing")
         os.putenv(old_name, "1")  # It has to be done this lower-level way to set it lower-case.
 
-        script_lines = [
-            "import subprocess, git",
-
-            # Importing git should be enough, but this really makes sure Git.execute is called.
-            f"repo = git.Repo({self.rorepo.working_dir!r})",
-            "git.Git(repo.working_dir).execute(['git', 'version'])",
-
-            f"print(subprocess.check_output(['set', {old_name!r}], shell=True, text=True))",
+        cmdline = [
+            sys.executable,
+            fixture_path("env_case.py"),
+            self.rorepo.working_dir,
+            old_name,
         ]
-        cmdline = [sys.executable, "-c", "\n".join(script_lines)]
         pair_text = subprocess.check_output(cmdline, shell=False, text=True)
         new_name = pair_text.split("=")[0]
         self.assertEqual(new_name, old_name)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 from tempfile import TemporaryDirectory, TemporaryFile
-from unittest import mock
+from unittest import mock, skipUnless
 
 from git import Git, refresh, GitCommandError, GitCommandNotFound, Repo, cmd
 from test.lib import TestBase, fixture_path
@@ -104,6 +104,27 @@ class TestGit(TestBase):
 
             with _chdir(tmpdir):
                 self.assertRegex(self.git.execute(["git", "version"]), r"^git version\b")
+
+    @skipUnless(is_win, "The regression only affected Windows, and this test logic is OS-specific.")
+    def test_it_avoids_upcasing_unrelated_environment_variable_names(self):
+        old_name = "28f425ca_d5d8_4257_b013_8d63166c8158"
+        if old_name == old_name.upper():
+            raise RuntimeError("test bug or strange locale: old_name invariant under upcasing")
+        os.putenv(old_name, "1")  # It has to be done this lower-level way to set it lower-case.
+
+        script_lines = [
+            "import subprocess, git",
+
+            # Importing git should be enough, but this really makes sure Git.execute is called.
+            f"repo = git.Repo({self.rorepo.working_dir!r})",
+            "git.Git(repo.working_dir).execute(['git', 'version'])",
+
+            f"print(subprocess.check_output(['set', {old_name!r}], shell=True, text=True))",
+        ]
+        cmdline = [sys.executable, "-c", "\n".join(script_lines)]
+        pair_text = subprocess.check_output(cmdline, shell=False, text=True)
+        new_name = pair_text.split("=")[0]
+        self.assertEqual(new_name, old_name)
 
     def test_it_accepts_stdin(self):
         filename = fixture_path("cat_file_blob")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -4,7 +4,6 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
-import contextlib
 import os
 import shutil
 import subprocess
@@ -15,22 +14,11 @@ from unittest import mock, skipUnless
 from git import Git, refresh, GitCommandError, GitCommandNotFound, Repo, cmd
 from test.lib import TestBase, fixture_path
 from test.lib import with_rw_directory
-from git.util import finalize_process
+from git.util import cwd, finalize_process
 
 import os.path as osp
 
 from git.compat import is_win
-
-
-@contextlib.contextmanager
-def _chdir(new_dir):
-    """Context manager to temporarily change directory. Not reentrant."""
-    old_dir = os.getcwd()
-    os.chdir(new_dir)
-    try:
-        yield
-    finally:
-        os.chdir(old_dir)
 
 
 class TestGit(TestBase):
@@ -102,7 +90,7 @@ class TestGit(TestBase):
                     print("#!/bin/sh", file=file)
                 os.chmod(impostor_path, 0o755)
 
-            with _chdir(tmpdir):
+            with cwd(tmpdir):
                 self.assertRegex(self.git.execute(["git", "version"]), r"^git version\b")
 
     @skipUnless(is_win, "The regression only affected Windows, and this test logic is OS-specific.")


### PR DESCRIPTION
*This pull request might be ready, but it is still a draft because I think I should look it over once more for any serious problems.*

Fixes #1646

This fixes the bug I inadvertently introduced in #1636 where all environment variables' names are set upper-case on Windows.

It uses a simple hand-rolled context manager to patch the `NoDefaultCurrentDirectoryInExePath` variable, instead of `unittest.mock.patch.dict`. The latter was setting unrelated environment variables to the original (same) values via `os.environ`, and as a result, their names were all converted to upper-case on Windows. This is the intended behavior of `os.environ` on Windows, at least in CPython, per https://github.com/python/cpython/issues/73010 and https://github.com/python/cpython/issues/101754, but I had not been thinking of this, and more importantly I was not aware that `unittest.mock.patch.dict` effectively writes all items to the mapping when it unpatches, including items that had not been listed for patching.

Because only environment variables that are actually set through `os.environ` have their names upcased, the only variable whose name should be upcased now is `NoDefaultCurrentDirectoryInExePath`, which should be fine. (It has a single established use/meaning in Windows, where it's treated case-insensitively as environment variables in Windows *usually* are.)

---

The actual fix here is pretty simple, but robustly testing it is tricky. One pitfall in testing it remains unaddressed at this point: Either the bug doesn't affect Cygwin builds of Python (linking `cygwin1.dll`), or `is_win` evaluates to false in the `test-cygwin.yml` workflows, **so the project's current CI cannot verify the fix.** Notice, for example, that the first two commits ([d88372a](https://github.com/gitpython-developers/GitPython/pull/1650/commits/d88372a11ac145d92013dcc64b7d21a5a6ad3a91) and [7296e5c](https://github.com/gitpython-developers/GitPython/pull/1650/commits/7296e5c021450743e5fe824e94b830a73eebc4c8)) show as passing all tests, even though they should show as failing on Windows. I am unsure if that should block this PR or not, since it seems like this sort of thing might actually be common.

I could make the test run on more platforms than Windows, but I don't think that would be more robust, because on other systems it would effectively just be testing that the Python implementation of `os.environ` works as expected on non-Windows systems. Furthermore, the important test logic would differ depending on the value of `is_win`, so if the Cygwin workflow has `is_win` as false, then it would only create the false impression that CI was verifying the fix.

It might be possible to improve the situation in the CI workflows themselves. But I think that would take longer than it might be good to wait on fixing this bug, since this bug currently prevents users who rely on case-sensitive environment variables from upgrading far enough to receive fixes for either CVE-2023-40590 (3.1.33) or CVE-2023-41040 (3.1.35, forthcoming).

[**I have verified the fix locally.**](https://gist.github.com/EliahKagan/21916264b96b302e13fd105f5ba2aae6) That test failure is from *before* the fix in [c7fad20](https://github.com/gitpython-developers/GitPython/pull/1650/commits/c7fad20be5df0a86636459bf673ff9242a82e1fc). It is taken from [7296e5c](https://github.com/gitpython-developers/GitPython/pull/1650/commits/7296e5c021450743e5fe824e94b830a73eebc4c8).

Both tests shown there pass starting in the third commit ([c7fad20](https://github.com/gitpython-developers/GitPython/pull/1650/commits/c7fad20be5df0a86636459bf673ff9242a82e1fc)), as expected, and continue to pass in the fourth commit ([eebdb25](https://github.com/gitpython-developers/GitPython/pull/1650/commits/eebdb25ee6e88d8fce83ea0970bd08f5e5301f65)). Due to the new test's use of the new "fixture" script `env_case.py`, together with how the official installation instructions do not create a true editable install, if `python setup.py install` was how installation was done, and it was done prior to checking out the fix, then `python setup.py install` has to be run again for the "fixture" script to get the current code when it runs `import git`. I considered going back to the previous way that doesn't execute a separate script file, but I think that code may be harder to understand for someone who doesn't already know how the test works.