### PR TITLE
Assorted small fixes/improvements to root dir docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,4 +52,5 @@ Contributors are:
 -Joseph Hale <me _at_ jhale.dev>
 -Santos Gallegos <stsewd _at_ proton.me>
 -Wenhan Zhu <wzhu.cosmos _at_ gmail.com>
+
 Portions derived from other open source works and are clearly marked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The following is a short step-by-step rundown of what one typically would do to contribute.
 
-- [fork this project](https://github.com/gitpython-developers/GitPython/fork) on GitHub.
+- [Fork this project](https://github.com/gitpython-developers/GitPython/fork) on GitHub.
 - For setting up the environment to run the self tests, please run `init-tests-after-clone.sh`.
 - Please try to **write a test that fails unless the contribution is present.**
 - Try to avoid massive commits and prefer to take small steps, with one commit for each.

--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,29 @@
 Copyright (C) 2008, 2009 Michael Trier and contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
 are met:
 
-* Redistributions of source code must retain the above copyright 
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright 
-notice, this list of conditions and the following disclaimer in the 
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-* Neither the name of the GitPython project nor the names of 
-its contributors may be used to endorse or promote products derived 
+* Neither the name of the GitPython project nor the names of
+its contributors may be used to endorse or promote products derived
 from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Please have a look at the [contributions file][contributing].
 
 - [User Documentation](http://gitpython.readthedocs.org)
 - [Questions and Answers](http://stackexchange.com/filters/167317/gitpython)
-- Please post on stackoverflow and use the `gitpython` tag
+- Please post on Stack Overflow and use the `gitpython` tag
 - [Issue Tracker](https://github.com/gitpython-developers/GitPython/issues)
   - Post reproducible bugs and feature requests as a new issue.
     Please be sure to provide the following information if posting bugs:
@@ -267,6 +267,7 @@ gpg --edit-key 4C08421980C9
 
 ### LICENSE
 
-New BSD License. See the LICENSE file.
+[New BSD License](https://opensource.org/license/bsd-3-clause/). See the [LICENSE file](https://github.com/gitpython-developers/GitPython/blob/main/license).
 
-[contributing]: https://github.com/gitpython-developers/GitPython/blob/master/CONTRIBUTING.md
+[contributing]: https://github.com/gitpython-developers/GitPython/blob/main/CONTRIBUTING.md
+[license]: https://github.com/gitpython-developers/GitPython/blob/main/license


### PR DESCRIPTION
This contains miscellaneous formatting fixes and minor proofreading in the top-level documentation files, plus making the text in the license section of `README.md` have links both to external information about the license and to the license file itself. The common theme is that these are changes to "documentation" files in the root of the repository that are individually minor but seem worth making and also don't seem like they would fit well in any other PR about anything else.

Note that the changes to the license file are just removal of excess whitespace (the extra blank line at the end, and spaces appearing at the end of lines). This does not attempt to change what license it used, *nor* the text of the license!

Some of are changes that are vaguely related to other PRs (whether existing or planned/aspirational). Changing anything related to the license in #1662 might've made that harder to review and might've given the impression to someone casually looking at the history that the license had changed (the opposite of what was really happening). I might open a future PR updating the readthedocs documentation source in `doc/source`, which may include this kind of proofreading, but it's not obviously better to do those together.