### PR TITLE
Fix up checks in Makefile and make them portable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 test/fixtures/* eol=lf
-init-tests-after-clone.sh eol=lf
-Makefile eol=lf
-check-version.sh eol=lf
-build-release.sh eol=lf
+*.sh eol=lf
+/Makefile eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 test/fixtures/* eol=lf
 init-tests-after-clone.sh eol=lf
-check-version.sh eol=lf
 Makefile eol=lf
+check-version.sh eol=lf
+build-release.sh eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 test/fixtures/* eol=lf
 init-tests-after-clone.sh eol=lf
+check-version.sh eol=lf
 Makefile eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 test/fixtures/* eol=lf
-init-tests-after-clone.sh
+init-tests-after-clone.sh eol=lf
+Makefile eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.py[co]
 *.swp
 *~
+.env/
+env/
 .venv/
 venv/
 /*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,29 @@ clean:
 	rm -rf build/ dist/ .eggs/ .tox/
 
 release: clean
-	# Check if latest tag is the current head we're releasing
-	@config_opts="$$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)" && \
+	# Check that VERSION and changes.rst exist and have no uncommitted changes
+	test -f VERSION
+	test -f doc/source/changes.rst
+	git status -s VERSION doc/source/changes.rst
+	@test -z "$$(git status -s VERSION doc/source/changes.rst)"
+
+	# Check that ALL changes are commited (can comment out if absolutely necessary)
+	git status -s
+	@test -z "$$(git status -s)"
+
+	# Check that latest tag matches version and is the current head we're releasing
+	@version_file="$$(cat VERSION)" && \
+	changes_file="$$(awk '/^[0-9]/ {print $$0; exit}' doc/source/changes.rst)" && \
+	config_opts="$$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)" && \
 	latest_tag=$$(git $$config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1) && \
 	head_sha=$$(git rev-parse HEAD) latest_tag_sha=$$(git rev-parse "$$latest_tag") && \
-	printf '%-14s = %s\n' 'Latest tag'     "$$latest_tag" \
+	printf '%-14s = %s\n' 'VERSION file'   "$$version_file" \
+	                      'changes.rst'    "$$changes_file" \
+	                      'Latest tag'     "$$latest_tag" \
 	                      'HEAD SHA'       "$$head_sha" \
 	                      'Latest tag SHA' "$$latest_tag_sha" && \
+	test "$$version_file" = "$$changes_file" && \
+	test "$$latest_tag" = "$$version_file" && \
 	test "$$head_sha" = "$$latest_tag_sha"
 
 	make force_release

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ release: clean
 force_release: clean
 	# IF we're in a virtual environment, add build tools
 	test -z "$$VIRTUAL_ENV" || pip install -U build twine
-	python3 -m build --sdist --wheel || echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead"
+
+	# Build the sdist and wheel that will be uploaded to PyPI.
+	python3 -m build --sdist --wheel || \
+		test -z "$$VIRTUAL_ENV" && \
+		echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead" && \
+		false
+
+	# Upload to PyPI and push the tag.
 	twine upload dist/*
 	git push --tags origin main

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,14 @@ clean:
 
 release: clean
 	# Check if latest tag is the current head we're releasing
-	echo "Latest tag = $$(git tag -l '[0-9]*' --sort=-v:refname | head -n1)"
-	echo "HEAD SHA       = $$(git rev-parse HEAD)"
-	echo "Latest tag SHA = $$(git tag -l '[0-9]*' --sort=-v:refname | head -n1 | xargs git rev-parse)"
-	@test "$$(git rev-parse HEAD)" = "$$(git tag -l '[0-9]*' --sort=-v:refname | head -n1 | xargs git rev-parse)"
+	@config_opts="$$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)" && \
+	latest_tag=$$(git $$config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1) && \
+	head_sha=$$(git rev-parse HEAD) latest_tag_sha=$$(git rev-parse "$$latest_tag") && \
+	printf '%-14s = %s\n' 'Latest tag'     "$$latest_tag" \
+	                      'HEAD SHA'       "$$head_sha" \
+	                      'Latest tag SHA' "$$latest_tag_sha" && \
+	test "$$head_sha" = "$$latest_tag_sha"
+
 	make force_release
 
 force_release: clean

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ clean:
 
 release: clean
 	# Check if latest tag is the current head we're releasing
-	echo "Latest tag = $$(git tag | sort -nr | head -n1)"
+	echo "Latest tag = $$(git tag -l '[0-9]*' --sort=-v:refname | head -n1)"
 	echo "HEAD SHA       = $$(git rev-parse HEAD)"
-	echo "Latest tag SHA = $$(git tag | sort -nr | head -n1 | xargs git rev-parse)"
-	@test "$$(git rev-parse HEAD)" = "$$(git tag | sort -nr | head -n1 | xargs git rev-parse)"
+	echo "Latest tag SHA = $$(git tag -l '[0-9]*' --sort=-v:refname | head -n1 | xargs git rev-parse)"
+	@test "$$(git rev-parse HEAD)" = "$$(git tag -l '[0-9]*' --sort=-v:refname | head -n1 | xargs git rev-parse)"
 	make force_release
 
 force_release: clean

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ clean:
 release: clean
 	# Check if latest tag is the current head we're releasing
 	echo "Latest tag = $$(git tag | sort -nr | head -n1)"
-	echo "HEAD SHA       = $$(git rev-parse head)"
+	echo "HEAD SHA       = $$(git rev-parse HEAD)"
 	echo "Latest tag SHA = $$(git tag | sort -nr | head -n1 | xargs git rev-parse)"
-	@test "$$(git rev-parse head)" = "$$(git tag | sort -nr | head -n1 | xargs git rev-parse)"
+	@test "$$(git rev-parse HEAD)" = "$$(git tag | sort -nr | head -n1 | xargs git rev-parse)"
 	make force_release
 
 force_release: clean

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,13 @@ force_release: clean
 	test -z "$$VIRTUAL_ENV" || pip install -U build twine
 
 	# Build the sdist and wheel that will be uploaded to PyPI.
-	python3 -m build --sdist --wheel || \
-		test -z "$$VIRTUAL_ENV" && \
+	if test -n "$$VIRTUAL_ENV"; then \
+		python -m build --sdist --wheel; \
+	else \
+		python3 -m build --sdist --wheel || \
 		echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead" && \
-		false
+		false; \
+	fi
 
 	# Upload to PyPI and push the tag.
 	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -7,31 +7,7 @@ clean:
 	rm -rf build/ dist/ .eggs/ .tox/
 
 release: clean
-	# Check that VERSION and changes.rst exist and have no uncommitted changes
-	test -f VERSION
-	test -f doc/source/changes.rst
-	git status -s VERSION doc/source/changes.rst
-	@test -z "$$(git status -s VERSION doc/source/changes.rst)"
-
-	# Check that ALL changes are commited (can comment out if absolutely necessary)
-	git status -s
-	@test -z "$$(git status -s)"
-
-	# Check that latest tag matches version and is the current head we're releasing
-	@version_file="$$(cat VERSION)" && \
-	changes_file="$$(awk '/^[0-9]/ {print $$0; exit}' doc/source/changes.rst)" && \
-	config_opts="$$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)" && \
-	latest_tag=$$(git $$config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1) && \
-	head_sha=$$(git rev-parse HEAD) latest_tag_sha=$$(git rev-parse "$$latest_tag") && \
-	printf '%-14s = %s\n' 'VERSION file'   "$$version_file" \
-	                      'changes.rst'    "$$changes_file" \
-	                      'Latest tag'     "$$latest_tag" \
-	                      'HEAD SHA'       "$$head_sha" \
-	                      'Latest tag SHA' "$$latest_tag_sha" && \
-	test "$$version_file" = "$$changes_file" && \
-	test "$$latest_tag" = "$$version_file" && \
-	test "$$head_sha" = "$$latest_tag_sha"
-
+	./check-version.sh
 	make force_release
 
 force_release: clean

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,6 @@ release: clean
 	make force_release
 
 force_release: clean
-	# IF we're in a virtual environment, add build tools
-	test -z "$$VIRTUAL_ENV" || pip install -U build twine
-
-	# Build the sdist and wheel that will be uploaded to PyPI.
-	if test -n "$$VIRTUAL_ENV"; then \
-		python -m build --sdist --wheel; \
-	else \
-		python3 -m build --sdist --wheel || \
-		{ echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead" && false; }; \
-	fi
-
-	# Upload to PyPI and push the tag.
+	./build-release.sh
 	twine upload dist/*
 	git push --tags origin main

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ force_release: clean
 		python -m build --sdist --wheel; \
 	else \
 		python3 -m build --sdist --wheel || \
-		echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead" && \
-		false; \
+		{ echo "Use a virtual-env with 'python -m venv env && source env/bin/activate' instead" && false; }; \
 	fi
 
 	# Upload to PyPI and push the tag.

--- a/build-release.sh
+++ b/build-release.sh
@@ -5,18 +5,22 @@
 
 set -eEu
 
+function release_with() {
+    $1 -m build --sdist --wheel
+}
+
 if test -n "${VIRTUAL_ENV:-}"; then
     deps=(build twine)  # Install twine along with build, as we need it later.
-    printf 'Virtual environment detected. Adding packages: %s\n' "${deps[*]}"
-    pip install -U "${deps[@]}"
-    printf 'Starting the build.\n'
-    python -m build --sdist --wheel
+    echo "Virtual environment detected. Adding packages: ${deps[*]}"
+    pip install --quiet --upgrade "${deps[@]}"
+    echo 'Starting the build.'
+    release_with python
 else
-    suggest_venv() {
+    function suggest_venv() {
         venv_cmd='python -m venv env && source env/bin/activate'
-        printf "Use a virtual-env with '%s' instead.\n" "$venv_cmd"
+        printf "HELP: To avoid this error, use a virtual-env with '%s' instead.\n" "$venv_cmd"
     }
     trap suggest_venv ERR  # This keeps the original exit (error) code.
-    printf 'Starting the build.\n'
-    python3 -m build --sdist --wheel  # Outside a venv, use python3.
+    echo 'Starting the build.'
+    release_with python3 # Outside a venv, use python3.
 fi

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# This script builds a release. If run in a venv, it auto-installs its tools.
+# You may want to run "make release" instead of running this script directly.
+
+set -eEu
+
+if test -n "${VIRTUAL_ENV:-}"; then
+    deps=(build twine)  # Install twine along with build, as we need it later.
+    printf 'Virtual environment detected. Adding packages: %s\n' "${deps[*]}"
+    pip install -U "${deps[@]}"
+    printf 'Starting the build.\n'
+    python -m build --sdist --wheel
+else
+    suggest_venv() {
+        venv_cmd='python -m venv env && source env/bin/activate'
+        printf "Use a virtual-env with '%s' instead.\n" "$venv_cmd"
+    }
+    trap suggest_venv ERR  # This keeps the original exit (error) code.
+    printf 'Starting the build.\n'
+    python3 -m build --sdist --wheel  # Outside a venv, use python3.
+fi

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # This script builds a release. If run in a venv, it auto-installs its tools.
 # You may want to run "make release" instead of running this script directly.

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This script checks if we appear ready to build and publish a new release.
+# See the release instructions in README.md for the steps to make this pass.
+
+set -eEfuo pipefail
+trap 'printf "%s: Check failed. Stopping.\n" "$0" >&2' ERR
+
+readonly version_path='VERSION'
+readonly changes_path='doc/source/changes.rst'
+
+printf 'Checking current directory.\n'
+test "$(cd -- "$(dirname -- "$0")" && pwd)" = "$(pwd)"  # Ugly, but portable.
+
+printf 'Checking that %s and %s exist and have no committed changes.\n' \
+    "$version_path" "$changes_path"
+test -f "$version_path"
+test -f "$changes_path"
+git status -s -- "$version_path" "$changes_path"
+test -z "$(git status -s -- "$version_path" "$changes_path")"
+
+# This section can be commented out, if absolutely necessary.
+printf 'Checking that ALL changes are committed.\n'
+git status -s
+test -z "$(git status -s)"
+
+printf 'Gathering current version, latest tag, and current HEAD commit info.\n'
+version_version="$(cat "$version_path")"
+changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"
+config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
+latest_tag="$(git $config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1)"
+head_sha="$(git rev-parse HEAD)"
+latest_tag_sha="$(git rev-parse "$latest_tag")"
+
+# Display a table of all the current version, tag, and HEAD commit information.
+printf '%-14s = %s\n' 'VERSION file'   "$version_version" \
+                      'changes.rst'    "$changes_version" \
+                      'Latest tag'     "$latest_tag" \
+                      'HEAD SHA'       "$head_sha" \
+                      'Latest tag SHA' "$latest_tag_sha"
+
+# Check that latest tag matches version and is the current HEAD we're releasing
+test "$version_version" = "$changes_version"
+test "$latest_tag" = "$version_version"
+test "$head_sha" = "$latest_tag_sha"
+printf 'OK, everything looks good.\n'

--- a/check-version.sh
+++ b/check-version.sh
@@ -5,27 +5,26 @@
 # You may want to run "make release" instead of running this script directly.
 
 set -eEfuo pipefail
-trap 'printf "%s: Check failed. Stopping.\n" "$0" >&2' ERR
+trap 'echo "$0: Check failed. Stopping." >&2' ERR
 
 readonly version_path='VERSION'
 readonly changes_path='doc/source/changes.rst'
 
-printf 'Checking current directory.\n'
+echo 'Checking current directory.'
 test "$(cd -- "$(dirname -- "$0")" && pwd)" = "$(pwd)"  # Ugly, but portable.
 
-printf 'Checking that %s and %s exist and have no uncommitted changes.\n' \
-    "$version_path" "$changes_path"
+echo "Checking that $version_path and $changes_path exist and have no uncommitted changes."
 test -f "$version_path"
 test -f "$changes_path"
 git status -s -- "$version_path" "$changes_path"
 test -z "$(git status -s -- "$version_path" "$changes_path")"
 
 # This section can be commented out, if absolutely necessary.
-printf 'Checking that ALL changes are committed.\n'
+echo 'Checking that ALL changes are committed.'
 git status -s --ignore-submodules
 test -z "$(git status -s --ignore-submodules)"
 
-printf 'Gathering current version, latest tag, and current HEAD commit info.\n'
+echo 'Gathering current version, latest tag, and current HEAD commit info.'
 version_version="$(cat "$version_path")"
 changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"
 config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
@@ -44,4 +43,4 @@ printf '%-14s = %s\n' 'VERSION file'   "$version_version" \
 test "$version_version" = "$changes_version"
 test "$latest_tag" = "$version_version"
 test "$head_sha" = "$latest_tag_sha"
-printf 'OK, everything looks good.\n'
+echo 'OK, everything looks good.'

--- a/check-version.sh
+++ b/check-version.sh
@@ -22,8 +22,8 @@ test -z "$(git status -s -- "$version_path" "$changes_path")"
 
 # This section can be commented out, if absolutely necessary.
 printf 'Checking that ALL changes are committed.\n'
-git status -s
-test -z "$(git status -s)"
+git status -s --ignore-submodules
+test -z "$(git status -s --ignore-submodules)"
 
 printf 'Gathering current version, latest tag, and current HEAD commit info.\n'
 version_version="$(cat "$version_path")"

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# This script checks if we appear ready to build and publish a new release.
+# This script checks if we are in a consistent state to build a new release.
 # See the release instructions in README.md for the steps to make this pass.
+# You may want to run "make release" instead of running this script directly.
 
 set -eEfuo pipefail
 trap 'printf "%s: Check failed. Stopping.\n" "$0" >&2' ERR

--- a/check-version.sh
+++ b/check-version.sh
@@ -13,7 +13,7 @@ readonly changes_path='doc/source/changes.rst'
 printf 'Checking current directory.\n'
 test "$(cd -- "$(dirname -- "$0")" && pwd)" = "$(pwd)"  # Ugly, but portable.
 
-printf 'Checking that %s and %s exist and have no committed changes.\n' \
+printf 'Checking that %s and %s exist and have no uncommitted changes.\n' \
     "$version_path" "$changes_path"
 test -f "$version_path"
 test -f "$changes_path"
@@ -40,7 +40,7 @@ printf '%-14s = %s\n' 'VERSION file'   "$version_version" \
                       'HEAD SHA'       "$head_sha" \
                       'Latest tag SHA' "$latest_tag_sha"
 
-# Check that latest tag matches version and is the current HEAD we're releasing
+# Check that the latest tag and current version match the HEAD we're releasing.
 test "$version_version" = "$changes_version"
 test "$latest_tag" = "$version_version"
 test "$head_sha" = "$latest_tag_sha"

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # This script checks if we are in a consistent state to build a new release.
 # See the release instructions in README.md for the steps to make this pass.

--- a/check-version.sh
+++ b/check-version.sh
@@ -24,7 +24,6 @@ echo 'Checking that ALL changes are committed.'
 git status -s --ignore-submodules
 test -z "$(git status -s --ignore-submodules)"
 
-echo 'Gathering current version, latest tag, and current HEAD commit info.'
 version_version="$(cat "$version_path")"
 changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"
 config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
@@ -33,6 +32,7 @@ head_sha="$(git rev-parse HEAD)"
 latest_tag_sha="$(git rev-parse "$latest_tag")"
 
 # Display a table of all the current version, tag, and HEAD commit information.
+echo $'\nThe VERSION must be the same in all locations, and so must the HEAD and tag SHA'
 printf '%-14s = %s\n' 'VERSION file'   "$version_version" \
                       'changes.rst'    "$changes_version" \
                       'Latest tag'     "$latest_tag" \


### PR DESCRIPTION
Fixes #1660

In `.gitattributes`:

- Fix checking out `init-tests-after-clone.sh` with LF line endings on all systems (this was broken).
- Add `Makefile` to so it is also checked out with LF line endings on all systems.\
  (Windows ports of `make` will usually tolerate CRLF line endings, but `\r` or other representations of CR may, and often do, appear in output, giving an appearance of a problem that is hard to dismiss. So it's worth keeping it LF.)

For the `force_release` target:

- Don't try to upload if building failed (#1660).
- Only suggest using a virtual environment to solve a failure that occurred outside of one.
- In a virtual environment, use `python`, not `python3`, for compatibility with Windows.\
  (Windows may have a `python3` command installed outside the virtual environment, which is the most confusing case, since it gets used even from inside, so it feels like installing packages in the venv had no effect. In contrast, some Debian and derived systems, and some macOS systems, have no `python` command *outside* a venv, or it's Python 2. So keep using `python3` when no venv is detected.)

For the `release` target:

- Reference the current commit as `HEAD` rather than `head`. `HEAD` is more portable, because `git` does not treat names case-insensitively by default on all systems. `head` works on Windows and I think macOS, but not GNU/Linux or most other Unix-like systems.
- Use `git tag --sort=-v:refname` with an appropriate [`versionsort.suffix`](https://www.git-scm.com/docs/git-config/#Documentation/git-config.txt-versionsortsuffix) to [**order the version tags in the specific SemVer-inspired way this project uses**](https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717237180), and a glob to omit the non-version tags. This avoids [the correctness problem](https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717014696) with the `| sort -nr` approach, is portable, and is more precise for this project's versions than even [nonportable `sort -V` tweaked for SemVer](https://gist.github.com/loisaidasam/b1e6879f3deb495c22cc?permalink_comment_id=4070026#gistcomment-4070026), because this project has SemVer suffixes like `-pre` where `N-pre` sorts before `N`, but also non-SemVer `-patched` where `N-patched` sorts after `N`.\
  (Thanks to @hugovk for [investigating what `sort -nr` was doing on macOS](https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717014696)!)
- Decrease duplication of complex `git` commands and pipelines.
- Write the checks to fail if a command in `$(` `)` fails (by extracting them to assignments), so that if a `git` command whose output is needed fails, this doesn't cause a check to wrongly succeed.
- Check for `VERSION` and `changes.rst`, against each other and also the latest tag name.
- Check for uncommitted changes.
- Do the version/tag/reference agreement check after printing out a table showing all the relevant values, so the specific problems can always be efficiently identified.

The above includes checks for indications that each of the actions listed in the `README.md` release instructions was done, and is intended to make it so `make release` is correct, fully usable, and preferable to `make force_release` in most situations.

I have tested this on Ubuntu and Windows. When testing, I pressed <kbd>Ctrl</kbd>+<kbd>C</kbd> when `twine` prompted for credentials. I tested both the `release` and `force_release` targets. Some of the manual tests of the `release` target on Ubuntu [can be seen in this original gist](https://gist.github.com/EliahKagan/e080b25996b97cb9561e3c74a664c8da) from [before that review](https://github.com/gitpython-developers/GitPython/pull/1661#pullrequestreview-1626077838), and [**this newer gist testing `build-release.sh`**](https://gist.github.com/EliahKagan/25ac58dd7ed5b952c20529acea1a2fe1). Although not shown in those gists, I have also tested that the Makefile targets use the scripts correctly since extracting commands to them.

Here's an example of output from `make release` showing various checks and the new version/tag/ref table and failing with an error due to an inconsistency that should block the release:

```text
(.venv) ek@Glub:~/repos-wsl/GitPython (portable-makefile=)$ make release
rm -rf build/ dist/ .eggs/ .tox/
./check-version.sh
Checking current directory.
Checking that VERSION and doc/source/changes.rst exist and have no uncommitted changes.
Checking that ALL changes are committed.
Gathering current version, latest tag, and current HEAD commit info.
VERSION file   = 3.1.36
changes.rst    = 3.1.36
Latest tag     = 3.1.36
HEAD SHA       = 4b7d7028193d3a03cc20867fa534e21528886f51
Latest tag SHA = 5297f6210f185c9df9c97392ffef4da8562b58ff
./check-version.sh: Check failed. Stopping.
make: *** [Makefile:10: release] Error 1
```

Here's an example of a failure where it doesn't get anywhere near that far:

```text
(.venv) ek@Glub:~/repos-wsl/GitPython (portable-makefile +=)$ make release
rm -rf build/ dist/ .eggs/ .tox/
./check-version.sh
Checking current directory.
Checking that VERSION and doc/source/changes.rst exist and have no uncommitted changes.
M  VERSION
./check-version.sh: Check failed. Stopping.
make: *** [Makefile:10: release] Error 1
```