### PR TITLE
Drop unneeded flake8 suppressions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,38 +1,26 @@
 [flake8]
+
 show-source = True
-count= True
+count = True
 statistics = True
-# E265 = comment blocks like @{ section, which it can't handle
+
 # E266 = too many leading '#' for block comment
 # E731 = do not assign a lambda expression, use a def
-# W293 = Blank line contains whitespace
-# W504 = Line break after operator
-# E704 = multiple statements in one line  - used for @override
 # TC002 = move third party import to TYPE_CHECKING
-# ANN = flake8-annotations
 # TC, TC2 = flake8-type-checking
-# D = flake8-docstrings
 
 # select = C,E,F,W ANN, TC, TC2  # to enable code. Disabled if not listed, including builtin codes
 enable-extensions = TC, TC2  # only needed for extensions not enabled by default
 
-ignore = E265,E266,E731,E704,
-         W293, W504,
-         ANN0 ANN1 ANN2,
-         TC002,
-         TC0, TC1, TC2
-         # B,
-         A,
-         D,
-         RST, RST3
+ignore = E266, E731
 
-exclude = .tox,.venv,build,dist,doc,git/ext/
+exclude = .tox, .venv, build, dist, doc, git/ext/
 
 rst-roles =  # for flake8-RST-docstrings
-    attr,class,func,meth,mod,obj,ref,term,var  # used by sphinx
+    attr, class, func, meth, mod, obj, ref, term, var  # used by sphinx
 
 min-python-version = 3.7.0
 
 # for `black` compatibility
 max-line-length = 120
-extend-ignore = E203,W503
+extend-ignore = E203, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,9 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          [
-            flake8-bugbear==23.9.16,
-            flake8-comprehensions==3.14.0,
-            flake8-typing-imports==1.14.0,
-          ]
+          - flake8-bugbear==23.9.16
+          - flake8-comprehensions==3.14.0
+          - flake8-typing-imports==1.14.0
         exclude: ^doc|^git/ext/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Some `flake8` suppressions are no longer needed and can be removed even without changing any Python code. This PR removes them, as well as the comments that were present to explain them. Other comments are retained. I've also reformatted the pre-commit and flake8-specific configuration files for readability.

In #1673 I mentioned I didn't plan to do anything more with `flake8` before trying to replace it with `ruff`, but I realized that these changes make the configuration simpler and shorter. (They *may* also make a switch to `ruff`, if/when it is done, easier, because there are fewer suppression to look up how to do. But I am not asking that this PR be evaluated on that basis.)