### PR TITLE
Fix rollback bug in SymbolicReference.set_reference

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -406,15 +406,14 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             return
 
         try:
-            try:
-                self.write()
-            except IOError:
-                log.error("Exception during destruction of GitConfigParser", exc_info=True)
-            except ReferenceError:
-                # This happens in PY3 ... and usually means that some state cannot be written
-                # as the sections dict cannot be iterated
-                # Usually when shutting down the interpreter, don'y know how to fix this
-                pass
+            self.write()
+        except IOError:
+            log.error("Exception during destruction of GitConfigParser", exc_info=True)
+        except ReferenceError:
+            # This happens in PY3 ... and usually means that some state cannot be
+            # written as the sections dict cannot be iterated
+            # Usually when shutting down the interpreter, don't know how to fix this
+            pass
         finally:
             if self._lock is not None:
                 self._lock._release_lock()

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -224,13 +224,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         lfd = LockedFD(file_path or self._file_path)
         stream = lfd.open(write=True, stream=True)
 
-        ok = False
         try:
             self._serialize(stream, ignore_extension_data)
-            ok = True
-        finally:
-            if not ok:
-                lfd.rollback()
+        except BaseException:
+            lfd.rollback()
+            raise
 
         lfd.commit()
 

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -262,8 +262,7 @@ class RefLog(List[RefLogEntry], Serializable):
         try:
             self._serialize(fp)
             lfd.commit()
-        except Exception:
-            # on failure it rolls back automatically, but we make it clear
+        except BaseException:
             lfd.rollback()
             raise
         # END handle change

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -370,14 +370,12 @@ class SymbolicReference(object):
 
         lfd = LockedFD(fpath)
         fd = lfd.open(write=True, stream=True)
-        ok = False
         try:
             fd.write(write_value.encode("utf-8") + b"\n")
             lfd.commit()
-            ok = True
-        finally:
-            if not ok:
-                lfd.rollback()
+        except BaseException:
+            lfd.rollback()
+            raise
         # Adjust the reflog
         if logmsg is not None:
             self.log_append(oldbinsha, logmsg)

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -370,7 +370,7 @@ class SymbolicReference(object):
 
         lfd = LockedFD(fpath)
         fd = lfd.open(write=True, stream=True)
-        ok = True
+        ok = False
         try:
             fd.write(write_value.encode("utf-8") + b"\n")
             lfd.commit()


### PR DESCRIPTION
Fixes #1669

This fixes the *specific* bug in `SymbolicReference.set_reference` where the local call to `ldf.rollback` is never made. It also refactors, both here and elsewhere, to make `try`-`finally` logic clearer and simpler, and in some cases to replace it. This is to prevent such bugs from recurring, or at least make them easier to spot. This cleanup corresponds to `try`-`finally` cleanup done in the test suite as part of the larger PR #1673, but none of these changes were necessary to fix `flake8` warnings, nor directly related to changes that were necessary for that, and it seemed like including this in that PR would make it broader than would be ideal.

As noted in https://github.com/gitpython-developers/GitPython/issues/1669#issuecomment-1729125356, the best solution to this, along with much of the rest of what may fall under the current [resource leakage limitation](https://github.com/gitpython-developers/GitPython?tab=readme-ov-file#leakage-of-system-resources), would be to make `LockedFD` and other classes with `__del__` methods into context managers and use them as such (typically with `with`-statements) throughout GitPython. **This does not make that change**, as it is only a narrow-bugfix and cleanup PR.

From https://github.com/gitpython-developers/GitPython/issues/1669#issuecomment-1729125356 I am uncertain if this pull request would be considered to be in good shape without additions or other changes. However, I figured that, by opening it, these extra changes I did in `git/` while working on #1673, that I considered useful but not topically suitable for inclusion in #1673, can be reviewed and, if considered valuable, merged with or without refinements.