### PR TITLE
Improve scripts and tool configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "weekly"
+    interval: "weekly"

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Prepare this repo for tests
       run: |
-        TRAVIS=yes ./init-tests-after-clone.sh
+        ./init-tests-after-clone.sh
 
     - name: Set git user identity and command aliases for the tests
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
 
     - uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --hook-stage manual
+        extra_args: --all-files --hook-stage manual
       env:
         SKIP: black-format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,7 @@ jobs:
         python-version: "3.x"
 
     - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --hook-stage manual
+      env:
+        SKIP: black-format

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Prepare this repo for tests
       run: |
-        TRAVIS=yes ./init-tests-after-clone.sh
+        ./init-tests-after-clone.sh
 
     - name: Set git user identity and command aliases for the tests
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,14 @@ repos:
           - flake8-typing-imports==1.14.0
         exclude: ^doc|^git/ext/
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.5
+    hooks:
+      - id: shellcheck
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+      - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+      - id: black
+        args: [--check, --diff]
+        exclude: ^git/ext/
+
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:
@@ -14,6 +21,7 @@ repos:
     hooks:
       - id: shellcheck
         args: [--color]
+        exclude: ^git/ext/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,15 @@ repos:
     rev: 23.9.1
     hooks:
       - id: black
+        alias: black-check
+        name: black (check)
         args: [--check, --diff]
+        exclude: ^git/ext/
+        stages: [manual]
+
+      - id: black
+        alias: black-format
+        name: black (format)
         exclude: ^git/ext/
 
   - repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v0.9.0.5
     hooks:
       - id: shellcheck
+        args: [--color]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,39 @@
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
-    hooks:
-      - id: black
-        alias: black-check
-        name: black (check)
-        args: [--check, --diff]
-        exclude: ^git/ext/
-        stages: [manual]
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 23.9.1
+  hooks:
+  - id: black
+    alias: black-check
+    name: black (check)
+    args: [--check, --diff]
+    exclude: ^git/ext/
+    stages: [manual]
 
-      - id: black
-        alias: black-format
-        name: black (format)
-        exclude: ^git/ext/
+  - id: black
+    alias: black-format
+    name: black (format)
+    exclude: ^git/ext/
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear==23.9.16
-          - flake8-comprehensions==3.14.0
-          - flake8-typing-imports==1.14.0
-        exclude: ^doc|^git/ext/
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.1.0
+  hooks:
+  - id: flake8
+    additional_dependencies:
+    - flake8-bugbear==23.9.16
+    - flake8-comprehensions==3.14.0
+    - flake8-typing-imports==1.14.0
+    exclude: ^doc|^git/ext/
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.5
-    hooks:
-      - id: shellcheck
-        args: [--color]
-        exclude: ^git/ext/
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.9.0.5
+  hooks:
+  - id: shellcheck
+    args: [--color]
+    exclude: ^git/ext/
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: check-merge-conflict
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-toml
+  - id: check-yaml
+  - id: check-merge-conflict

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean release force_release
 
 all:
-	@grep -E '^[[:alpha:]].*:' Makefile | cut -d: -f1 | grep -vxF all
+	@awk -F: '/^[[:alpha:]].*:/ && !/^all:/ {print $$1}' Makefile
 
 clean:
 	rm -rf build/ dist/ .eggs/ .tox/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: all clean release force_release
+.PHONY: all lint clean release force_release
 
 all:
 	@awk -F: '/^[[:alpha:]].*:/ && !/^all:/ {print $$1}' Makefile
+
+lint:
+	SKIP=black-format pre-commit run --all-files --hook-stage manual
 
 clean:
 	rm -rf build/ dist/ .eggs/ .tox/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean release force_release
 
 all:
-	@grep -Ee '^[a-z].*:' Makefile | cut -d: -f1 | grep -vF all
+	@grep -E '^[[:alpha:]].*:' Makefile | cut -d: -f1 | grep -vxF all
 
 clean:
 	rm -rf build/ dist/ .eggs/ .tox/

--- a/README.md
+++ b/README.md
@@ -79,13 +79,17 @@ cd GitPython
 ./init-tests-after-clone.sh
 ```
 
+On Windows, `./init-tests-after-clone.sh` can be run in a Git Bash shell.
+
 If you are cloning [your own fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks), then replace the above `git clone` command with one that gives the URL of your fork. Or use this [`gh`](https://cli.github.com/) command (assuming you have `gh` and your fork is called `GitPython`):
 
 ```bash
 gh repo clone GitPython
 ```
 
-Having cloned the repo, create and activate your [virtual environment](https://docs.python.org/3/tutorial/venv.html). Then make an [editable install](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs):
+Having cloned the repo, create and activate your [virtual environment](https://docs.python.org/3/tutorial/venv.html).
+
+Then make an [editable install](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs):
 
 ```bash
 pip install -e ".[test]"

--- a/README.md
+++ b/README.md
@@ -148,11 +148,8 @@ To lint, and apply automatic code formatting, run:
 pre-commit run --all-files
 ```
 
-Code formatting can also be done by itself by running:
-
-```
-black .
-```
+- Linting without modifying code can be done with: `make lint`
+- Auto-formatting without other lint checks can be done with: `black .`
 
 To typecheck, run:
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ mypy -p git
 The same linting, and running tests on all the different supported Python versions, will be performed:
 
 - Upon submitting a pull request.
-- On each push, *if* you have a fork with a "main" branch and GitHub Actions enabled.
+- On each push, *if* you have a fork with GitHub Actions enabled.
 - Locally, if you run [`tox`](https://tox.wiki/) (this skips any Python versions you don't have installed).
 
 #### Configuration files

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ To clone the [the GitHub repository](https://github.com/gitpython-developers/Git
 ```bash
 git clone https://github.com/gitpython-developers/GitPython
 cd GitPython
-git fetch --tags
 ./init-tests-after-clone.sh
 ```
 
@@ -114,9 +113,9 @@ See [Issue #525](https://github.com/gitpython-developers/GitPython/issues/525).
 
 ### RUNNING TESTS
 
-_Important_: Right after cloning this repository, please be sure to have
-executed `git fetch --tags` followed by the `./init-tests-after-clone.sh`
-script in the repository root. Otherwise you will encounter test failures.
+_Important_: Right after cloning this repository, please be sure to have executed
+the `./init-tests-after-clone.sh` script in the repository root. Otherwise
+you will encounter test failures.
 
 On _Windows_, make sure you have `git-daemon` in your PATH. For MINGW-git, the `git-daemon.exe`
 exists in `Git\mingw64\libexec\git-core\`.

--- a/README.md
+++ b/README.md
@@ -157,12 +157,26 @@ To typecheck, run:
 mypy -p git
 ```
 
-Configuration for flake8 is in the `./.flake8` file.
+#### CI (and tox)
 
-Configurations for `mypy`, `pytest`, `coverage.py`, and `black` are in `./pyproject.toml`.
+The same linting, and running tests on all the different supported Python versions, will be performed:
 
-The same linting and testing will also be performed against different supported python versions
-upon submitting a pull request (or on each push if you have a fork with a "main" branch and actions enabled).
+- Upon submitting a pull request.
+- On each push, *if* you have a fork with a "main" branch and GitHub Actions enabled.
+- Locally, if you run [`tox`](https://tox.wiki/) (this skips any Python versions you don't have installed).
+
+#### Configuration files
+
+Specific tools:
+
+- Configurations for `mypy`, `pytest`, `coverage.py`, and `black` are in `./pyproject.toml`.
+- Configuration for `flake8` is in the `./.flake8` file.
+
+Orchestration tools:
+
+- Configuration for `pre-commit` is in the `./.pre-commit-config.yaml` file.
+- Configuration for `tox` is in `./tox.ini`.
+- Configuration for GitHub Actions (CI) is in files inside `./.github/workflows/`.
 
 ### Contributions
 

--- a/README.md
+++ b/README.md
@@ -142,22 +142,22 @@ To test, run:
 pytest
 ```
 
-To lint, run:
+To lint, and apply automatic code formatting, run:
 
 ```bash
 pre-commit run --all-files
+```
+
+Code formatting can also be done by itself by running:
+
+```
+black .
 ```
 
 To typecheck, run:
 
 ```bash
 mypy -p git
-```
-
-For automatic code formatting, run:
-
-```bash
-black .
 ```
 
 Configuration for flake8 is in the `./.flake8` file.

--- a/build-release.sh
+++ b/build-release.sh
@@ -6,7 +6,7 @@
 set -eEu
 
 function release_with() {
-    $1 -m build --sdist --wheel
+    "$1" -m build --sdist --wheel
 }
 
 if test -n "${VIRTUAL_ENV:-}"; then

--- a/build-release.sh
+++ b/build-release.sh
@@ -9,6 +9,11 @@ function release_with() {
     "$1" -m build --sdist --wheel
 }
 
+function suggest_venv() {
+    local venv_cmd='python -m venv env && source env/bin/activate'
+    printf "HELP: To avoid this error, use a virtual-env with '%s' instead.\n" "$venv_cmd"
+}
+
 if test -n "${VIRTUAL_ENV:-}"; then
     deps=(build twine)  # Install twine along with build, as we need it later.
     echo "Virtual environment detected. Adding packages: ${deps[*]}"
@@ -16,11 +21,7 @@ if test -n "${VIRTUAL_ENV:-}"; then
     echo 'Starting the build.'
     release_with python
 else
-    function suggest_venv() {
-        venv_cmd='python -m venv env && source env/bin/activate'
-        printf "HELP: To avoid this error, use a virtual-env with '%s' instead.\n" "$venv_cmd"
-    }
     trap suggest_venv ERR  # This keeps the original exit (error) code.
     echo 'Starting the build.'
-    release_with python3 # Outside a venv, use python3.
+    release_with python3  # Outside a venv, use python3.
 fi

--- a/build-release.sh
+++ b/build-release.sh
@@ -14,7 +14,7 @@ function suggest_venv() {
     printf "HELP: To avoid this error, use a virtual-env with '%s' instead.\n" "$venv_cmd"
 }
 
-if test -n "${VIRTUAL_ENV:-}"; then
+if test -n "${VIRTUAL_ENV-}"; then
     deps=(build twine)  # Install twine along with build, as we need it later.
     echo "Virtual environment detected. Adding packages: ${deps[*]}"
     pip install --quiet --upgrade "${deps[@]}"

--- a/check-version.sh
+++ b/check-version.sh
@@ -41,7 +41,8 @@ head_sha="$(git rev-parse HEAD)"
 latest_tag_sha="$(git rev-parse "${latest_tag}^{commit}")"
 
 # Display a table of all the current version, tag, and HEAD commit information.
-echo $'\nThe VERSION must be the same in all locations, and so must the HEAD and tag SHA'
+echo
+echo 'The VERSION must be the same in all locations, and so must the HEAD and tag SHA'
 printf '%-14s = %s\n' 'VERSION file'   "$version_version" \
                       'changes.rst'    "$changes_version" \
                       'Latest tag'     "$latest_tag" \

--- a/check-version.sh
+++ b/check-version.sh
@@ -10,6 +10,11 @@ trap 'echo "$0: Check failed. Stopping." >&2' ERR
 readonly version_path='VERSION'
 readonly changes_path='doc/source/changes.rst'
 
+function check_status() {
+    git status -s "$@"
+    test -z "$(git status -s "$@")"
+}
+
 function get_latest_tag() {
     local config_opts
     printf -v config_opts ' -c versionsort.suffix=-%s' alpha beta pre rc RC
@@ -23,13 +28,11 @@ test "$(cd -- "$(dirname -- "$0")" && pwd)" = "$(pwd)"  # Ugly, but portable.
 echo "Checking that $version_path and $changes_path exist and have no uncommitted changes."
 test -f "$version_path"
 test -f "$changes_path"
-git status -s -- "$version_path" "$changes_path"
-test -z "$(git status -s -- "$version_path" "$changes_path")"
+check_status -- "$version_path" "$changes_path"
 
 # This section can be commented out, if absolutely necessary.
 echo 'Checking that ALL changes are committed.'
-git status -s --ignore-submodules
-test -z "$(git status -s --ignore-submodules)"
+check_status --ignore-submodules
 
 version_version="$(<"$version_path")"
 changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"

--- a/check-version.sh
+++ b/check-version.sh
@@ -12,7 +12,7 @@ readonly changes_path='doc/source/changes.rst'
 
 function get_latest_tag() {
     local config_opts
-    config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
+    printf -v config_opts ' -c versionsort.suffix=-%s' alpha beta pre rc RC
     # shellcheck disable=SC2086  # Deliberately word-splitting the arguments.
     git $config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1
 }
@@ -31,7 +31,7 @@ echo 'Checking that ALL changes are committed.'
 git status -s --ignore-submodules
 test -z "$(git status -s --ignore-submodules)"
 
-version_version="$(cat "$version_path")"
+version_version="$(<"$version_path")"
 changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"
 latest_tag="$(get_latest_tag)"
 head_sha="$(git rev-parse HEAD)"

--- a/check-version.sh
+++ b/check-version.sh
@@ -10,6 +10,13 @@ trap 'echo "$0: Check failed. Stopping." >&2' ERR
 readonly version_path='VERSION'
 readonly changes_path='doc/source/changes.rst'
 
+function get_latest_tag() {
+    local config_opts
+    config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
+    # shellcheck disable=SC2086  # Deliberately word-splitting the arguments.
+    git $config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1
+}
+
 echo 'Checking current directory.'
 test "$(cd -- "$(dirname -- "$0")" && pwd)" = "$(pwd)"  # Ugly, but portable.
 
@@ -26,8 +33,7 @@ test -z "$(git status -s --ignore-submodules)"
 
 version_version="$(cat "$version_path")"
 changes_version="$(awk '/^[0-9]/ {print $0; exit}' "$changes_path")"
-config_opts="$(printf ' -c versionsort.suffix=-%s' alpha beta pre rc RC)"
-latest_tag="$(git $config_opts tag -l '[0-9]*' --sort=-v:refname | head -n1)"
+latest_tag="$(get_latest_tag)"
 head_sha="$(git rev-parse HEAD)"
 latest_tag_sha="$(git rev-parse "${latest_tag}^{commit}")"
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,7 @@
 #
 
 # You can set these variables from the command line.
+BUILDDIR      = build
 SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
@@ -9,7 +10,7 @@ PAPER         =
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck
 
@@ -24,52 +25,52 @@ help:
 	@echo "  linkcheck to check all external links for integrity"
 
 clean:
-	-rm -rf build/*
+	-rm -rf $(BUILDDIR)/*
 
 html:
-	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
+	mkdir -p $(BUILDDIR)/html $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
-	@echo "Build finished. The HTML pages are in build/html."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 pickle:
-	mkdir -p build/pickle build/doctrees
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) build/pickle
+	mkdir -p $(BUILDDIR)/pickle $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
 web: pickle
 
 json:
-	mkdir -p build/json build/doctrees
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) build/json
+	mkdir -p $(BUILDDIR)/json $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
 htmlhelp:
-	mkdir -p build/htmlhelp build/doctrees
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) build/htmlhelp
+	mkdir -p $(BUILDDIR)/htmlhelp $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in build/htmlhelp."
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 latex:
-	mkdir -p build/latex build/doctrees
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex
+	mkdir -p $(BUILDDIR)/latex $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
-	@echo "Build finished; the LaTeX files are in build/latex."
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
 
 changes:
-	mkdir -p build/changes build/doctrees
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) build/changes
+	mkdir -p $(BUILDDIR)/changes $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
-	@echo "The overview file is in build/changes."
+	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	mkdir -p build/linkcheck build/doctrees
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) build/linkcheck
+	mkdir -p $(BUILDDIR)/linkcheck $(BUILDDIR)/doctrees
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
-	      "or in build/linkcheck/output.txt."
+	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -30,7 +30,7 @@ git reset --hard __testing_point__
 
 # Do some setup that CI takes care of but that may not have been done locally.
 if test -z "${TRAVIS-}"; then
-    # The tests needs some version tags. Try to get them even in forks.
+    # The tests need some version tags. Try to get them even in forks.
     git fetch --all --tags
 
     # The tests need submodules, including a submodule with a submodule.

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-set -e
+set -eu
 
-if test -z "$TRAVIS"; then
+if test -z "${TRAVIS-}"; then
     printf 'This operation will destroy locally modified files. Continue ? [N/y]: ' >&2
     read -r answer
     case "$answer" in
@@ -29,7 +29,7 @@ git reset --hard HEAD~1
 git reset --hard __testing_point__
 
 # Do some setup that CI takes care of but that may not have been done locally.
-if test -z "$TRAVIS"; then
+if test -z "${TRAVIS-}"; then
     # The tests needs some version tags. Try to get them even in forks.
     git fetch --all --tags
 

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -19,4 +19,8 @@ git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard __testing_point__
+
+test -z "$TRAVIS" || exit 0  # CI jobs will already have taken care of the rest.
+
+git fetch --all --tags
 git submodule update --init --recursive

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -2,7 +2,12 @@
 
 set -eu
 
-if test -z "${TRAVIS-}"; then
+ci() {
+    # For now, check just these, as a false positive could lead to data loss.
+    test -n "${TRAVIS-}" || test -n "${GITHUB_ACTIONS-}"
+}
+
+if ! ci; then
     printf 'This operation will destroy locally modified files. Continue ? [N/y]: ' >&2
     read -r answer
     case "$answer" in
@@ -29,7 +34,7 @@ git reset --hard HEAD~1
 git reset --hard __testing_point__
 
 # Do some setup that CI takes care of but that may not have been done locally.
-if test -z "${TRAVIS-}"; then
+if ! ci; then
     # The tests need some version tags. Try to get them even in forks.
     git fetch --all --tags
 

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -14,10 +14,10 @@ no_version_tags() {
 }
 
 warn() {
-    printf '%s\n' "$@" >&2  # Warn in step output.
-
     if test -n "${GITHUB_ACTIONS-}"; then
         printf '::warning ::%s\n' "$*" >&2  # Annotate workflow.
+    else
+        printf '%s\n' "$@" >&2
     fi
 }
 

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -52,8 +52,8 @@ if ! ci; then
     git submodule update --init --recursive
 fi
 
-# The tests need some version tags. Try to get them even in forks. This fetch
-# gets other objects too, so for a consistent experience, always do it locally.
+# The tests need some version tags. Try to get them even in forks. This fetches
+# other objects too. So, locally, we always do it, for a consistent experience.
 if ! ci || no_version_tags; then
     git fetch --all --tags
 fi

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -1,12 +1,16 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
-if [[ -z "$TRAVIS" ]]; then
-    read -rp "This operation will destroy locally modified files. Continue ? [N/y]: " answer
-    if [[ ! $answer =~ [yY] ]]; then
-        exit 2
-    fi
+if test -z "$TRAVIS"; then
+    printf 'This operation will destroy locally modified files. Continue ? [N/y]: ' >&2
+    read -r answer
+    case "$answer" in
+    [yY])
+        ;;
+    *)
+        exit 2 ;;
+    esac
 fi
 
 git tag __testing_point__

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -10,7 +10,7 @@ if [[ -z "$TRAVIS" ]]; then
 fi
 
 git tag __testing_point__
-git checkout master || git checkout -b master
+git checkout master -- || git checkout -b master
 git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard HEAD~1

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -3,10 +3,10 @@
 set -e
 
 if [[ -z "$TRAVIS" ]]; then
-  read -rp "This operation will destroy locally modified files. Continue ? [N/y]: " answer
-  if [[ ! $answer =~ [yY] ]]; then
-    exit 2
-  fi
+    read -rp "This operation will destroy locally modified files. Continue ? [N/y]: " answer
+    if [[ ! $answer =~ [yY] ]]; then
+        exit 2
+    fi
 fi
 
 git tag __testing_point__

--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -13,14 +13,26 @@ if test -z "$TRAVIS"; then
     esac
 fi
 
+# Stop if we have run this. (You can delete __testing_point__ to let it rerun.)
+# This also keeps track of where we are, so we can get back here.
 git tag __testing_point__
+
+# The tests need a branch called master.
 git checkout master -- || git checkout -b master
+
+# The tests need a reflog history on the master branch.
 git reset --hard HEAD~1
 git reset --hard HEAD~1
 git reset --hard HEAD~1
+
+# Point the master branch where we started, so we test the correct code.
 git reset --hard __testing_point__
 
-test -z "$TRAVIS" || exit 0  # CI jobs will already have taken care of the rest.
+# Do some setup that CI takes care of but that may not have been done locally.
+if test -z "$TRAVIS"; then
+    # The tests needs some version tags. Try to get them even in forks.
+    git fetch --all --tags
 
-git fetch --all --tags
-git submodule update --init --recursive
+    # The tests need submodules, including a submodule with a submodule.
+    git submodule update --init --recursive
+fi

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -43,7 +43,7 @@ class TestGit(TestBase):
     def _assert_logged_for_popen(self, log_watcher, name, value):
         re_name = re.escape(name)
         re_value = re.escape(str(value))
-        re_line = re.compile(fr"DEBUG:git.cmd:Popen\(.*\b{re_name}={re_value}[,)]")
+        re_line = re.compile(rf"DEBUG:git.cmd:Popen\(.*\b{re_name}={re_value}[,)]")
         match_attempts = [re_line.match(message) for message in log_watcher.output]
         self.assertTrue(any(match_attempts), repr(log_watcher.output))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires = tox>=4
-env_list = py{37,38,39,310,311,312}, lint, mypy
+env_list = py{37,38,39,310,311,312}, lint, mypy, html
 
 [testenv]
 description = Run unit tests
@@ -22,11 +22,11 @@ base_python = py39
 commands = mypy -p git
 ignore_outcome = true
 
-# Run "tox -e html" for this. It is deliberately excluded from env_list, as
-# unlike the other environments, this one writes outside the .tox/ directory.
 [testenv:html]
 description = Build HTML documentation
 base_python = py39
 deps = -r doc/requirements.txt
 allowlist_externals = make
-commands = make -C doc html
+commands =
+    make BUILDDIR={env_tmp_dir}/doc/build -C doc clean
+    make BUILDDIR={env_tmp_dir}/doc/build -C doc html

--- a/tox.ini
+++ b/tox.ini
@@ -11,20 +11,20 @@ commands = pytest --color=yes {posargs}
 
 [testenv:lint]
 description = Lint via pre-commit
-base_python = py39
+base_python = py{39,310,311,312,38,37}
 set_env =
     SKIP = black-format
 commands = pre-commit run --all-files --hook-stage manual
 
 [testenv:mypy]
 description = Typecheck with mypy
-base_python = py39
+base_python = py{39,310,311,312,38,37}
 commands = mypy -p git
 ignore_outcome = true
 
 [testenv:html]
 description = Build HTML documentation
-base_python = py39
+base_python = py{39,310,311,312,38,37}
 deps = -r doc/requirements.txt
 allowlist_externals = make
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires = tox>=4
-env_list = py{37,38,39,310,311,312}, lint, mypy, black
+env_list = py{37,38,39,310,311,312}, lint, mypy
 
 [testenv]
 description = Run unit tests
@@ -19,11 +19,6 @@ description = Typecheck with mypy
 base_python = py39
 commands = mypy -p git
 ignore_outcome = true
-
-[testenv:black]
-description = Check style with black
-base_python = py39
-commands = black --check --diff .
 
 # Run "tox -e html" for this. It is deliberately excluded from env_list, as
 # unlike the other environments, this one writes outside the .tox/ directory.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ commands = pytest --color=yes {posargs}
 [testenv:lint]
 description = Lint via pre-commit
 base_python = py39
-commands = pre-commit run --all-files
+set_env =
+    SKIP = black-format
+commands = pre-commit run --all-files --hook-stage manual
 
 [testenv:mypy]
 description = Typecheck with mypy


### PR DESCRIPTION
Fixes #1690
Fixes #1691
Fixes #1692

This combines the solutions I recommended in those three issues on a single branch. Although I feel this does compose into a coherent whole, with each of those issues' practical ramifications having some tendrils into each other, and opening separate PRs would have resulted in nontrivial merge conflicts... nonetheless this PR is broader than I would usually like. But I have done it this way because it was by working on them together that I was able to get clear on the distinct ideas that I presented as those issues, as well as whether the solutions would work reasonably when all combined.

This PR is what remains after pieces that seemed reasonable to sever into their on PRs, such as #1684, have been removed, and excessively enterprising ideas, such as writing a batch-file version of `init-tests-after-clone.sh` (discussed in #1691) or switching `lint.yml` to use [pre-commit.ci](https://pre-commit.ci/), abandoned or deferred. However, I would be pleased to make further changes as requested. I think the changes here are feasible to review together, but I am willing to rework this into multiple more narrowly scoped PRs if necessary.

The problems and their solutions in general are presented in the three linked issues that this would close. (Details are given in commit messages.)

Specific considerations that I suspect may be important when reviewing this PR follow.

### Shell script portability

I believe the shell scripts that pertain to building do not need to be any more portable than they are now: they run on `bash` version 3 or later, which most systems have or can get. I did make modifications to them, some of which were inspired and emboldened by `shellcheck`, but not for portability to other shells.

I take https://github.com/gitpython-developers/GitPython/pull/1661#issuecomment-1720753764 (specifically: d18d90a, 1e0b3f9) as an indication of a general preference of `echo` over `printf`. The `bash` shell provides an `echo` builtin that has good design decisions and, more importantly, behaves the same in `bash` on any system, because it is a builtin. (I have actually slightly increased the use of `echo` in `bash` in this PR.)

However, for POSIX shell scripts that assume only what the standard insists on (or that call `echo` through another command, such as with `find -exec` or `xargs`, thereby using an external `echo` executable), the situation is [considerably messier](https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo). To write a portable script, I have avoided the use of `echo` in the init script that, for portability, I have changed from `bash` to `sh`.

### What fallback version-tag fetching looks like

Fallback fetching of version tags is the "back-up" strategy that is part of the fix for #1690. It works both locally and on CI. Here's what it looks like on CI (I temporarily deleted all the version tags from my fork and reran the tip of this PR's branch):

- [Ubuntu](https://github.com/EliahKagan/GitPython/actions/runs/6400756535/job/17376098279#step:4:1)
- [Cygwin](https://github.com/EliahKagan/GitPython/actions/runs/6400756541/job/17376097449#step:6:1)

(In case for any reason you want to see the version from an earlier commit and prior to multiple rebases that I had shown before in an earlier draft of this PR description, [that's here](https://github.com/EliahKagan/GitPython/actions/runs/6348264101/job/17244568946#step:4:20).)

### Fallback version-tag fetching would fail on old `git`

At least as currently written, it uses a feature that was introduced in Git 2.6.0.

I have [posted a review comment](https://github.com/gitpython-developers/GitPython/pull/1693#discussion_r1345132123) on the specific code this affects, with full details.

### Security implications of where `init-tests-after-clone.sh` makes `master`

> *Edit:* Based on #1615, I think you might prefer `git checkout -B master` not be used, for reasons of stability rather than security. Maybe `git checkout -B master ea43defd777a9c0751fc44a9c6a622fc2dbd18a0` should even be used, to get the same old commit even in forks that don't have the `master` branch, and to add the same commits to the top of the reflog history even when `__testing_point__` is deleted and the script rerun.

Currently, on `main`, `init-tests-after-clone.sh` creates or switches to a `master` branch like this:

```sh
git checkout master || git checkout -b master
```

One of the changes in this PR is to ensure that `master` cannot be interpreted as a path--it has to be taken to be a branch, or at least a ref--which is mainly for better output to stderr when the branch doesn't exist, but also to safeguard against rare situations where a file or directory named `master` exists:

```sh
git checkout master -- || git checkout -b master
```

However, there is a simpler, more elegant, and more robust way to get a suitable `master` branch for tests, that I think is more likely to work well most of the time *[edit: though the answer to #1615 suggests a reason it might not]*:

```sh
git checkout -B master
```

`master` is already getting reset back to `__testing_point__`, so the main disadvantage of `-B`, that one can lose one's branch if it is not pushed, applies already.

I would like to do it that way (and I have [a branch](https://github.com/EliahKagan/GitPython/commits/sh-branch-here/) for it, ready to go). But it has security implications, *specifically* for people who review pull requests. As detailed in #1690, wherever `master` gets checked out, editors and IDEs may be fooled into running unreviewed untrusted code from there. Using the `-B` way I want to use would be a mitigation for the situation described in #1690 (though that's not the main reason I want to do it). But it would be an *exacerbation* of it for a reviewer, because it would weaken the already brittle assurance `git diff main feature` would provide. Consider:

```text
main  ←  evil  ←  evil  ←  evil  ←  feature
```

There, a pull request proposes a useful feature on the `feature` branch. But the preceding three commits have evil code in them that, if an editor/IDE  imports modules to do test discovery (or any other operation the editor reserves for "trusted folders"), will be run. The tip of `feature` removes the evil code, so `git diff main feature` does not reveal it. But because `master` is checked out at the tip of `feature` even if `master` already exists in the reviewer's local or remote repository, *the script's reflog-building commands reset to each of the evil commits*.

This may not be a serious problem. When reviewing, one should already not rely merely on `git diff main feature`, and CI in pull requests is set up to run on the `pull-request` trigger (which, unlike `pull-request-target` which is dangerous if not used very carefully, runs with the fork's permissions, not allowing elevation). Furthermore, one may already not have `master` locally or on a remote, in which case the existing checkout code already creates it at `HEAD`, so it's not like this is a new situation. Furthermore, it's generally unnecessary to run that script while reviewing, even *if* one opens up an only partially reviewed PR branch in an editor that may perform unsafe operations based on its contents.

Nonetheless, I wanted to bring this up rather than just adding a commit to change it to `git checkout -B master`.

### `black` via `pre-commit`: I'm not sure what's best.

It seems to me that there is actually just one thing that, in hindsight, would have been better to have developed separately. Adding `black` to `pre-commit`, and using that on CI, presents choices to be made while reviewing that are practically separate from the other changes.

The core issue is that all the other tools run via `pre-commit` only perform checks, while the way most users of `black` and `pre-commit` would expect and prefer they be used together is for `pre-commit` to actually perform auto-formatting. This is actually no problem on CI; the GitHub Action being used accepts code changes from a hook as a check failure. But there should be a way to *just lint* locally, that includes checking for `black`-conforming formatting and that does not change any files.

Therefore, I have set up *two* hooks for `black`: one that runs by default and formats, and another that does not run by default and that only performs checks. The `tox` linting environment and `lint.yml` CI workflow use the check-only hook and skip the formatting one. But there should also be a way to do this locally *without* building the project and setting up `tox` environments and without typing in a complex `pre-commit` command. So I have made `make lint` do that.

This is all documented as part of the readme improvements. It is inelegant, though, because everything else done by makefiles in this project is directly related to *building*. There are a few options, which I present in descending order of my preference, but they are all things I think are reasonable:

- Use this, for now.
- Use this, for now, but add a note in the readme about how `make lint` may go away. (I think this is not really necessary, because the *development* instructions are not implied to be stable. But I am not sure.)
- Change `pre-commit` to have *only* the check-only `black` hook, at least for now, and modify the readme accordingly. Then there is no need for `make lint` because `pre-commit run --all-files` just lints, as it did before, but including `black`. This has the disadvantage that people who like `black` and `pre-commit` probably prefer that they facilitate auto-formatting, but it is otherwise elegant. I suspect you might prefer this approach, therefore I have made a commit for it on my [`sh-nofmt`](https://github.com/EliahKagan/GitPython/commits/sh-nofmt/) branch, which can be easily fast-forward merged into here (or opened as a separate PR if the change is desired after merging this).
- Remove everything to do with `black` from `.pre-commit-config.yml` on this branch, modifying the readme accordingly, and propose it separately. It could be removed by rebasing, or just by adding a commit to remove it. This is more work, but actually a bigger reason this is not my preferred approach is the same reason I had added `black` to `pre-commit` in the first place: with everything else being done by `pre-commit`, and with this project being in `black` style (aside from this project's very long lines), it is unintuitive and unexpected that it would not, in any form, be usable via `pre-commit`.