### PR TITLE
Use venv instead of virtualenv in test_installation

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,3 @@ pre-commit
 pytest
 pytest-cov
 pytest-sugar
-virtualenv

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -4,6 +4,8 @@
 import ast
 import os
 import subprocess
+import sys
+
 from git.compat import is_win
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
@@ -12,7 +14,7 @@ from test.lib.helper import with_rw_directory
 class TestInstallation(TestBase):
     def setUp_venv(self, rw_dir):
         self.venv = rw_dir
-        subprocess.run(["virtualenv", self.venv], stdout=subprocess.PIPE)
+        subprocess.run([sys.executable, "-m", "venv", self.venv], stdout=subprocess.PIPE)
         bin_name = "Scripts" if is_win else "bin"
         self.python = os.path.join(self.venv, bin_name, "python")
         self.pip = os.path.join(self.venv, bin_name, "pip")


### PR DESCRIPTION
This eliminates the test dependency on `virtualenv` by using the standard library `venv` module instead in `test_installation`.

This is independent of which, if either, users use for the environment that the test runner is run in. `sys.executable` is the Python interpreter of that environment, but once he test creates the virtual environment, it uses the virtual environment's `python` and `pip` commands for everything else. This is really the same exact approach as before, just instead of installing `virtualenv` as a dependency of the project, the standard library `venv` is used.

`venv` is more commonly used and more widely recommended today than `virtualenv`. So while users can use either and they both work well, it makes sense to test with venv instead. It is rare but possible for a Python installation not to have the `venv` module, if a fully working build is not installed, such as in a Docker container with insufficient packages installed on some operating systems. But this can usually be remedied by installing the appropriate packages, and because `venv` is a standard library module, it is reasonable to rely on its presence. (Furthermore, the `virtualenv` command as tested was looked up in a `$PATH` search and could just as well have been broken.)