### PR TITLE
Fix URLs that were redirecting to another license

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 # flake8: noqa
 # @PydevCodeAnalysisIgnore
 from git.exc import *  # @NoMove @IgnorePep8

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 from __future__ import annotations
 import re
 import contextlib

--- a/git/compat.py
+++ b/git/compat.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """utilities to help provide compatibility with python 3"""
 # flake8: noqa
 

--- a/git/config.py
+++ b/git/config.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """Module containing module parser implementation able to properly read and write
 configuration files"""
 

--- a/git/diff.py
+++ b/git/diff.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 import re
 from git.cmd import handle_process_output

--- a/git/exc.py
+++ b/git/exc.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """ Module containing all exceptions thrown throughout the git package, """
 
 from gitdb.exc import BadName  # NOQA @UnusedWildImport skipcq: PYL-W0401, PYL-W0614

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from contextlib import ExitStack
 import datetime

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from git.exc import WorkTreeRepositoryUnsupported
 from git.util import LazyMixin, join_path_native, stream_copy, bin_to_hex

--- a/git/objects/blob.py
+++ b/git/objects/blob.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 from mimetypes import guess_type
 from . import base
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import datetime
 import re
 from subprocess import Popen, PIPE

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """ Module containing all object based types. """
 from . import base
 from .util import get_object_type_by_name, parse_actor_and_date

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from git.util import IterableList, join_path
 import git.diff as git_diff

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """Module for general utility functions"""
 # flake8: noqa F401
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 # Module implementing a remote object allowing easy access to git remotes
 import logging

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 from __future__ import annotations
 import logging
 import os

--- a/git/types.py
+++ b/git/types.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 # flake8: noqa
 
 import os

--- a/git/util.py
+++ b/git/util.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from abc import abstractmethod
 import os.path as osp

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 # flake8: noqa
 import inspect

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import contextlib
 from functools import wraps
 import gc

--- a/test/performance/test_commit.py
+++ b/test/performance/test_commit.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 from io import BytesIO
 from time import time
 import sys

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase
 from git import Actor

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import os
 import sys
 import tempfile

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase
 from git import Blob

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from pathlib import Path
 import re

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import copy
 from datetime import datetime
 from io import BytesIO

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 import glob
 import io

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 from git.db import GitCmdObjectDB
 from git.exc import BadObject
 from test.lib import TestBase

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import ddt
 import shutil
 import tempfile
@@ -414,7 +414,7 @@ class TestDiff(TestBase):
 
     @with_rw_directory
     def test_rename_override(self, rw_dir):
-        """Test disabling of diff rename detection""" 
+        """Test disabling of diff rename detection"""
 
         # create and commit file_a.txt
         repo = Repo.init(rw_dir)
@@ -480,4 +480,3 @@ class TestDiff(TestBase):
         self.assertEqual(True, diff.renamed_file)
         self.assertEqual('file_a.txt', diff.rename_from)
         self.assertEqual('file_b.txt', diff.rename_to)
-

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import os
 import sys
 

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009, 2016 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 
 import re

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import os
 import shutil
 import subprocess

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
 import os

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -1,5 +1,5 @@
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 import ast
 import os

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from itertools import chain
 from pathlib import Path

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 import random
 import tempfile

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import glob
 import io
 from io import BytesIO

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase, fixture
 from git import Stats

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 import contextlib
 import os
 import shutil

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
 from unittest import skipIf

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 
 import os
 import pickle


### PR DESCRIPTION
All the opensource.org BSD [license URLs](http://www.opensource.org/licenses/bsd-license.php) at the top of source code files in this project had [originally pointed](https://web.archive.org/web/20080907042355/http://www.opensource.org/licenses/bsd-license.php) to a page on the 3-clause BSD license that this project [used](https://github.com/gitpython-developers/GitPython/commit/33ebe7acec14b25c5f84f35a664803fcab2f7781#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7) and [continues to use](https://github.com/gitpython-developers/GitPython/blob/main/LICENSE).

But over time the site was apparently reorganized and the link became a redirect to the page about the 2-clause BSD license. Because it is identified only as the "BSD license" in the comments in this project that contain the links, this unfortunately makes it so those top-of-file comments all wrongly claim that the project is 2-clause BSD licensed.

To be more specific, [bisecting archivals](https://web.archive.org/web/20110501000000*/http://www.opensource.org/licenses/bsd-license.php) reveals that the change apparently occurred sometime between [29 April 2011](https://web.archive.org/web/20110429232045/http://www.opensource.org/licenses/bsd-license.php) and [5 June 2011](https://web.archive.org/web/20110605023935/http://www.opensource.org/licenses/bsd-license.php).

This fixes the links by replacing them with the current URL of the opensource.org page on the 3-clause BSD license. The current URL contains "bsd-3-clause" in it, so this specific problem is unlikely to recur with that URL (and even if it did, the text "bsd-3-clause is information that may clue readers in to what is going on).

There may be other changes that could be made in the future to further clarify the license. For example, in `setup.py`, the license name is passed as `BSD`. There may be a more specific name that can be used and that PyPI and/or common tools will recognize for the 3-clause BSD license name. (If any [SPDX](https://spdx.org/licenses/) name can be used, which I think it can, then this is definitely so. However, a more specific *classifier* does not appear available.) But that's not actually a bug--it's not referring to a specific different license--and this PR does not make any such changes. Other than how I permitted my editor to remove trailing whitespace in the files it was saving, this pull request is strictly limited to updating those URLs.

This also affects numerous URLs in `gitdb`, for which I have opened https://github.com/gitpython-developers/gitdb/pull/96. It does not affect `smmap`.