### PR TITLE
Fix new link to license in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ gpg --edit-key 4C08421980C9
 
 ### LICENSE
 
-[New BSD License](https://opensource.org/license/bsd-3-clause/). See the [LICENSE file](https://github.com/gitpython-developers/GitPython/blob/main/license).
+[New BSD License](https://opensource.org/license/bsd-3-clause/). See the [LICENSE file][license].
 
 [contributing]: https://github.com/gitpython-developers/GitPython/blob/main/CONTRIBUTING.md
-[license]: https://github.com/gitpython-developers/GitPython/blob/main/license
+[license]: https://github.com/gitpython-developers/GitPython/blob/main/LICENSE


### PR DESCRIPTION
In #1663, I linked from the readme to the license file, except I accidentally combined two styles of Markdown links in a way that doesn't actually work, and the link is a 404. This affected only the link to the license file *in* the repo, not to the external page about the license. I'm not sure how I missed this, but my guess is that I tested it using a case-insensitive filesystem, on which the link would incidentally have worked. (It does not work when browsing GitHub, so this PR is fixing a documentation bug.)