### PR TITLE
Format tests with black and auto-exclude untracked paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ mypy -p git
 For automatic code formatting, run:
 
 ```bash
-black git
+black .
 ```
 
 Configuration for flake8 is in the `./.flake8` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ omit = ["*/git/ext/*"]
 [tool.black]
 line-length = 120
 target-version = ['py37']
-exclude = "git/ext/gitdb"
+extend-exclude = "git/ext/gitdb"

--- a/test/performance/test_streams.py
+++ b/test/performance/test_streams.py
@@ -15,7 +15,6 @@ from .lib import TestBigRepoR
 
 
 class TestObjDBPerformance(TestBigRepoR):
-
     large_data_size_bytes = 1000 * 1000 * 10  # some MiB should do it
     moderate_data_size_bytes = 1000 * 1000 * 1  # just 1 MiB
 

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -93,7 +93,6 @@ class TestCommitSerialization(TestBase):
 
 class TestCommit(TestCommitSerialization):
     def test_bake(self):
-
         commit = self.rorepo.commit("2454ae89983a4496a445ce347d7a41c0bb0ea7ae")
         # commits have no dict
         self.assertRaises(AttributeError, setattr, commit, "someattr", 1)
@@ -170,15 +169,15 @@ class TestCommit(TestCommitSerialization):
 
         def check_entries(path, changes):
             expected = {
-                ".github/workflows/Future.yml" : {
-                    'insertions': 57,
-                    'deletions': 0,
-                    'lines': 57,
+                ".github/workflows/Future.yml": {
+                    "insertions": 57,
+                    "deletions": 0,
+                    "lines": 57,
                 },
-                ".github/workflows/test_pytest.yml" : {
-                    'insertions': 0,
-                    'deletions': 55,
-                    'lines': 55,
+                ".github/workflows/test_pytest.yml": {
+                    "insertions": 0,
+                    "deletions": 55,
+                    "lines": 55,
                 },
             }
             assert path in expected

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -173,12 +173,12 @@ class TestCommit(TestCommitSerialization):
                 ".github/workflows/Future.yml" : {
                     'insertions': 57,
                     'deletions': 0,
-                    'lines': 57
+                    'lines': 57,
                 },
                 ".github/workflows/test_pytest.yml" : {
                     'insertions': 0,
                     'deletions': 55,
-                    'lines': 55
+                    'lines': 55,
                 },
             }
             assert path in expected

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -419,7 +419,7 @@ class TestDiff(TestBase):
         # create and commit file_a.txt
         repo = Repo.init(rw_dir)
         file_a = osp.join(rw_dir, "file_a.txt")
-        with open(file_a, "w", encoding='utf-8') as outfile:
+        with open(file_a, "w", encoding="utf-8") as outfile:
             outfile.write("hello world\n")
         repo.git.add(Git.polish_url(file_a))
         repo.git.commit(message="Added file_a.txt")
@@ -429,21 +429,21 @@ class TestDiff(TestBase):
 
         # create and commit file_b.txt with similarity index of 52
         file_b = osp.join(rw_dir, "file_b.txt")
-        with open(file_b, "w", encoding='utf-8') as outfile:
+        with open(file_b, "w", encoding="utf-8") as outfile:
             outfile.write("hello world\nhello world")
         repo.git.add(Git.polish_url(file_b))
         repo.git.commit(message="Removed file_a.txt. Added file_b.txt")
 
-        commit_a = repo.commit('HEAD')
-        commit_b = repo.commit('HEAD~1')
+        commit_a = repo.commit("HEAD")
+        commit_b = repo.commit("HEAD~1")
 
         # check default diff command with renamed files enabled
         diffs = commit_b.diff(commit_a)
         self.assertEqual(1, len(diffs))
         diff = diffs[0]
         self.assertEqual(True, diff.renamed_file)
-        self.assertEqual('file_a.txt', diff.rename_from)
-        self.assertEqual('file_b.txt', diff.rename_to)
+        self.assertEqual("file_a.txt", diff.rename_from)
+        self.assertEqual("file_b.txt", diff.rename_to)
 
         # check diff with rename files disabled
         diffs = commit_b.diff(commit_a, no_renames=True)
@@ -452,31 +452,31 @@ class TestDiff(TestBase):
         # check fileA.txt deleted
         diff = diffs[0]
         self.assertEqual(True, diff.deleted_file)
-        self.assertEqual('file_a.txt', diff.a_path)
+        self.assertEqual("file_a.txt", diff.a_path)
 
         # check fileB.txt added
         diff = diffs[1]
         self.assertEqual(True, diff.new_file)
-        self.assertEqual('file_b.txt', diff.a_path)
+        self.assertEqual("file_b.txt", diff.a_path)
 
         # check diff with high similarity index
-        diffs = commit_b.diff(commit_a, split_single_char_options=False, M='75%')
+        diffs = commit_b.diff(commit_a, split_single_char_options=False, M="75%")
         self.assertEqual(2, len(diffs))
 
         # check fileA.txt deleted
         diff = diffs[0]
         self.assertEqual(True, diff.deleted_file)
-        self.assertEqual('file_a.txt', diff.a_path)
+        self.assertEqual("file_a.txt", diff.a_path)
 
         # check fileB.txt added
         diff = diffs[1]
         self.assertEqual(True, diff.new_file)
-        self.assertEqual('file_b.txt', diff.a_path)
+        self.assertEqual("file_b.txt", diff.a_path)
 
         # check diff with low similarity index
-        diffs = commit_b.diff(commit_a, split_single_char_options=False, M='40%')
+        diffs = commit_b.diff(commit_a, split_single_char_options=False, M="40%")
         self.assertEqual(1, len(diffs))
         diff = diffs[0]
         self.assertEqual(True, diff.renamed_file)
-        self.assertEqual('file_a.txt', diff.rename_from)
-        self.assertEqual('file_b.txt', diff.rename_to)
+        self.assertEqual("file_a.txt", diff.rename_from)
+        self.assertEqual("file_b.txt", diff.rename_to)

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -481,7 +481,7 @@ class Tutorials(TestBase):
     @pytest.mark.xfail(
         sys.platform == "cygwin",
         reason="Cygwin GitPython can't find SHA for submodule",
-        raises=ValueError
+        raises=ValueError,
     )
     def test_submodules(self):
         # [1-test_submodules]

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -946,7 +946,7 @@ class TestIndex(TestBase):
         else:
             raise AssertionError("Should have caught a HookExecutionError")
 
-    @with_rw_repo('HEAD')
+    @with_rw_repo("HEAD")
     def test_index_add_pathlike(self, rw_repo):
         git_dir = Path(rw_repo.git_dir)
 

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -13,14 +13,13 @@ class QuickDoc(TestBase):
 
     @with_rw_directory
     def test_init_repo_object(self, path_to_dir):
-
         # [1-test_init_repo_object]
         # $ git init <path/to/dir>
 
         from git import Repo
 
         repo = Repo.init(path_to_dir)
-       # ![1-test_init_repo_object]
+        # ![1-test_init_repo_object]
 
         # [2-test_init_repo_object]
         repo = Repo(path_to_dir)
@@ -28,9 +27,9 @@ class QuickDoc(TestBase):
 
     @with_rw_directory
     def test_cloned_repo_object(self, local_dir):
-
         from git import Repo
         import git
+
         # code to clone from url
         # [1-test_cloned_repo_object]
         # $ git clone <url> <local_dir>
@@ -44,9 +43,9 @@ class QuickDoc(TestBase):
         # [2-test_cloned_repo_object]
         # We must make a change to a file so that we can add the update to git
 
-        update_file = 'dir1/file2.txt' # we'll use local_dir/dir1/file2.txt
-        with open(f"{local_dir}/{update_file}", 'a') as f:
-            f.write('\nUpdate version 2')
+        update_file = "dir1/file2.txt"  # we'll use local_dir/dir1/file2.txt
+        with open(f"{local_dir}/{update_file}", "a") as f:
+            f.write("\nUpdate version 2")
         # ![2-test_cloned_repo_object]
 
         # [3-test_cloned_repo_object]
@@ -82,7 +81,7 @@ class QuickDoc(TestBase):
 
         # Untracked files - create new file
         # [7-test_cloned_repo_object]
-        f = open(f'{local_dir}/untracked.txt', 'w')  # creates an empty file
+        f = open(f"{local_dir}/untracked.txt", "w")  # creates an empty file
         f.close()
         # ![7-test_cloned_repo_object]
 
@@ -95,8 +94,8 @@ class QuickDoc(TestBase):
         # [9-test_cloned_repo_object]
         # Let's modify one of our tracked files
 
-        with open(f'{local_dir}/Downloads/file3.txt', 'w') as f:
-            f.write('file3 version 2')  # overwrite file 3
+        with open(f"{local_dir}/Downloads/file3.txt", "w") as f:
+            f.write("file3 version 2")  # overwrite file 3
         # ![9-test_cloned_repo_object]
 
         # [10-test_cloned_repo_object]
@@ -126,7 +125,7 @@ class QuickDoc(TestBase):
         # ![11.1-test_cloned_repo_object]
         # [11.2-test_cloned_repo_object]
         # lets add untracked.txt
-        repo.index.add(['untracked.txt'])
+        repo.index.add(["untracked.txt"])
         diffs = repo.index.diff(repo.head.commit)
         for d in diffs:
             print(d.a_path)
@@ -146,9 +145,7 @@ class QuickDoc(TestBase):
         # dir1/file2.txt
         # ![11.3-test_cloned_repo_object]
 
-
-
-        '''Trees and Blobs'''
+        """Trees and Blobs"""
 
         # Latest commit tree
         # [12-test_cloned_repo_object]
@@ -195,7 +192,7 @@ class QuickDoc(TestBase):
 
         # Printing text files
         # [17-test_cloned_repo_object]
-        print_file = 'dir1/file2.txt'
+        print_file = "dir1/file2.txt"
         tree[print_file]  # the head commit tree
 
         # Output <git.Blob "SHA1-HEX-HASH">

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -251,7 +251,9 @@ class TestRepo(TestBase):
                 self.fail("Raised UnicodeEncodeError")
 
     @with_rw_directory
-    @skip("the referenced repository was removed, and one needs to setup a new password controlled repo under the orgs control")
+    @skip(
+        "the referenced repository was removed, and one needs to setup a new password controlled repo under the orgs control"
+    )
     def test_leaking_password_in_clone_logs(self, rw_dir):
         password = "fakepassword1234"
         try:
@@ -391,7 +393,9 @@ class TestRepo(TestBase):
             for i, unsafe_option in enumerate(unsafe_options):
                 destination = tmp_dir / str(i)
                 assert not destination.exists()
-                Repo.clone_from(rw_repo.working_dir, destination, multi_options=[unsafe_option], allow_unsafe_options=True)
+                Repo.clone_from(
+                    rw_repo.working_dir, destination, multi_options=[unsafe_option], allow_unsafe_options=True
+                )
                 assert destination.exists()
 
     @with_rw_repo("HEAD")
@@ -755,8 +759,8 @@ class TestRepo(TestBase):
     @mock.patch.object(Git, "_call_process")
     def test_blame_accepts_rev_opts(self, git):
         res = self.rorepo.blame("HEAD", "README.md", rev_opts=["-M", "-C", "-C"])
-        expected_args = ['blame', 'HEAD', '-M', '-C', '-C', '--', 'README.md']
-        boilerplate_kwargs = {"p" : True, "stdout_as_string": False}
+        expected_args = ["blame", "HEAD", "-M", "-C", "-C", "--", "README.md"]
+        boilerplate_kwargs = {"p": True, "stdout_as_string": False}
         git.assert_called_once_with(*expected_args, **boilerplate_kwargs)
 
     @skipIf(
@@ -1415,14 +1419,16 @@ class TestRepo(TestBase):
 
             gi = tmp_dir / "repo" / ".gitignore"
 
-            with open(gi, 'w') as file:
-                file.write('ignored_file.txt\n')
-                file.write('ignored_dir/\n')
+            with open(gi, "w") as file:
+                file.write("ignored_file.txt\n")
+                file.write("ignored_dir/\n")
 
-            assert temp_repo.ignored(['included_file.txt', 'included_dir/file.txt']) == []
-            assert temp_repo.ignored(['ignored_file.txt']) == ['ignored_file.txt']
-            assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt']) == ['ignored_file.txt']
-            assert temp_repo.ignored(['included_file.txt', 'ignored_file.txt', 'included_dir/file.txt', 'ignored_dir/file.txt']) == ['ignored_file.txt', 'ignored_dir/file.txt']
+            assert temp_repo.ignored(["included_file.txt", "included_dir/file.txt"]) == []
+            assert temp_repo.ignored(["ignored_file.txt"]) == ["ignored_file.txt"]
+            assert temp_repo.ignored(["included_file.txt", "ignored_file.txt"]) == ["ignored_file.txt"]
+            assert temp_repo.ignored(
+                ["included_file.txt", "ignored_file.txt", "included_dir/file.txt", "ignored_dir/file.txt"]
+            ) == ["ignored_file.txt", "ignored_dir/file.txt"]
 
     def test_ignored_raises_error_w_symlink(self):
         with tempfile.TemporaryDirectory() as tdir:

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1115,7 +1115,7 @@ class TestRepo(TestBase):
     @pytest.mark.xfail(
         sys.platform == "cygwin",
         reason="Cygwin GitPython can't find submodule SHA",
-        raises=ValueError
+        raises=ValueError,
     )
     def test_submodules(self):
         self.assertEqual(len(self.rorepo.submodules), 1)  # non-recursive

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -39,11 +39,14 @@ def _patch_git_config(name, value):
 
     # This is recomputed each time the context is entered, for compatibility with
     # existing GIT_CONFIG_* environment variables, even if changed in this process.
-    patcher = mock.patch.dict(os.environ, {
-        "GIT_CONFIG_COUNT": str(pair_index + 1),
-        f"GIT_CONFIG_KEY_{pair_index}": name,
-        f"GIT_CONFIG_VALUE_{pair_index}": value,
-    })
+    patcher = mock.patch.dict(
+        os.environ,
+        {
+            "GIT_CONFIG_COUNT": str(pair_index + 1),
+            f"GIT_CONFIG_KEY_{pair_index}": name,
+            f"GIT_CONFIG_VALUE_{pair_index}": value,
+        },
+    )
 
     with patcher:
         yield
@@ -914,17 +917,17 @@ class TestSubmodule(TestBase):
         os.mkdir(smp)
 
         with open(osp.join(smp, "a"), "w", encoding="utf-8") as f:
-            f.write('test\n')
+            f.write("test\n")
 
         with open(osp.join(rwdir, ".gitmodules"), "w", encoding="utf-8") as f:
-            f.write("[submodule \"a\"]\n")
+            f.write('[submodule "a"]\n')
             f.write("    path = module\n")
             f.write("    url = https://github.com/chaconinc/DbConnector\n")
 
         parent.git.add(Git.polish_url(osp.join(smp, "a")))
         parent.git.add(Git.polish_url(osp.join(rwdir, ".gitmodules")))
 
-        parent.git.commit(message='test')
+        parent.git.commit(message="test")
 
         assert len(parent.submodules) == 0
 
@@ -1200,7 +1203,12 @@ class TestSubmodule(TestBase):
                 # The options will be allowed, but the command will fail.
                 with self.assertRaises(GitCommandError):
                     Submodule.add(
-                        rw_repo, "new", "new", str(tmp_dir), clone_multi_options=[unsafe_option], allow_unsafe_options=True
+                        rw_repo,
+                        "new",
+                        "new",
+                        str(tmp_dir),
+                        clone_multi_options=[unsafe_option],
+                        allow_unsafe_options=True,
                     )
                 assert not tmp_file.exists()
 
@@ -1211,7 +1219,12 @@ class TestSubmodule(TestBase):
             for unsafe_option in unsafe_options:
                 with self.assertRaises(GitCommandError):
                     Submodule.add(
-                        rw_repo, "new", "new", str(tmp_dir), clone_multi_options=[unsafe_option], allow_unsafe_options=True
+                        rw_repo,
+                        "new",
+                        "new",
+                        str(tmp_dir),
+                        clone_multi_options=[unsafe_option],
+                        allow_unsafe_options=True,
                     )
 
     @with_rw_repo("HEAD")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -469,7 +469,7 @@ class TestSubmodule(TestBase):
     @pytest.mark.xfail(
         sys.platform == "cygwin",
         reason="Cygwin GitPython can't find submodule SHA",
-        raises=ValueError
+        raises=ValueError,
     )
     @skipIf(
         HIDE_WINDOWS_KNOWN_ERRORS,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -159,7 +159,7 @@ class TestUtils(TestBase):
     @pytest.mark.xfail(
         sys.platform == "cygwin",
         reason="Cygwin fails here for some reason, always",
-        raises=AssertionError
+        raises=AssertionError,
     )
     def test_blocking_lock_file(self):
         my_file = tempfile.mktemp()

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ ignore_outcome = true
 [testenv:black]
 description = Check style with black
 base_python = py39
-commands = black --check --diff git
+commands = black --check --diff .
 
 # Run "tox -e html" for this. It is deliberately excluded from env_list, as
 # unlike the other environments, this one writes outside the .tox/ directory.


### PR DESCRIPTION
This expands the use of `black` to cover the whole codebase (still excluding submodules).

- Replaced `exclude` with `extend-exclude` so `black`'s default exclusions, which include anything specified in `.gitignore`, remain in effect as well as the specific path(s) specified to be excluded. This allows `black .` to be run to format everything that should be formatted and nothing that shouldn't.
- Made a few manual formatting adjustments that lead to more readable code in a few places once formatted with `black`. (This does not have to be redone; the idea is to be in the common subset of what was intended and what `black` considers its style.)
- Changed `black git` to `black .` in the instructions in `README.md` and in the command in `tox.ini` that runs via `tox` or `tox -e black`.
- Actually ran `black .`, formatting the tests in `black` style.