### PR TITLE
Fix Git.execute shell use and reporting bugs

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -974,6 +974,8 @@ class Git(LazyMixin):
         istream_ok = "None"
         if istream:
             istream_ok = "<valid stream>"
+        if shell is None:
+            shell = self.USE_SHELL
         log.debug(
             "Popen(%s, cwd=%s, universal_newlines=%s, shell=%s, istream=%s)",
             redacted_command,
@@ -992,7 +994,7 @@ class Git(LazyMixin):
                     stdin=istream or DEVNULL,
                     stderr=PIPE,
                     stdout=stdout_sink,
-                    shell=shell is not None and shell or self.USE_SHELL,
+                    shell=shell,
                     close_fds=is_posix,  # unsupported on windows
                     universal_newlines=universal_newlines,
                     creationflags=PROC_CREATIONFLAGS,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 black
 coverage[toml]
-ddt>=1.1.1, !=1.4.3
+ddt >= 1.1.1, != 1.4.3
+mock ; python_version < "3.8"
 mypy
 pre-commit
 pytest

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -95,7 +95,7 @@ class TestGit(TestBase):
         with mock.patch.object(Git, "USE_SHELL", value_from_class):
             with contextlib.suppress(GitCommandError):
                 self.git.execute(
-                    "git",  # No args, so it runs with or without a shell, on all OSes.
+                    ["git"],  # No args, so it runs with or without a shell, on all OSes.
                     shell=value_in_call,
                 )
 
@@ -112,7 +112,7 @@ class TestGit(TestBase):
             with mock.patch.object(Git, "USE_SHELL", value_from_class):
                 with contextlib.suppress(GitCommandError):
                     self.git.execute(
-                        "git",  # No args, so it runs with or without a shell, on all OSes.
+                        ["git"],  # No args, so it runs with or without a shell, on all OSes.
                         shell=value_in_call,
                     )
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -73,7 +73,7 @@ class TestGit(TestBase):
         res = self.git.transform_kwargs(**{"s": True, "t": True})
         self.assertEqual({"-s", "-t"}, set(res))
 
-    def test_it_executes_git_to_shell_and_returns_result(self):
+    def test_it_executes_git_and_returns_result(self):
         self.assertRegex(self.git.execute(["git", "version"]), r"^git version [\d\.]{2}.*$")
 
     def test_it_executes_git_not_from_cwd(self):

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -13,7 +13,12 @@ import shutil
 import subprocess
 import sys
 from tempfile import TemporaryDirectory, TemporaryFile
-from unittest import mock, skipUnless
+from unittest import skipUnless
+
+if sys.version_info >= (3, 8):
+    from unittest import mock
+else:
+    import mock  # To be able to examine call_args.kwargs on a mock.
 
 import ddt
 


### PR DESCRIPTION
Fixes #1685
Fixes #1686

### Changes to `git` module code

This updates the `shell` variable itself, only when it is `None`, from `self.USE_SHELL`.

(That attribute usually gets its value from `Git.USE_SHELL` rather than being separately instance attribute. But `self.USE_SHELL` is an idiomatic way to access it. Furthermore, although people probably shouldn't set it on instances, people may expect that this is permitted.)

Now:

- `USE_SHELL` is used as a fallback only. When `shell=False` is passed, `USE_SHELL` is no longer consulted. Thus `shell=False` always keeps a shell from being used, even in the non-default case where the `USE_SHELL` attribute has been set to `True`.
- The debug message printed to the log shows the actual value that is being passed to `Popen`, because the updated shell variable is used both to produce that message and in the `Popen` call.

### New tests

This also (actually, first) adds tests, some to check that the correct value is always passed as `shell=` when `Git.execute` calls `Popen`, and others to check that whatever it passes is the same as it claims to be passing in the log. I've made them two separate test methods rather than a test method with multiple assertions, because I think the results of these particular tests are easier to understand that way (even compared to the option of using `self.subTest`). But the major shared logic is extracted to a helper function, where its important subtleties are commented. I have verified that the tests fail, in the expected way, before the bugs are fixed, and then pass, and that these are both the case even on native Windows where we don't (yet) have CI jobs.

The tests cover the six combinations of valid values of the `shell=` argument to `Git.execute` (`None`, `False`, and `True`) and `Git.USE_SHELL` (`False` and `True`). I used `ddt` for this, so there are only two test methods, even though there are six test cases. The tests are simple in principle, with the main source of complexity being the question of how to deal with how the command argument to `Popen` typically differs, including by *type*, based on the `shell` argument, yet the tests must not misbehave, nor induce extraneous misbehavior, even when the code under test has a bug that would ordinarily prevent such agreement.

On Python 3.7 only, this adds [`mock`](https://pypi.org/project/mock/) as a development dependency (in the `test` extra, not as a regular dependency). `mock` is a backport of `unittest.mock`, and a couple of my assertions use a handy feature that was introduced to the mock library in Python 3.8. Besides being harder to write without it, I believe it would be less clearly expressed. (Details are commented with the import logic.)

While adding the new tests, I also renamed `test_it_executes_git_to_shell_and_returns_result` to `test_it_executes_git_and_returns_result`, because that test case does not test that a shell is used to run `git` (and a shell is *not* used in that test).