### PR TITLE
Remove `@NoEffect` annotations

### DIFF
--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -167,7 +167,7 @@ class Tutorials(TestBase):
         open(new_file_path, "wb").close()  # create new file in working tree
         cloned_repo.index.add([new_file_path])  # add it to the index
         # Commit the changes to deviate masters history
-        cloned_repo.index.commit("Added a new file in the past - for later merege")
+        cloned_repo.index.commit("Added a new file in the past - for later merge")
 
         # prepare a merge
         master = cloned_repo.heads.master  # right-hand side is ahead of us, in the future
@@ -198,7 +198,7 @@ class Tutorials(TestBase):
 
         # .gitmodules was written and added to the index, which is now being committed
         cloned_repo.index.commit("Added submodule")
-        assert sm.exists() and sm.module_exists()  # this submodule is defintely available
+        assert sm.exists() and sm.module_exists()  # this submodule is definitely available
         sm.remove(module=True, configuration=False)  # remove the working tree
         assert sm.exists() and not sm.module_exists()  # the submodule itself is still available
 
@@ -263,9 +263,9 @@ class Tutorials(TestBase):
         # [8-test_references_and_objects]
         hc = repo.head.commit
         hct = hc.tree
-        hc != hct  # noqa: B015  # @NoEffect
-        hc != repo.tags[0]  # noqa: B015  # @NoEffect
-        hc == repo.head.reference.commit  # noqa: B015  # @NoEffect
+        assert hc != hct
+        assert hc != repo.tags[0]
+        assert hc == repo.head.reference.commit
         # ![8-test_references_and_objects]
 
         # [9-test_references_and_objects]

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -386,7 +386,7 @@ class TestRefs(TestBase):
         head_tree = head.commit.tree
         self.assertRaises(ValueError, setattr, head, "commit", head_tree)
         assert head.commit == old_commit  # and the ref did not change
-        # we allow heds to point to any object
+        # we allow heads to point to any object
         head.object = head_tree
         assert head.object == head_tree
         # cannot query tree as commit
@@ -489,7 +489,7 @@ class TestRefs(TestBase):
             cur_head.reference.commit,
         )
         # it works if the new ref points to the same reference
-        assert SymbolicReference.create(rw_repo, symref.path, symref.reference).path == symref.path  # @NoEffect
+        assert SymbolicReference.create(rw_repo, symref.path, symref.reference).path == symref.path
         SymbolicReference.delete(rw_repo, symref)
         # would raise if the symref wouldn't have been deletedpbl
         symref = SymbolicReference.create(rw_repo, symref_path, cur_head.reference)

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -111,7 +111,7 @@ class TestSubmodule(TestBase):
 
         # force it to reread its information
         del smold._url
-        smold.url == sm.url  # noqa: B015  # @NoEffect
+        smold.url == sm.url  # noqa: B015  # FIXME: Should this be an assertion?
 
         # test config_reader/writer methods
         sm.config_reader()


### PR DESCRIPTION
Fixes #1674

Along with removing all `@NoEffect` annotations (there were only a handful), this:

- Adds missing asserts, where an expression statement was by itself that was intended as an assertion. This turned out to be the case in the places `@NoEffect` appeared in rendered documentation, making it so no per-file-ignores or other broadened suppressions were needed.
- Fixes misspellings (including one case affecting documentation).
- Adds a FIXME comment for investigating a free-standing expression statement with no obvious side effects that may have been meant as an assertion but [would fail if turned into one](https://gist.github.com/EliahKagan/9c49ca00036b3138458cbbfd0c008ebc).

There are some other commented `@`-style suppression annotations throughout the project. This PR deliberately does not touch those. Some of them express useful intent that should eventually be stated in a different way but currently could be a breaking change to express better. For example, some of them express that a name that is imported but not used is intended to be present, which is better expressed with a static `__all__` listing exactly the names (imports and otherwise) meant to be accessed through the module, but to usefully express this an `__all__` needs to omit names not intended to be accessed that way, which [may be a breaking change](https://github.com/gitpython-developers/GitPython/pull/1659#issuecomment-1718867511).