### PR TITLE
Upgrade and broaden flake8, fixing style problems and bugs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,7 @@ ignore = E265,E266,E731,E704,
          D,
          RST, RST3
 
-exclude = .tox,.venv,build,dist,doc,git/ext/,test
+exclude = .tox,.venv,build,dist,doc,git/ext/
 
 rst-roles =  # for flake8-RST-docstrings
     attr,class,func,meth,mod,obj,ref,term,var  # used by sphinx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
       - id: flake8
         additional_dependencies:
           [
-            flake8-bugbear==22.12.6,
-            flake8-comprehensions==3.10.1,
+            flake8-bugbear==23.9.16,
+            flake8-comprehensions==3.14.0,
             flake8-typing-imports==1.14.0,
           ]
         exclude: ^doc|^git/ext/|^test/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
             flake8-comprehensions==3.14.0,
             flake8-typing-imports==1.14.0,
           ]
-        exclude: ^doc|^git/ext/|^test/
+        exclude: ^doc|^git/ext/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1403,7 +1403,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END handle critical error
 
             # Make sure we are looking at a submodule object
-            if type(sm) != git.objects.submodule.base.Submodule:
+            if type(sm) is not git.objects.submodule.base.Submodule:
                 continue
 
             # fill in remaining info - saves time as it doesn't have to be parsed again

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -244,7 +244,7 @@ class RefLog(List[RefLogEntry], Serializable):
             for i in range(index + 1):
                 line = fp.readline()
                 if not line:
-                    raise IndexError(f"Index file ended at line {i+1}, before given index was reached")
+                    raise IndexError(f"Index file ended at line {i + 1}, before given index was reached")
                 # END abort on eof
             # END handle runup
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -206,7 +206,8 @@ class Repo(object):
         if expand_vars and re.search(self.re_envvars, epath):
             warnings.warn(
                 "The use of environment variables in paths is deprecated"
-                + "\nfor security reasons and may be removed in the future!!"
+                + "\nfor security reasons and may be removed in the future!!",
+                stacklevel=1,
             )
         epath = expand_path(epath, expand_vars)
         if epath is not None:

--- a/git/util.py
+++ b/git/util.py
@@ -1136,7 +1136,7 @@ class IterableClassWatcher(type):
 
     def __init__(cls, name: str, bases: Tuple, clsdict: Dict) -> None:
         for base in bases:
-            if type(base) == IterableClassWatcher:
+            if type(base) is IterableClassWatcher:
                 warnings.warn(
                     f"GitPython Iterable subclassed by {name}. "
                     "Iterable is deprecated due to naming clash since v3.1.18"

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -94,17 +94,16 @@ def with_rw_directory(func):
         os.mkdir(path)
         keep = False
         try:
-            try:
-                return func(self, path)
-            except Exception:
-                log.info(
-                    "Test %s.%s failed, output is at %r\n",
-                    type(self).__name__,
-                    func.__name__,
-                    path,
-                )
-                keep = True
-                raise
+            return func(self, path)
+        except Exception:
+            log.info(
+                "Test %s.%s failed, output is at %r\n",
+                type(self).__name__,
+                func.__name__,
+                path,
+            )
+            keep = True
+            raise
         finally:
             # Need to collect here to be sure all handles have been closed. It appears
             # a windows-only issue. In fact things should be deleted, as well as
@@ -147,12 +146,11 @@ def with_rw_repo(working_tree_ref, bare=False):
             prev_cwd = os.getcwd()
             os.chdir(rw_repo.working_dir)
             try:
-                try:
-                    return func(self, rw_repo)
-                except:  # noqa E722
-                    log.info("Keeping repo after failure: %s", repo_dir)
-                    repo_dir = None
-                    raise
+                return func(self, rw_repo)
+            except:  # noqa E722
+                log.info("Keeping repo after failure: %s", repo_dir)
+                repo_dir = None
+                raise
             finally:
                 os.chdir(prev_cwd)
                 rw_repo.git.clear_cache()

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -277,7 +277,7 @@ class TestCommit(TestCommitSerialization):
                 super(Child, self).__init__(*args, **kwargs)
 
         child_commits = list(Child.iter_items(self.rorepo, "master", paths=("CHANGES", "AUTHORS")))
-        assert type(child_commits[0]) == Child
+        assert type(child_commits[0]) is Child
 
     def test_iter_items(self):
         # pretty not allowed
@@ -525,12 +525,12 @@ JzJMZDRLQLFvnzqZuCjE
 
         # check that trailer stays empty for multiple msg combinations
         msgs = [
-            f"Subject\n",
-            f"Subject\n\nBody with some\nText\n",
-            f"Subject\n\nBody with\nText\n\nContinuation but\n doesn't contain colon\n",
-            f"Subject\n\nBody with\nText\n\nContinuation but\n only contains one :\n",
-            f"Subject\n\nBody with\nText\n\nKey: Value\nLine without colon\n",
-            f"Subject\n\nBody with\nText\n\nLine without colon\nKey: Value\n",
+            "Subject\n",
+            "Subject\n\nBody with some\nText\n",
+            "Subject\n\nBody with\nText\n\nContinuation but\n doesn't contain colon\n",
+            "Subject\n\nBody with\nText\n\nContinuation but\n only contains one :\n",
+            "Subject\n\nBody with\nText\n\nKey: Value\nLine without colon\n",
+            "Subject\n\nBody with\nText\n\nLine without colon\nKey: Value\n",
         ]
 
         for msg in msgs:

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -7,7 +7,6 @@
 import ddt
 import shutil
 import tempfile
-import unittest
 from git import (
     Repo,
     GitCommandError,

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -263,9 +263,9 @@ class Tutorials(TestBase):
         # [8-test_references_and_objects]
         hc = repo.head.commit
         hct = hc.tree
-        hc != hct  # @NoEffect
-        hc != repo.tags[0]  # @NoEffect
-        hc == repo.head.reference.commit  # @NoEffect
+        hc != hct  # noqa: B015  # @NoEffect
+        hc != repo.tags[0]  # noqa: B015  # @NoEffect
+        hc == repo.head.reference.commit  # noqa: B015  # @NoEffect
         # ![8-test_references_and_objects]
 
         # [9-test_references_and_objects]
@@ -369,7 +369,7 @@ class Tutorials(TestBase):
         # The index contains all blobs in a flat list
         assert len(list(index.iter_blobs())) == len([o for o in repo.head.commit.tree.traverse() if o.type == "blob"])
         # Access blob objects
-        for (_path, _stage), entry in index.entries.items():
+        for (_path, _stage), _entry in index.entries.items():
             pass
         new_file_path = os.path.join(repo.working_tree_dir, "new-file-name")
         open(new_file_path, "w").close()

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -195,17 +195,12 @@ class TestGit(TestBase):
         # END verify number types
 
     def test_cmd_override(self):
-        prev_cmd = self.git.GIT_PYTHON_GIT_EXECUTABLE
-        exc = GitCommandNotFound
-        try:
-            # set it to something that doesn't exist, assure it raises
-            type(self.git).GIT_PYTHON_GIT_EXECUTABLE = osp.join(
-                "some", "path", "which", "doesn't", "exist", "gitbinary"
-            )
-            self.assertRaises(exc, self.git.version)
-        finally:
-            type(self.git).GIT_PYTHON_GIT_EXECUTABLE = prev_cmd
-        # END undo adjustment
+        with mock.patch.object(
+            type(self.git),
+            "GIT_PYTHON_GIT_EXECUTABLE",
+            osp.join("some", "path", "which", "doesn't", "exist", "gitbinary"),
+        ):
+            self.assertRaises(GitCommandNotFound, self.git.version)
 
     def test_refresh(self):
         # test a bad git path refresh

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -245,7 +245,7 @@ class TestGit(TestBase):
 
     def test_env_vars_passed_to_git(self):
         editor = "non_existent_editor"
-        with mock.patch.dict("os.environ", {"GIT_EDITOR": editor}):  # @UndefinedVariable
+        with mock.patch.dict(os.environ, {"GIT_EDITOR": editor}):
             self.assertEqual(self.git.var("GIT_EDITOR"), editor)
 
     @with_rw_directory

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
 
@@ -25,10 +22,11 @@ class QuickDoc(TestBase):
         repo = Repo(path_to_dir)
         # ![2-test_init_repo_object]
 
+        del repo  # Avoids "assigned to but never used" warning. Doesn't go in the docs.
+
     @with_rw_directory
     def test_cloned_repo_object(self, local_dir):
         from git import Repo
-        import git
 
         # code to clone from url
         # [1-test_cloned_repo_object]
@@ -72,7 +70,7 @@ class QuickDoc(TestBase):
 
         # [6-test_cloned_repo_object]
         commits_for_file_generator = repo.iter_commits(all=True, max_count=10, paths=update_file)
-        commits_for_file = [c for c in commits_for_file_generator]
+        commits_for_file = list(commits_for_file_generator)
         commits_for_file
 
         # Outputs: [<git.Commit "SHA1-HEX_HASH-2">,
@@ -136,7 +134,7 @@ class QuickDoc(TestBase):
 
         # Compare commit to commit
         # [11.3-test_cloned_repo_object]
-        first_commit = [c for c in repo.iter_commits(all=True)][-1]
+        first_commit = list(repo.iter_commits(all=True))[-1]
         diffs = repo.head.commit.diff(first_commit)
         for d in diffs:
             print(d.a_path)
@@ -154,7 +152,7 @@ class QuickDoc(TestBase):
 
         # Previous commit tree
         # [13-test_cloned_repo_object]
-        prev_commits = [c for c in repo.iter_commits(all=True, max_count=10)]  # last 10 commits from all branches
+        prev_commits = list(repo.iter_commits(all=True, max_count=10))  # last 10 commits from all branches
         tree = prev_commits[0].tree
         # ![13-test_cloned_repo_object]
 
@@ -210,7 +208,7 @@ class QuickDoc(TestBase):
 
         # print previous tree
         # [18.1-test_cloned_repo_object]
-        commits_for_file = [c for c in repo.iter_commits(all=True, paths=print_file)]
+        commits_for_file = list(repo.iter_commits(all=True, paths=print_file))
         tree = commits_for_file[-1].tree  # gets the first commit tree
         blob = tree[print_file]
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -160,7 +160,7 @@ class TestRemote(TestBase):
             # END error checking
         # END for each info
 
-        if any([info.flags & info.ERROR for info in results]):
+        if any(info.flags & info.ERROR for info in results):
             self.assertRaises(GitCommandError, results.raise_if_error)
         else:
             # No errors, so this should do nothing

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -847,18 +847,13 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     def test_tilde_and_env_vars_in_repo_path(self, rw_dir):
-        ph = os.environ.get("HOME")
-        try:
+        with mock.patch.dict(os.environ, {"HOME": rw_dir}):
             os.environ["HOME"] = rw_dir
             Repo.init(osp.join("~", "test.git"), bare=True)
 
+        with mock.patch.dict(os.environ, {"FOO": rw_dir}):
             os.environ["FOO"] = rw_dir
             Repo.init(osp.join("$FOO", "test.git"), bare=True)
-        finally:
-            if ph:
-                os.environ["HOME"] = ph
-                del os.environ["FOO"]
-        # end assure HOME gets reset to what it was
 
     def test_git_cmd(self):
         # test CatFileContentStream, just to be very sure we have no fencepost errors

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -252,7 +252,8 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     @skip(
-        "the referenced repository was removed, and one needs to setup a new password controlled repo under the orgs control"
+        """The referenced repository was removed, and one needs to set up a new
+        password controlled repo under the org's control."""
     )
     def test_leaking_password_in_clone_logs(self, rw_dir):
         password = "fakepassword1234"
@@ -758,9 +759,9 @@ class TestRepo(TestBase):
 
     @mock.patch.object(Git, "_call_process")
     def test_blame_accepts_rev_opts(self, git):
-        res = self.rorepo.blame("HEAD", "README.md", rev_opts=["-M", "-C", "-C"])
         expected_args = ["blame", "HEAD", "-M", "-C", "-C", "--", "README.md"]
         boilerplate_kwargs = {"p": True, "stdout_as_string": False}
+        self.rorepo.blame("HEAD", "README.md", rev_opts=["-M", "-C", "-C"])
         git.assert_called_once_with(*expected_args, **boilerplate_kwargs)
 
     @skipIf(
@@ -971,7 +972,7 @@ class TestRepo(TestBase):
         # history with number
         ni = 11
         history = [obj.parents[0]]
-        for pn in range(ni):
+        for _ in range(ni):
             history.append(history[-1].parents[0])
         # END get given amount of commits
 
@@ -1329,6 +1330,7 @@ class TestRepo(TestBase):
         # move .git directory to a subdirectory
         # set GIT_DIR and GIT_WORK_TREE appropriately
         # check that repo.working_tree_dir == rw_dir
+
         self.rorepo.clone(join_path_native(rw_dir, "master_repo"))
 
         repo_dir = join_path_native(rw_dir, "master_repo")
@@ -1338,16 +1340,12 @@ class TestRepo(TestBase):
         os.mkdir(new_subdir)
         os.rename(old_git_dir, new_git_dir)
 
-        oldenv = os.environ.copy()
-        os.environ["GIT_DIR"] = new_git_dir
-        os.environ["GIT_WORK_TREE"] = repo_dir
+        to_patch = {"GIT_DIR": new_git_dir, "GIT_WORK_TREE": repo_dir}
 
-        try:
+        with mock.patch.dict(os.environ, to_patch):
             r = Repo()
             self.assertEqual(r.working_tree_dir, repo_dir)
             self.assertEqual(r.working_dir, repo_dir)
-        finally:
-            os.environ = oldenv
 
     @with_rw_directory
     def test_rebasing(self, rw_dir):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -111,7 +111,7 @@ class TestSubmodule(TestBase):
 
         # force it to reread its information
         del smold._url
-        smold.url == sm.url  # @NoEffect
+        smold.url == sm.url  # noqa: B015  # @NoEffect
 
         # test config_reader/writer methods
         sm.config_reader()
@@ -248,7 +248,7 @@ class TestSubmodule(TestBase):
             assert csm.module_exists()
 
             # tracking branch once again
-            csm.module().head.ref.tracking_branch() is not None  # @NoEffect
+            assert csm.module().head.ref.tracking_branch() is not None
 
             # this flushed in a sub-submodule
             assert len(list(rwrepo.iter_submodules())) == 2
@@ -480,8 +480,9 @@ class TestSubmodule(TestBase):
         File "C:\\projects\\gitpython\\git\\cmd.py", line 559, in execute
         raise GitCommandNotFound(command, err)
         git.exc.GitCommandNotFound: Cmd('git') not found due to: OSError('[WinError 6] The handle is invalid')
-        cmdline: git clone -n --shared -v C:\\projects\\gitpython\\.git Users\\appveyor\\AppData\\Local\\Temp\\1\\tmplyp6kr_rnon_bare_test_root_module""",
-    )  # noqa E501
+        cmdline: git clone -n --shared -v C:\\projects\\gitpython\\.git Users\\appveyor\\AppData\\Local\\Temp\\1\\tmplyp6kr_rnon_bare_test_root_module
+        """,  # noqa E501
+    )
     @with_rw_repo(k_subm_current, bare=False)
     def test_root_module(self, rwrepo):
         # Can query everything without problems


### PR DESCRIPTION
Fixes #1670
Fixes #1671

I've upgraded `flake8` in the pre-commit configuration, which automatically upgrades its `pycodestyle` dependency. This makes it compatible with Python 3.12 (or at least we seem unaffected by any remaining incompatibilities). I've also upgraded its non-default plugins, which are listed there as additional dependencies. I have fixed a warning that was for some reason specific to 3.12 about spacing around `+`, as well as some new warnings that came in the new version of `pycodestyle` and new versions of the non-default packages. This included changing `==` to `is` and `!=` to `is not` when comparing `type` objects, since in all cases it appeared *exact* type matching was intended (rather than what an `issubclass` or, under simplification of the surrounding code, `isinstance` would check). See #1670.

I've also broadened `flake8` to check the whole project (except the `doc/` directory). That is, it now checks the test suite. It issued a number of warnings, and I fixed the code accordingly. Most of these are style changes, but it revealed #1671, which I fixed as described there (by using `unittest.mock.patch.dict`, which as noted there is okay because it is only in the tests). I then looked for bugs in `finally` cleanup logic throughout the project, in case anything else like that was present that I could identify and fix. I found no further serious bugs inside `test/` while doing this, but I did find some areas I could simplify or otherwise improve, including one place where a throwaway environment variable `FOO` was never unpatched.

I included those changes in this PR, but not any changes to code in `git/` other than to fix what `flake8` found. One place in `git/` that should be changed is a bug that merits fixing in some way, which I opened #1669 for. Other areas of improvement in `git/` related to the use of `finally` are less important, and some of them subjective. I could include them in a fix for #1669 (if I end up fixing it) or in a separate PR, but I've omitted those further changes in `git/` from this PR to keep its scope from creeping too large.

**An area that I think deserves special attention in review** is changes I made in parts of the test code that are reflected in built documentation that will be published on readthedocs:

- Where `@NoEffect` appeared in code that is copied to automatically generate usage examples in the documentation, I expanded it to `# noqa: B015  # @NoEffect`. Readability seems still intact, and I am inclined to think this is justified as long as we need to have `@NoEffect`. However, if `@NoEffect` is no longer needed, then I think configuring `flake8` to disable the specific warning in those two specific test modules would be better, since then neither `@NoEffect` nor `# noqa: B015` would need to appear anywhere in documentation example code.
- Comprehensions that perform neither mapping nor filtering are only occasionally useful, and almost never when they are list comprehensions: code like `[c for c in commits_for_file_generator]` should be `list(commits_for_file_generator)` instead. Expressions of that form appear a number of times in tests from which documentation is automatically generated, and I think changing it in this way is only beneficial. However, since it is a code change that will affect documentation (which might otherwise be unexpected), I do want to call attention to it, too.

In most cases I have retained existing `noqa` comments, and I suspect a number of them could be removed. That could be done at any time, and it was also only to limit scope that I have not tried to do it here. Besides that, however, there is a different reason I have deliberately avoided going further with `flake8`--for example, by adding it and its extra plugins as development dependencies of the project (they are still only installed by and for `pre-commit`), running it on CI, enabling more checks, or attempting to get the `flake8-type-checking` plugin listed in `requirements-dev.txt` working. The reason is that I think it would be beneficial to replace `flake8` in this project with [`ruff`](https://docs.astral.sh/ruff/), which is modern, versatile, and extremely fast. (This is also why I have not proposed that we also adopt [`isort`](https://pycqa.github.io/isort/), even though `isort` is one of my favorite tools: `ruff` might take care of that, too.)