### PR TITLE
No longer allow CI to select a prerelease for 3.12

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - experimental: false
-          - python-version: "3.12"
-            experimental: true
+        - experimental: false
+        - python-version: "3.12"
+          experimental: true
 
     defaults:
       run:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,8 +18,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
         - experimental: false
-        - python-version: "3.12"
-          experimental: true
 
     defaults:
       run:


### PR DESCRIPTION
Since 3.12.0 stable has been released, and is [available via setup-python](https://github.com/actions/python-versions/blob/main/versions-manifest.json).

This is not needed to cause setup-python to select the stable version, so long as nothing goes wrong. However, I believe that unexpected version unavailability, or (more likely) the future *presence* of a prerelease of a patch version, could cause a prerelease to be wrongly used. Furthermore, because it would be incorrect for a prerelease to be used for 3.12 from this point forward, and because 3.12 is no longer differently situated from other Python releases with respect to the suitability of prerelease versions, the workflow should no longer explicitly state that a prerelease is acceptable for 3.12.

I've kept the machinery for marking a version experimental. I'm not sure if that should be kept, since it could still be put back next time it is needed, and since the workflow is likely to undergo some other changes in the future. But it seems to me that the presence of `matrix.experimental`, and the `allow-prereleases` key taking its value from it, is independent of changes that are likely to be made in the near future. So keep it isn't doing any harm. I'd be pleased to add a commit (or open a new PR) to remove it, if you like.