### PR TITLE
Don't track code coverage temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/
 /lib/GitPython.egg-info
 cover/
 .coverage
+.coverage.*
 /build
 /dist
 /doc/_build


### PR DESCRIPTION
While running tests with coverage enabled (as is automatically the case in this project), files of the form `.coverage.MachineName.####.######` are created temporarily. For example, on my system, one of the names was recently `.coverage.Glub.7791.638878`.

When tests complete normally (whether or not there are failures), these files are automatically removed. However, when tests are cancelled with SIGINT (<kbd>Ctrl</kbd>+<kbd>C</kbd>), they are sometimes retained.

This adds another pattern to `.gitignore` so that, in addition to not tracking the `.coverage` file that is retained after tests, these other temporary files are also not tracked.

Further considerations:

- This also has the benefit of avoiding a situation at development time where one runs tests and also stages deliberate code changes at the same time, causing these files to be unintentionally staged along with the code. Relatedly, editors that frequently update with information about source control changes will no longer show these entries flashing in and out of existence, and (least importantly) such editors may run slightly faster in some cases.
- I considered simply changing existing `.coverage` pattern to `.coverage*`, but I decided against it, because if someone ever introduces a [`.coveragerc`](https://coverage.readthedocs.io/en/latest/config.html) file, they would expect that not to be ignored by source control. (They should probably not do this, since `pyproject.toml` is being used for this instead, but if they do, then it should not be automatically ignored.)