### PR TITLE
Better document env_case test/fixture and cwd

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -150,7 +150,10 @@ def unbare_repo(func: Callable[..., T]) -> Callable[..., T]:
 
 @contextlib.contextmanager
 def cwd(new_dir: PathLike) -> Generator[PathLike, None, None]:
-    """Context manager to temporarily change directory. Not reentrant."""
+    """Context manager to temporarily change directory.
+
+    This is similar to contextlib.chdir introduced in Python 3.11, but the context
+    manager object returned by a single call to this function is not reentrant."""
     old_dir = os.getcwd()
     os.chdir(new_dir)
     try:

--- a/test/fixtures/env_case.py
+++ b/test/fixtures/env_case.py
@@ -1,13 +1,18 @@
+# Steps 3 and 4 for test_it_avoids_upcasing_unrelated_environment_variable_names.
+
 import subprocess
 import sys
 
+# Step 3a: Import the module, in case that upcases the environment variable name.
 import git
 
 
 _, working_dir, env_var_name = sys.argv
 
-# Importing git should be enough, but this really makes sure Git.execute is called.
+# Step 3b: Use Git.execute explicitly, in case that upcases the environment variable.
+#          (Importing git should be enough, but this ensures Git.execute is called.)
 repo = git.Repo(working_dir)  # Hold the reference.
 git.Git(repo.working_dir).execute(["git", "version"])
 
+# Step 4: Create the non-Python grandchild that accesses the variable case-sensitively.
 print(subprocess.check_output(["set", env_var_name], shell=True, text=True))

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -109,11 +109,11 @@ class TestGit(TestBase):
         #         name to its own child process (the grandchild).
         cmdline = [
             sys.executable,
-            fixture_path("env_case.py"),
+            fixture_path("env_case.py"),  # Contains steps 3 and 4.
             self.rorepo.working_dir,
             old_name,
         ]
-        pair_text = subprocess.check_output(cmdline, shell=False, text=True)  # Steps 3 and 4.
+        pair_text = subprocess.check_output(cmdline, shell=False, text=True)  # Run steps 3 and 4.
 
         new_name = pair_text.split("=")[0]
         self.assertEqual(new_name, old_name)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -104,11 +104,9 @@ class TestGit(TestBase):
         #         process, so the name is not upcased even on Windows.
         os.putenv(old_name, "1")
 
-        # Step 2: Create the child process that inherits the environment variable. It will see it
-        #         in os.environ with an upcased name, but if it is not mutated through os.environ
-        #         then it will pass it on to its own child processes with the original name. The
-        #         child process will use GitPython, and we are testing that it passes the variable
-        #         with the exact original name to its own child processes.
+        # Step 2: Create the child process that inherits the environment variable. The child uses
+        #         GitPython, and we are testing that it passes the variable with the exact original
+        #         name to its own child process (the grandchild).
         cmdline = [
             sys.executable,
             fixture_path("env_case.py"),


### PR DESCRIPTION
This improves how some of the changes in #1650 are documented, expanding comments and a docstring.

I ended up doing this in four commits, but really it would probably be just as clear with two. If you'd like me to rebase this to have just two commits, please let me know.

### Identifying the steps in the "`env_case`" test

This is my main motivation for opening this PR, and most of the change.

I was thinking about how it was not immediately obvious why `test_it_avoids_upcasing_unrelated_environment_variable_names` (the "`env_case`" test) works and why it is done in this way.

To improve on this, I wrote comments that divide it into four steps. Two of the steps occur in the test case method, and the others occur in the supporting `env_case.py` fixture. The comments are in both files.

This only adds and changes comments, but just in case I have locally tested that it does not stop the test from passing, nor from failing when using the version of the code in `git/` from just before the merge of #1650.

### Non-reentrancy of some context manager objects

I had intended my brief mention of non-reentrancy to distinguish `git.util.cwd` from [`contextlib.chdir`](https://docs.python.org/3/library/contextlib.html#contextlib.chdir), which is fully reentrant by having each returned object maintain a stack of directories (but which is not available before Python 3.11). But this was not clear at all--I had nowhere mentioned `contextlib.chdir`!--and it risked giving the wrong impression that `cwd` couldn't be called multiple times in nested `with`-statements.

Furthermore, the newly introduced `patch_env` function is non-reentrant in exactly the same narrow sense, but because it did not mention this and `cwd` did, this gave the wrong impression that `patch_env` was reentrant in this way. (I think `patch_env` actually *doesn't* need to document this--really `cwd`'s limitation compared to `contextlib.chdir` is the only thing important enough to mention.)

I've somewhat clarified this, but maybe further improvements can be made in the future. This can be make clearer with [extended example](https://gist.github.com/EliahKagan/eb0c0d34b0b5e911f52cd044f8fac320#file-transcript-txt), but I would be very reluctant to bloat the `cwd` docstring with fully worked examples. If anything, maybe there is a way to say it shorter. Or maybe the reentrancy information should be removed altogether.