### PR TITLE
Make clear every test's status in every CI run

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -33,10 +33,6 @@ jobs:
       with:
         packages: python39 python39-pip python39-virtualenv git
 
-    - name: Limit $PATH to Cygwin
-      run: |
-        echo 'C:\cygwin\bin' > "$GITHUB_PATH"  # Overwrite it with just this.
-
     - name: Special configuration for Cygwin's git
       run: |
         git config --global --add safe.directory "$(pwd)"

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
     env:
       CHERE_INVOKING: 1
-      SHELLOPTS: igncr
       TMP: "/tmp"
       TEMP: "/tmp"
     defaults:
@@ -19,7 +18,7 @@ jobs:
     steps:
     - name: Force LF line endings
       run: |
-        git config --global core.autocrlf input
+        git config --global core.autocrlf false  # Affects the non-Cygwin git.
       shell: bash
 
     - uses: actions/checkout@v4
@@ -32,11 +31,13 @@ jobs:
         packages: python39 python39-pip python39-virtualenv git
 
     - name: Limit $PATH to Cygwin
-      run: echo 'C:\cygwin\bin' >"$GITHUB_PATH"
+      run: |
+        echo 'C:\cygwin\bin' > "$GITHUB_PATH"  # Overwrite it with just this.
 
-    - name: Tell git to trust this repo
+    - name: Special configuration for Cygwin's git
       run: |
         git config --global --add safe.directory "$(pwd)"
+        git config --global core.autocrlf false
 
     - name: Prepare this repo for tests
       run: |
@@ -70,5 +71,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        set +x
         python -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         TRAVIS=yes ./init-tests-after-clone.sh
 
-    - name: Further prepare git configuration for tests
+    - name: Set git user identity and command aliases for the tests
       run: |
         git config --global user.email "travis@ci.com"
         git config --global user.name "Travis Runner"
@@ -52,7 +52,8 @@ jobs:
 
     - name: Update PyPA packages
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -oF setuptools) wheel
 
     - name: Install project and test dependencies
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -64,4 +64,4 @@ jobs:
     - name: Test with pytest
       run: |
         set +x
-        /usr/bin/python -m pytest -v
+        /usr/bin/python -m pytest -p no:sugar -v --instafail

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -58,7 +58,11 @@ jobs:
       run: |
         /usr/bin/python -m pip install ".[test]"
 
+    - name: Check 'is_win'
+      run: |
+        /usr/bin/python -c 'import os, git; print(f"os.name={os.name}, is_win={git.compat.is_win}")'
+
     - name: Test with pytest
       run: |
         set +x
-        /usr/bin/python -m pytest
+        /usr/bin/python -m pytest -v

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -29,11 +29,6 @@ jobs:
       with:
         packages: python39 python39-pip python39-virtualenv git
 
-    - name: Show python and git versions
-      run: |
-        /usr/bin/python --version
-        /usr/bin/git version
-
     - name: Tell git to trust this repo
       run: |
         /usr/bin/git config --global --add safe.directory "$(pwd)"
@@ -58,9 +53,13 @@ jobs:
       run: |
         /usr/bin/python -m pip install ".[test]"
 
-    - name: Check 'is_win'
+    - name: Show version and platform information
       run: |
-        /usr/bin/python -c 'import os, git; print(f"os.name={os.name}, is_win={git.compat.is_win}")'
+        /usr/bin/git version
+        /usr/bin/python --version
+        /usr/bin/python -c 'import sys; print(sys.platform)'
+        /usr/bin/python -c 'import os; print(os.name)'
+        /usr/bin/python -c 'import git; print(git.compat.is_win)'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -55,6 +55,7 @@ jobs:
 
     - name: Show version and platform information
       run: |
+        /usr/bin/uname -a
         /usr/bin/git version
         /usr/bin/python --version
         /usr/bin/python -c 'import sys; print(sys.platform)'

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -5,12 +5,15 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: windows-latest
+
     strategy:
       fail-fast: false
+
     env:
       CHERE_INVOKING: 1
       TMP: "/tmp"
       TEMP: "/tmp"
+
     defaults:
       run:
         shell: C:\cygwin\bin\bash.exe --noprofile --norc -exo pipefail -o igncr "{0}"

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -14,11 +14,13 @@ jobs:
       TEMP: "/tmp"
     defaults:
       run:
-        shell: bash.exe --noprofile --norc -exo pipefail -o igncr "{0}"
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -exo pipefail -o igncr "{0}"
 
     steps:
     - name: Force LF line endings
-      run: git config --global core.autocrlf input
+      run: |
+        git config --global core.autocrlf input
+      shell: bash
 
     - uses: actions/checkout@v4
       with:
@@ -29,9 +31,12 @@ jobs:
       with:
         packages: python39 python39-pip python39-virtualenv git
 
+    - name: Limit $PATH to Cygwin
+      run: echo 'C:\cygwin\bin' >"$GITHUB_PATH"
+
     - name: Tell git to trust this repo
       run: |
-        /usr/bin/git config --global --add safe.directory "$(pwd)"
+        git config --global --add safe.directory "$(pwd)"
 
     - name: Prepare this repo for tests
       run: |
@@ -39,30 +44,31 @@ jobs:
 
     - name: Further prepare git configuration for tests
       run: |
-        /usr/bin/git config --global user.email "travis@ci.com"
-        /usr/bin/git config --global user.name "Travis Runner"
+        git config --global user.email "travis@ci.com"
+        git config --global user.name "Travis Runner"
         # If we rewrite the user's config by accident, we will mess it up
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
     - name: Update PyPA packages
       run: |
-        /usr/bin/python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
 
     - name: Install project and test dependencies
       run: |
-        /usr/bin/python -m pip install ".[test]"
+        python -m pip install ".[test]"
 
     - name: Show version and platform information
       run: |
-        /usr/bin/uname -a
-        /usr/bin/git version
-        /usr/bin/python --version
-        /usr/bin/python -c 'import sys; print(sys.platform)'
-        /usr/bin/python -c 'import os; print(os.name)'
-        /usr/bin/python -c 'import git; print(git.compat.is_win)'
+        uname -a
+        command -v git python
+        git version
+        python --version
+        python -c 'import sys; print(sys.platform)'
+        python -c 'import os; print(os.name)'
+        python -c 'import git; print(git.compat.is_win)'
 
     - name: Test with pytest
       run: |
         set +x
-        /usr/bin/python -m pytest --color=yes -p no:sugar --instafail -vv
+        python -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -64,4 +64,4 @@ jobs:
     - name: Test with pytest
       run: |
         set +x
-        /usr/bin/python -m pytest -p no:sugar --instafail -vv
+        /usr/bin/python -m pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -64,4 +64,4 @@ jobs:
     - name: Test with pytest
       run: |
         set +x
-        /usr/bin/python -m pytest -p no:sugar -v --instafail
+        /usr/bin/python -m pytest -p no:sugar --instafail -vv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -p no:sugar --instafail -vv
+        pytest --color=yes -p no:sugar --instafail -vv
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -50,12 +50,12 @@ jobs:
 
     - name: Update PyPA packages
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
+
+        # Python prior to 3.12 ships setuptools. Upgrade it if present.
         if pip freeze --all | grep --quiet '^setuptools=='; then
-            # Python prior to 3.12 ships setuptools. Upgrade it if present.
             python -m pip install --upgrade setuptools
         fi
-        python -m pip install --upgrade wheel
 
     - name: Install project and test dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Show version and platform information
       run: |
         uname -a
+        command -v git python
         git version
         python --version
         python -c 'import sys; print(sys.platform)'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -73,9 +73,13 @@ jobs:
       # so we have to ignore errors until that changes.
       continue-on-error: true
 
+    - name: Check 'is_win'
+      run: |
+        python -c 'import os, git; print(f"os.name={os.name}, is_win={git.compat.is_win}")'
+
     - name: Test with pytest
       run: |
-        pytest
+        pytest -v
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +20,7 @@ jobs:
           - experimental: false
           - python-version: "3.12"
             experimental: true
+
     defaults:
       run:
         shell: /bin/bash --noprofile --norc -exo pipefail {0}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -v
+        pytest -v -p no:sugar --instafail
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         TRAVIS=yes ./init-tests-after-clone.sh
 
-    - name: Prepare git configuration for tests
+    - name: Set git user identity and command aliases for the tests
       run: |
         git config --global user.email "travis@ci.com"
         git config --global user.name "Travis Runner"
@@ -51,12 +51,8 @@ jobs:
 
     - name: Update PyPA packages
       run: |
-        python -m pip install --upgrade pip wheel
-
-        # Python prior to 3.12 ships setuptools. Upgrade it if present.
-        if pip freeze --all | grep --quiet '^setuptools=='; then
-            python -m pip install --upgrade setuptools
-        fi
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -oF setuptools) wheel
 
     - name: Install project and test dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -63,6 +63,7 @@ jobs:
 
     - name: Show version and platform information
       run: |
+        uname -a
         git version
         python --version
         python -c 'import sys; print(sys.platform)'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -v -p no:sugar --instafail
+        pytest -p no:sugar --instafail -vv
       continue-on-error: false
 
     - name: Documentation

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,11 +36,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
-    - name: Show python and git versions
-      run: |
-        python --version
-        git version
-
     - name: Prepare this repo for tests
       run: |
         TRAVIS=yes ./init-tests-after-clone.sh
@@ -66,16 +61,20 @@ jobs:
       run: |
         pip install ".[test]"
 
+    - name: Show version and platform information
+      run: |
+        git version
+        python --version
+        python -c 'import sys; print(sys.platform)'
+        python -c 'import os; print(os.name)'
+        python -c 'import git; print(git.compat.is_win)'
+
     - name: Check types with mypy
       run: |
         mypy -p git
       # With new versions of mypy new issues might arise. This is a problem if there is nobody able to fix them,
       # so we have to ignore errors until that changes.
       continue-on-error: true
-
-    - name: Check 'is_win'
-      run: |
-        python -c 'import os, git; print(f"os.name={os.name}, is_win={git.compat.is_win}")'
 
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 python_files = 'test_*.py'
 testpaths = 'test'  # space separated list of paths from root e.g test tests doc/testing
-addopts = '--cov=git --cov-report=term --maxfail=10 --force-sugar --disable-warnings'
+addopts = '--cov=git --cov-report=term --force-sugar --disable-warnings'
 filterwarnings = 'ignore::DeprecationWarning'
 # --cov   coverage
 # --cov-report term  # send report to terminal term-missing -> terminal with line numbers  html  xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 python_files = 'test_*.py'
 testpaths = 'test'  # space separated list of paths from root e.g test tests doc/testing
-addopts = '--cov=git --cov-report=term --force-sugar --disable-warnings'
+addopts = '--cov=git --cov-report=term --disable-warnings'
 filterwarnings = 'ignore::DeprecationWarning'
 # --cov   coverage
 # --cov-report term  # send report to terminal term-missing -> terminal with line numbers  html  xml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,5 @@ mypy
 pre-commit
 pytest
 pytest-cov
+pytest-instafail
 pytest-sugar

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -7,7 +7,7 @@
 import os
 import sys
 import tempfile
-from unittest import SkipTest, skipIf
+from unittest import skipIf
 
 from git import Repo
 from git.objects import Blob, Tree, Commit, TagObject
@@ -126,7 +126,7 @@ class TestBase(_TestBase):
         try:
             file_path.encode(sys.getfilesystemencoding())
         except UnicodeEncodeError as e:
-            raise SkipTest("Environment doesn't support unicode filenames") from e
+            raise RuntimeError("Environment doesn't support unicode filenames") from e
 
         with open(file_path, "wb") as fp:
             fp.write(b"something")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -100,6 +100,7 @@ class TestBase(TestCase):
             # values must be considered as soon as they get them
             assert r_config.get_value("diff", "tool") == "meld"
             try:
+                # FIXME: Split this assertion out somehow and mark it xfail (or fix it).
                 assert r_config.get_value("sec", "var1") == "value1_main"
             except AssertionError as e:
                 raise SkipTest("Known failure -- included values are not in effect right away") from e

--- a/test/test_fun.py
+++ b/test/test_fun.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from stat import S_IFDIR, S_IFREG, S_IFLNK, S_IXUSR
 from os import stat
 import os.path as osp
-from unittest import SkipTest
 
 from git import Git
 from git.index import IndexFile
@@ -279,7 +278,7 @@ class TestFun(TestBase):
         """Check that we can identify a linked worktree based on a .git file"""
         git = Git(rw_dir)
         if git.version_info[:3] < (2, 5, 1):
-            raise SkipTest("worktree feature unsupported")
+            raise RuntimeError("worktree feature unsupported (test needs git 2.5.1 or later)")
 
         rw_master = self.rorepo.clone(join_path_native(rw_dir, "master_repo"))
         branch = rw_master.create_head("aaaaaaaa")

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from stat import S_ISLNK, ST_MODE
 import shutil
 import tempfile
-from unittest import skipIf
 
 import pytest
 
@@ -27,16 +26,13 @@ from git import (
     GitCommandError,
     CheckoutError,
 )
-from git.cmd import Git
 from git.compat import is_win
 from git.exc import HookExecutionError, InvalidGitRepositoryError
 from git.index.fun import hook_path
 from git.index.typ import BaseIndexEntry, IndexEntry
 from git.objects import Blob
-from test.lib import TestBase, fixture_path, fixture, with_rw_repo
-from test.lib import with_rw_directory
-from git.util import Actor, rmtree
-from git.util import HIDE_WINDOWS_KNOWN_ERRORS, hex_to_bin
+from test.lib import TestBase, fixture, fixture_path, with_rw_directory, with_rw_repo
+from git.util import Actor, hex_to_bin, rmtree
 from gitdb.base import IStream
 
 HOOKS_SHEBANG = "#!/usr/bin/env sh\n"
@@ -434,14 +430,6 @@ class TestIndex(TestBase):
 
     # END num existing helper
 
-    @skipIf(
-        HIDE_WINDOWS_KNOWN_ERRORS and Git.is_cygwin(),
-        """FIXME: File "C:\\projects\\gitpython\\git\\test\\test_index.py", line 642, in test_index_mutation
-                self.assertEqual(fd.read(), link_target)
-                AssertionError: '!<symlink>\xff\xfe/\x00e\x00t\x00c\x00/\x00t\x00h\x00a\x00t\x00\x00\x00'
-                != '/etc/that'
-                """,
-    )
     @with_rw_repo("0.1.6")
     def test_index_mutation(self, rw_repo):
         index = rw_repo.index

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -41,10 +41,8 @@ from git.exc import (
     UnsafeProtocolError,
 )
 from git.repo.fun import touch
-from test.lib import TestBase, with_rw_repo, fixture
-from git.util import cygpath
-from test.lib import with_rw_directory
-from git.util import join_path_native, rmtree, rmfile, bin_to_hex
+from git.util import bin_to_hex, cygpath, join_path_native, rmfile, rmtree
+from test.lib import TestBase, fixture, with_rw_directory, with_rw_repo
 
 import os.path as osp
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -13,7 +13,7 @@ import pathlib
 import pickle
 import sys
 import tempfile
-from unittest import mock, SkipTest, skip
+from unittest import mock, skip
 
 import pytest
 
@@ -1235,7 +1235,7 @@ class TestRepo(TestBase):
     def test_is_ancestor(self):
         git = self.rorepo.git
         if git.version_info[:3] < (1, 8, 0):
-            raise SkipTest("git merge-base --is-ancestor feature unsupported")
+            raise RuntimeError("git merge-base --is-ancestor feature unsupported (test needs git 1.8.0 or later)")
 
         repo = self.rorepo
         c1 = "f6aa8d1"
@@ -1283,7 +1283,7 @@ class TestRepo(TestBase):
         based on it."""
         git = Git(rw_dir)
         if git.version_info[:3] < (2, 5, 1):
-            raise SkipTest("worktree feature unsupported")
+            raise RuntimeError("worktree feature unsupported (test needs git 2.5.1 or later)")
 
         rw_master = self.rorepo.clone(join_path_native(rw_dir, "master_repo"))
         branch = rw_master.create_head("aaaaaaaa")

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -13,7 +13,7 @@ import pathlib
 import pickle
 import sys
 import tempfile
-from unittest import mock, skipIf, SkipTest, skip
+from unittest import mock, SkipTest, skip
 
 import pytest
 
@@ -42,7 +42,7 @@ from git.exc import (
 )
 from git.repo.fun import touch
 from test.lib import TestBase, with_rw_repo, fixture
-from git.util import HIDE_WINDOWS_KNOWN_ERRORS, cygpath
+from git.util import cygpath
 from test.lib import with_rw_directory
 from git.util import join_path_native, rmtree, rmfile, bin_to_hex
 
@@ -764,16 +764,6 @@ class TestRepo(TestBase):
         self.rorepo.blame("HEAD", "README.md", rev_opts=["-M", "-C", "-C"])
         git.assert_called_once_with(*expected_args, **boilerplate_kwargs)
 
-    @skipIf(
-        HIDE_WINDOWS_KNOWN_ERRORS and Git.is_cygwin(),
-        """FIXME: File "C:\\projects\\gitpython\\git\\cmd.py", line 671, in execute
-                    raise GitCommandError(command, status, stderr_value, stdout_value)
-                GitCommandError: Cmd('git') failed due to: exit code(128)
-                  cmdline: git add 1__��ava verb��ten 1_test _myfile 1_test_other_file
-                          1_��ava-----verb��ten
-                  stderr: 'fatal: pathspec '"1__çava verböten"' did not match any files'
-                """,
-    )
     @with_rw_repo("HEAD", bare=False)
     def test_untracked_files(self, rwrepo):
         for run, repo_add in enumerate((rwrepo.index.add, rwrepo.git.add)):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -474,14 +474,13 @@ class TestSubmodule(TestBase):
         reason="Cygwin GitPython can't find submodule SHA",
         raises=ValueError,
     )
-    @skipIf(
+    @pytest.mark.xfail(
         HIDE_WINDOWS_KNOWN_ERRORS,
-        """
-        E  PermissionError:
-        [WinError 32] The process cannot access the file because it is being used by another process:
-        'C:\\Users\\ek\\AppData\\Local\\Temp\\non_bare_test_root_modulep0eqt8_r\\git\\ext\\gitdb'
-        -> 'C:\\Users\\ek\\AppData\\Local\\Temp\\non_bare_test_root_modulep0eqt8_r\\path\\prefix\\git\\ext\\gitdb'
-        """,
+        reason=(
+            '"The process cannot access the file because it is being used by another process"'
+            + " on first call to rm.update"
+        ),
+        raises=PermissionError,
     )
     @with_rw_repo(k_subm_current, bare=False)
     def test_root_module(self, rwrepo):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1050,9 +1050,8 @@ class TestSubmodule(TestBase):
         msg = '_to_relative_path should be "submodule_path" but was "%s"' % relative_path
         assert relative_path == "submodule_path", msg
 
-    @skipIf(
-        True,
-        "for some unknown reason the assertion fails, even though it in fact is working in more common setup",
+    @pytest.mark.xfail(
+        reason="for some unknown reason the assertion fails, even though it in fact is working in more common setup",
     )
     @with_rw_directory
     def test_depth(self, rwdir):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from pathlib import Path
 import sys
-from unittest import mock, skipIf, skipUnless
+from unittest import mock, skipUnless
 
 import pytest
 
@@ -748,14 +748,13 @@ class TestSubmodule(TestBase):
         repo = git.Repo(repo_path)
         assert len(repo.submodules) == 0
 
-    @skipIf(
+    @pytest.mark.xfail(
         HIDE_WINDOWS_KNOWN_ERRORS,
-        """
-        E   PermissionError:
-        [WinError 32] The process cannot access the file because it is being used by another process:
-        'C:\\Users\\ek\\AppData\\Local\\Temp\\test_git_submodules_and_add_sm_with_new_commitu6d08von\\parent\\module'
-        -> 'C:\\Users\\ek\\AppData\\Local\\Temp\\test_git_submodules_and_add_sm_with_new_commitu6d08von\\parent\\module_moved'
-        """  # noqa: E501,
+        reason=(
+            '"The process cannot access the file because it is being used by another process"'
+            + " on first call to sm.move"
+        ),
+        raises=PermissionError,
     )
     @with_rw_directory
     @_patch_git_config("protocol.file.allow", "always")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -477,11 +477,11 @@ class TestSubmodule(TestBase):
     @skipIf(
         HIDE_WINDOWS_KNOWN_ERRORS,
         """
-        File "C:\\projects\\gitpython\\git\\cmd.py", line 559, in execute
-        raise GitCommandNotFound(command, err)
-        git.exc.GitCommandNotFound: Cmd('git') not found due to: OSError('[WinError 6] The handle is invalid')
-        cmdline: git clone -n --shared -v C:\\projects\\gitpython\\.git Users\\appveyor\\AppData\\Local\\Temp\\1\\tmplyp6kr_rnon_bare_test_root_module
-        """,  # noqa E501
+        E  PermissionError:
+        [WinError 32] The process cannot access the file because it is being used by another process:
+        'C:\\Users\\ek\\AppData\\Local\\Temp\\non_bare_test_root_modulep0eqt8_r\\git\\ext\\gitdb'
+        -> 'C:\\Users\\ek\\AppData\\Local\\Temp\\non_bare_test_root_modulep0eqt8_r\\path\\prefix\\git\\ext\\gitdb'
+        """,
     )
     @with_rw_repo(k_subm_current, bare=False)
     def test_root_module(self, rwrepo):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from pathlib import Path
 import sys
-from unittest import mock, skipIf
+from unittest import mock, skipIf, skipUnless
 
 import pytest
 
@@ -1039,7 +1039,7 @@ class TestSubmodule(TestBase):
         assert sm_mod.commit() == sm_pfb.commit, "Now head should have been reset"
         assert sm_mod.head.ref.name == sm_pfb.name
 
-    @skipIf(not is_win, "Specifically for Windows.")
+    @skipUnless(is_win, "Specifically for Windows.")
     def test_to_relative_path_with_super_at_root_drive(self):
         class Repo(object):
             working_tree_dir = "D:\\"

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -750,13 +750,12 @@ class TestSubmodule(TestBase):
 
     @skipIf(
         HIDE_WINDOWS_KNOWN_ERRORS,
-        """FIXME on cygwin: File "C:\\projects\\gitpython\\git\\cmd.py", line 671, in execute
-                raise GitCommandError(command, status, stderr_value, stdout_value)
-            GitCommandError: Cmd('git') failed due to: exit code(128)
-              cmdline: git add 1__Xava verbXXten 1_test _myfile 1_test_other_file 1_XXava-----verbXXten
-              stderr: 'fatal: pathspec '"1__çava verböten"' did not match any files'
-             FIXME on appveyor: see https://ci.appveyor.com/project/Byron/gitpython/build/1.0.185
-                """,
+        """
+        E   PermissionError:
+        [WinError 32] The process cannot access the file because it is being used by another process:
+        'C:\\Users\\ek\\AppData\\Local\\Temp\\test_git_submodules_and_add_sm_with_new_commitu6d08von\\parent\\module'
+        -> 'C:\\Users\\ek\\AppData\\Local\\Temp\\test_git_submodules_and_add_sm_with_new_commitu6d08von\\parent\\module_moved'
+        """  # noqa: E501,
     )
     @with_rw_directory
     @_patch_git_config("protocol.file.allow", "always")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1049,6 +1049,7 @@ class TestSubmodule(TestBase):
 
     @pytest.mark.xfail(
         reason="for some unknown reason the assertion fails, even though it in fact is working in more common setup",
+        raises=AssertionError,
     )
     @with_rw_directory
     def test_depth(self, rwdir):

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -5,24 +5,14 @@
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
-from unittest import skipIf
 
 from git.objects import Tree, Blob
 from test.lib import TestBase
-from git.util import HIDE_WINDOWS_KNOWN_ERRORS
 
 import os.path as osp
 
 
 class TestTree(TestBase):
-    @skipIf(
-        HIDE_WINDOWS_KNOWN_ERRORS,
-        """
-        File "C:\\projects\\gitpython\\git\\cmd.py", line 559, in execute
-        raise GitCommandNotFound(command, err)
-        git.exc.GitCommandNotFound: Cmd('git') not found due to: OSError('[WinError 6] The handle is invalid')
-        cmdline: git cat-file --batch-check""",
-    )
     def test_serializable(self):
         # tree at the given commit contains a submodule as well
         roottree = self.rorepo.tree("6c1faef799095f3990e9970bc2cb10aa0221cf9c")
@@ -51,14 +41,6 @@ class TestTree(TestBase):
             testtree._deserialize(stream)
         # END for each item in tree
 
-    @skipIf(
-        HIDE_WINDOWS_KNOWN_ERRORS,
-        """
-        File "C:\\projects\\gitpython\\git\\cmd.py", line 559, in execute
-        raise GitCommandNotFound(command, err)
-        git.exc.GitCommandNotFound: Cmd('git') not found due to: OSError('[WinError 6] The handle is invalid')
-        cmdline: git cat-file --batch-check""",
-    )
     def test_traverse(self):
         root = self.rorepo.tree("0.1.6")
         num_recursive = 0

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -9,7 +9,7 @@ import pickle
 import sys
 import tempfile
 import time
-from unittest import mock, skipIf
+from unittest import mock, skipUnless
 from datetime import datetime
 
 import ddt
@@ -84,14 +84,14 @@ class TestUtils(TestBase):
             "array": [42],
         }
 
-    @skipIf(not is_win, "Paths specifically for Windows.")
+    @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.idata(_norm_cygpath_pairs + _unc_cygpath_pairs)
     def test_cygpath_ok(self, case):
         wpath, cpath = case
         cwpath = cygpath(wpath)
         self.assertEqual(cwpath, cpath, wpath)
 
-    @skipIf(not is_win, "Paths specifically for Windows.")
+    @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.data(
         (r"./bar", "bar"),
         (r".\bar", "bar"),
@@ -104,7 +104,7 @@ class TestUtils(TestBase):
         cwpath = cygpath(wpath)
         self.assertEqual(cwpath, cpath or wpath, wpath)
 
-    @skipIf(not is_win, "Paths specifically for Windows.")
+    @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.data(
         r"C:",
         r"C:Relative",
@@ -117,7 +117,7 @@ class TestUtils(TestBase):
         cwpath = cygpath(wpath)
         self.assertEqual(cwpath, wpath.replace("\\", "/"), wpath)
 
-    @skipIf(not is_win, "Paths specifically for Windows.")
+    @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.idata(_norm_cygpath_pairs)
     def test_decygpath(self, case):
         wpath, cpath = case

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -85,6 +85,7 @@ class TestUtils(TestBase):
             "array": [42],
         }
 
+    # FIXME: Mark only the /proc-prefixing cases xfail, somehow (or fix them).
     @pytest.mark.xfail(
         reason="Many return paths prefixed /proc/cygdrive instead.",
         raises=AssertionError,
@@ -103,7 +104,7 @@ class TestUtils(TestBase):
     @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.data(
         (r"./bar", "bar"),
-        (r".\bar", "bar"),
+        (r".\bar", "bar"),  # FIXME: Mark only this one xfail, somehow (or fix it).
         (r"../bar", "../bar"),
         (r"..\bar", "../bar"),
         (r"../bar/.\foo/../chu", "../bar/chu"),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -13,6 +13,7 @@ from unittest import mock, skipUnless
 from datetime import datetime
 
 import ddt
+import pytest
 
 from git.cmd import dashify
 from git.compat import is_win
@@ -84,6 +85,10 @@ class TestUtils(TestBase):
             "array": [42],
         }
 
+    @pytest.mark.xfail(
+        reason="Many return paths prefixed /proc/cygdrive instead.",
+        raises=AssertionError,
+    )
     @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.idata(_norm_cygpath_pairs + _unc_cygpath_pairs)
     def test_cygpath_ok(self, case):
@@ -91,6 +96,10 @@ class TestUtils(TestBase):
         cwpath = cygpath(wpath)
         self.assertEqual(cwpath, cpath, wpath)
 
+    @pytest.mark.xfail(
+        reason=r'2nd example r".\bar" -> "bar" fails, returns "./bar"',
+        raises=AssertionError,
+    )
     @skipUnless(sys.platform == "cygwin", "Paths specifically for Cygwin.")
     @ddt.data(
         (r"./bar", "bar"),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -12,7 +12,6 @@ import time
 from unittest import mock, skipIf
 from datetime import datetime
 
-import pytest
 import ddt
 
 from git.cmd import dashify
@@ -156,11 +155,6 @@ class TestUtils(TestBase):
         lock_file._obtain_lock_or_raise()
         lock_file._release_lock()
 
-    @pytest.mark.xfail(
-        sys.platform == "cygwin",
-        reason="Cygwin fails here for some reason, always",
-        raises=AssertionError,
-    )
     def test_blocking_lock_file(self):
         my_file = tempfile.mktemp()
         lock_file = BlockingLockFile(my_file)
@@ -173,9 +167,8 @@ class TestUtils(TestBase):
         self.assertRaises(IOError, wait_lock._obtain_lock)
         elapsed = time.time() - start
         extra_time = 0.02
-        if is_win:
-            # for Appveyor
-            extra_time *= 6  # NOTE: Indeterministic failures here...
+        if is_win or sys.platform == "cygwin":
+            extra_time *= 6  # NOTE: Indeterministic failures without this...
         self.assertLess(elapsed, wait_time + extra_time)
 
     def test_user_id(self):


### PR DESCRIPTION
This makes changes so tests give more informative output, both locally and on CI but especially on CI. It comprises several interrelated changes that should help lead up to, but *do not include*, adding CI jobs for Windows. My motivation for doing this was to make it easier to add those jobs, and to get the most out of those jobs once they are added, but it seems to me that the benefit of these changes is actually largely independent of those goals, and can be reviewed independently of them (and thus before they are done). This description is divided into descriptions of the problems I believe the changes solve, and how they solve them.

### `pytest-sugar` output didn't display correctly on CI

The [`pytest-sugar`](https://github.com/Teemu/pytest-sugar/) plugin is working very well for local testing, but on CI it has been producing output that is voluminous, yet fairly low in information. This happens because instead of outputting a row of check marks as it does locally (at least when run in most terminals), updating the line creates a new one:

```text
 test/test_actor.py ✓                                              0%
 test/test_actor.py ✓✓                                             0% ▏
 test/test_actor.py ✓✓✓                                            1% ▏
 test/test_actor.py ✓✓✓✓                                           1% ▏
```

Those are four passing tests in `test_actor.py`, reported with one line per test, yet those lines give no information about the individual tests they represent, not even those tests' names. This happens because, from `pytest-sugar`'s perspective, it is updating a single line in a terminal.

The cause of the problem is the progress bar animated on the right side. Passing `-v` or `-vv` improves things somewhat, in that it shows specific information about the tests (their names and, where applicable, which in this project is almost everywhere, the test class they appear in). However, the progress bar of that style is still drawn, and extra newlines are still often shown, with the resulting excess blank lines making the output hard to read. I was not able to find a way to get `pytest-sugar` not to show this progress bar, or to show it in a different style. Fortunately, that turned out not to be necessary.

`pytest-sugar` provides two useful features: its pretty output, and showing each failure immediately. The former is not achieved on CI, for this project, currently. However, the latter is, and may be considered important. But there is another `pytest` plugin that separately provides just that feature: [`pytest-instafail`](https://github.com/pytest-dev/pytest-instafail). When enabled, `pytest-instafail` reports each failure with full details immediately. (It does not stop running the tests early or cancel any tests.)

So I added `pytest-instafail` as a development dependency (in the `test` extra) but did not set things up for it to be used automatically. And I configured `pytest` to use `pytest-sugar` by default, but invoked `pytest` on CI so that it runs with `pytest-sugar` turned off and `pytest-instafail` turned on. This plays well with how GitHub Actions handles output, at any level of verbosity. But I have also passed `-vv` on CI, to solve...

### CI did not show which tests had which statuses

CI is the easiest and also most reliable way to run tests in this project, and probably the most common. Often I found myself wanting to know what tests were actually running, versus being skipped. I often made assumptions about this that were mistaken, and others that were correct but hard to be confident about; see https://github.com/gitpython-developers/GitPython/pull/1657#issuecomment-1716870800.

Furthermore, it is useful to be able to notice--even when one is not looking for it, so long as it's not too distracting--what tests are passing, skipped, etc. The failing tests are reported in detail at each failure and listed at the end, but tests with other statuses are not listed with those statuses--or, really, at all--without `-v` or `-vv`.

So I have passed `-vv` so that, for non-failing tests, each test shows a line indicating the file, the class where applicable, the name of the test case (with `@ddt`-parameterized tests appearing as separate test cases but listed together, and named in terms of their arguments), and the test's status. This distinguishes tests with pass, skip, xfail, and xpass statuses. It also provides reassurance that particular tests really are running, and allows one to search for tests by name while viewing CI output.

### The custom `pytest` configuration was rigid and hid failures

Implicit options for `pytest` are configured in `pyproject.toml`. It is not immediately obvious, to someone running `pytest` on the project or inspecting CI output, what these are set to.

**One was `--force-sugar`**, which appears to have been necessary to get `pytest-sugar` to run on CI even in spite of its (in this case correct) guess that it does not have a suitable output device when doing so. This made it very difficult to run `pytest` without `pytest-sugar`, as is needed on CI (detailed above) and as may also be useful to do locally in some cases.

So I removed that. The plugin is still loaded automatically, but it can now be turned off with `-p no:sugar` (as well as automatically if it detects an unsuitable output device, but I am not relying on that in the CI workflows).

**Another was `--maxfail=10`.** I have removed this as well. It made `pytest` stop running tests once the tenth failure occurred, so no more than ten failures would ever be reported. It was possible to notice this by looking carefully at test output, either by noticing the line that warns about it (amongst lots of other output) or by seeing that the total number of tests that are run was lower than the number the runner found, by more than the number of skipped tests.

On CI, it is useful to see the output of all tests. Sometimes it makes sense to weaken that, but stopping in the middle of a test run because of a failure in that run (where one may want to know what else does, and what doesn't, also fail), is not, in my view, the best way to do it. Instead, [`fail-fast`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) could be enabled on the CI test matrix, or some available combinations of platforms and Python versions could even be omitted (for example, when Windows CI jobs are added, [fewer than six versions](https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717475862) could be tested, depending on how fast they run).

The bigger issue, though, is that I thought I was getting only ten test failures in a number of circumstances! Fortunately, I never relied on that, and even on my native Windows system where I was unable to get all tests passing, I ran the tests that seemed most germane to the changes I was making. Since it is more involved--on any operating system--to get all tests passing locally with GitPython than with most codebases, showing only ten failures seems like a stumbling block that is best removed.

Finally, removing `--maxfail=10` makes it much easier to investigate what fails due to removing `@skipIf` and related annotations, turning off `HIDE_WINDOWS_KNOWN_ERRORS`, and the like, because one can see everything that fails.

**I have retained `--disable-warnings`**, though that should be revisited in the future, since it could be hiding something of value. Delving into that would have been in keeping with the theme of this PR, but I have not done so, in part to limit the scope of the changes (as turning that off would likely lead to the addition of a number of more fine-grained suppressions).

The other arguments pertain to code coverage and are fine; code coverage reports are often wanted, especially for full test runs on CI, and they can be turned off easily by passing `--no-cov` to `pytest`.

### It wasn't clear when `is_win` was true

`is_win` is true only on native Windows systems, but this is not obvious, nor is it in all cases obvious what constitutes a native Windows system. In a couple cases, a test was skipped when `is_win` and a Cygwin check both hold. Those never happen together--those tests were running on all systems and doing fine (and I removed those `@skipIf` annotations).

`is_win`, which is provided by GitPython, is true when `os.name == "nt"`. On Cygwin, `os.name == "posix"`. Cygwin can be distinguished from other Unix-like platforms by checking that `sys.platform == "cygwin"`, which also holds on systems like MSYS2 that are derived from Cygwin. However, it does not hold on MinGW builds of Python, which are a native build that is provided with MSYS 2, and which is correctly detected as native Windows with `os.name` and thus GitPython's `is_win`. (The "Git Bash" environment also provides MinGW builds, though it does not include Python.)

Given this situation, I am unsure if it's really a good idea to have `is_win` in the project, rather than testing the above conditions directly. However, we do have it, and I believe users are supposed to be able to use it directly (so removing it would be a breaking change). I have certainly not endeavored to remove it here, nor to deprecate it. However, I have extended the part of both of the CI test workflows that output version information such as `git` and `python` versions to also output the values of all of the above, so they can be readily checked. Together with being able to see the status of each test by name (by either perusing or searching), I think this should avoid the kind of situation I faced in #1636 and #1650 where I didn't know what platforms my tests were running (or supposed to run) on and couldn't tell by examining CI output.

### Expected failures were handled by skipping

I have not completely addressed this, but I have made significant headway, and the areas where it remains so are either marked or are already known to be especially tricky cases.

When the actions a test performs should not be attempted at all, the test should be skipped. However, in testing frameworks with limited support for marking tests as *expected to fail*, skipping is often used to express this as well.  This is best avoided when possible, because it requires that both initiative and manual action be taken to check whether tests that were not working before are still not working, as well as to check that *how* they are failing remains the same, at least in the general sense of *what exception* is raised.

I replaced most, but not all, `@skipIf` and similar annotations, *in places where they represent expected failure* of a test that ought to pass, with [`@pytest.mark.xfail`](https://docs.pytest.org/en/7.1.x/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail). Both `unittest` and `pytest` provide facilities for expressing expected failure, but [`unittest.expectedFailure`](https://docs.python.org/3/library/unittest.html#unittest.expectedFailure) is very limited, not allowing a condition, reason, or expected exception to be passed. In contrast, [`pytest.mark.xfail`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-mark-xfail-ref) supports such arguments (among others), and I have always passed them. The `raises` argument takes an exception type (or tuple of them) that is expected to be raised, and test failures due to other exceptions will be reported as regular failures.

Because tests marked `xfail` still run (except in limited cases where one prevents this, which I have not done), examining `pytest` output (when `-v` or `-vv` have been passed) reveals, for each test, whether it really did fail as expected (xfail status), or if it unexpectedly passed (xpass status). It is possible to have the xpass status treated as a failure, but I have not done that.

An xfailing or xpassing test does not produce full test output with a traceback, so we are still only getting that highly verbose inline failure information (due to `pytest-sugar` locally and `pytest-instafail` on CI) if we get an unexpected failure, i.e., one that fails the run.

My goal with `xfail` is that, taken together with other changes in this PR, it should make it unnecessary to take any special action to check whether a test is still unable to pass--or to check whether the system or other condition for its failure, or the *way* it fails, has remained the same. Instead, one simply takes a look at the xfail output, a key part of [the approach articulated there](https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717475862) thus being continuously automated. Going along with that, it should be little more obtrusive than the effect of a *passing* test, so one is not distracted by it. I believe this PR largely achieves both goals, in a way that is worthwhile even though imperfect. But the imperfections are worth noting:

- I don't believe `ddt` has its own xfail feature. `@pytest.mark.parametrize` is made to work together with `@pytest.mark.xfail`, so generated tests with some arguments can be marked xfail while others generated from the same function/method are not. But `@pytest.mark.parametrize` [cannot be used effectively](https://docs.pytest.org/en/7.1.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses) on a method in a class that inherits directly or indirectly from `unittest.TestCase`, even if (as in this project) it is only necessary to support the `pytest` test runner. Most GitPython test classes derive indirectly from `TestCase` through a custom `TestBase` class that provides the import `rorepo` fixture, and I did not want migrate that as part of the work on this PR. But the effect is that there are some xpassing functions already, because I could only mark the whole group (i.e,, defined function) as `xfail`. The situation is clearly documented with comments and the `reason` keyword argument. It affects two groups of `cygpath` tests.

- `test_includes_order` contains a few assertions, the last of which is expected to fail, which is handled by placing it in a `try` block, catching the `AssertionError`, and reraising it as a `SkipTest` exception. It is possible to do something analogous to signal that an expected failure has occurred. But without splitting up or otherwise reorganizing the test case, this would not carry the benefit of an xpass status if the assertion unexpectedly starts working. It might still be reasonable to do that, but because I don't want to create the appearance of observability where we don't have it, I have not done so at this point. My hope is that either the test can be reorganized or the underlying problem can be fixed. I have clearly commented the situation.

- The `git` module (rather than its unit tests) has three places where `unittest.SkipTest` is raised from inside it to skip a test ([#790](https://github.com/gitpython-developers/GitPython/issues/790)). As in `test_includes_order`, these are situations where, if nothing goes wrong, no indication is given. So for the same reason as there--but also that it would be much harder because I am using `xfail` from `pytest` but the `git` module shouldn't have testing framework dependencies, per [#526](https://github.com/gitpython-developers/GitPython/issues/526) and [#527](https://github.com/gitpython-developers/GitPython/pull/527)--I have not changed that here. Note that, in spite of the connection to the related [#525](https://github.com/gitpython-developers/GitPython/issues/525), most occurrences of `HIDE_WINDOWS_KNOWN_ERRORS` do *not* straddle `git` and `test` in this way, and I *have* changed then from `@skipIf` and similar to `@pytest.mark.xfail`.

I have not applied `xfail` to `HIDE_WINDOWS_FREEZE_ERRORS`, but that is because I don't think they are expected failures, so I do not class this as an imperfection. (We don't want those tests to run automatically on native Windows systems, but `@pytest.mark.xfail` supports `run=False` for such cases, though that forgoes being able to observe an xpass. But I believe these tests usually work on all systems, but freeze *occasionally* on native Windows. I also think this should be addressed as its own change rather than here; I suspect there is actually a connection to #1676, as I've noted there, and maybe they can be fixed together.)

### Some expected failures were out of date (or originally erroneous)

This is to be expected, and a benefit of the above changes (of xfail and the other changes above it that support seeing and using that output) was to be able to identify these cases and fix the skip and xfail specifications, and most of all to verify that they are fixed.

To be clear, I didn't actually fix any bugs in the code under test. The changes to the test code should be evident in the diff (as, if not, then the test code is not as clear as I intend as a result of the changes), but a summary may help in distinguishing these from nearby changes, so in case it helps, here are the main (kinds of) changes of this kind:

- Removing skips/xfails for tests that had been broken but are now fully working.
- Fixing a wrong platform (some Cygwin tests were run *only* on native Windows).
- Removing skips for an impossible platform (the `is_win` and Cygwin case mentioned above).
- Identifying more specific failure conditions (in particular, `test_commit_msg_hook_success` on native Windows works with some `bash` interpreters and not others, possibly arising later than [#1399](https://github.com/gitpython-developers/GitPython/pull/1399)).
- Removing the Cygwin xfail on `test_blocking_lock_file`, which turned out just to need its time window extended on Cygwin the same as for native Windows.

### Very old `git` versions would skip tests needing newer features

*I think that was the right choice at the time*, but now those versions are even older. I've changed the logic to raise `RuntimeError` to error out those tests as being unable to run if one attempts to run them with extremely old versions of `git` that don't support them, rather than skipping.

Intuitively, people don't expect a bug to be caught if it only affects one platform and they test on another. In contrast, skipping these tests is likely to go unnoticed: just as one does not get a passing test run if one doesn't have *any* `git` installed, I think it makes sense for the few specific tests that require a non-ancient `git` to error out without it, now that new enough versions are so widely available.

Some operating systems, such as CentOS 7, that maintain downstream versions of extremely old software for an extremely long time, might have such an old `git` version that nonetheless has downstream security fixes that make it acceptably safe to use. But I suspect that anyone developing improvements to GitPython on such a system would also have installed a newer `git` to test with, even if not aware of any specific incompatibilities.

### The CI test workflows still appeared more different than they are

For debugging CI (and also for future efforts in extending it, including in adding native Windows jobs), it is useful to be able to readily identify the fundamental similarities and differences between the two CI test workflows. I had made some progress on this before, but I've taken care of some stuff I missed. Most notably, commands provided by Cygwin are now run with relative paths in the Cygwin workflow (and found), and `set -x` in the pytest step no longer breaks the tests. There is probably more that could reasonably be done in this area.