### PR TITLE
Update instructions and test helpers for git-daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ executed `git fetch --tags` followed by the `./init-tests-after-clone.sh`
 script in the repository root. Otherwise you will encounter test failures.
 
 On _Windows_, make sure you have `git-daemon` in your PATH. For MINGW-git, the `git-daemon.exe`
-exists in `Git\mingw64\libexec\git-core\`; CYGWIN has no daemon, but should get along fine
-with MINGW's.
+exists in `Git\mingw64\libexec\git-core\`.
 
 #### Install test dependencies
 

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -302,7 +302,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
                     cw.set("url", remote_repo_url)
 
                 with git_daemon_launched(
-                    Git.polish_url(base_daemon_path, is_cygwin=False),  # No daemon in Cygwin.
+                    Git.polish_url(base_daemon_path),
                     "127.0.0.1",
                     GIT_DAEMON_PORT,
                 ):

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -177,12 +177,10 @@ def git_daemon_launched(base_path, ip, port):
     gd = None
     try:
         if is_win:
-            ## On MINGW-git, daemon exists in .\Git\mingw64\libexec\git-core\,
-            #  but if invoked as 'git daemon', it detaches from parent `git` cmd,
-            #  and then CANNOT DIE!
-            #  So, invoke it as a single command.
-            ## Cygwin-git has no daemon.  But it can use MINGW's.
-            #
+            # On MINGW-git, daemon exists in Git\mingw64\libexec\git-core\,
+            # but if invoked as 'git daemon', it detaches from parent `git` cmd,
+            # and then CANNOT DIE!
+            # So, invoke it as a single command.
             daemon_cmd = [
                 "git-daemon",
                 "--enable=receive-pack",
@@ -217,12 +215,11 @@ def git_daemon_launched(base_path, ip, port):
         )
         if is_win:
             msg += textwrap.dedent(
-                r"""
+                R"""
 
             On Windows,
               the `git-daemon.exe` must be in PATH.
-              For MINGW, look into .\Git\mingw64\libexec\git-core\), but problems with paths might appear.
-              CYGWIN has no daemon, but if one exists, it gets along fine (but has also paths problems)."""
+              For MINGW, look into \Git\mingw64\libexec\git-core\, but problems with paths might appear."""
             )
         log.warning(msg, ex, ip, port, base_path, base_path, exc_info=1)
 


### PR DESCRIPTION
On a current Cygwin system with git 2.39.0 (the latest version offered by the Cygwin package manager), `git-daemon` is present, with the Cygwin path `/usr/libexec/git-core/git-daemon.exe`. I believe this has been the case for a long time; as detailed below, Cygwin was not ever treated specially in the way that was assumed, yet no breakage resulted.

The `cygwin-test.yml` workflow does not take any special steps to allow `git-daemon` to work, but all tests have been passing in it even without skipping or xfailing tests that seem related to `git-daemon`.

The `git_daemon_launched` function in `test/lib/helper.py` invokes `git-daemon` directly (rather than through `git daemon`) only when `is_win` evaluates true. This only happens on native Windows systems, while Cygwin is treated the same as (other) Unix-like systems yet still works. So maybe Cygwin `git-daemon` was never a special case.

Whether or not it was, the message about `git-daemon` needing to be findable in a `PATH` search is also under an `is_win` check, and thus is never shown on Cygwin. So I've removed the Cygwin part of that message. (Because the path shown is a MinGW-style path, I have kept the wording about that being for MinGW-git, even though it is no longer needed to disambiguate the Cygwin case.)

The greatest value here is the simplification of the documentation and comments. But for consistency, and to make sure the code and comments don't disagree, I've removed the previous *suppression* of Cygwin special casing: now, Cygwin paths are allowed to be normalized using Cygwin path logic even when passed to `git daemon` as part of the tests. Both ways work on Cygwin in the tests actually being done.

The code change part of this PR only affects test code. Nothing in this pull request modifies anything in the `git` module.