### PR TITLE
Ask git where its daemon is and use that

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,6 @@ _Important_: Right after cloning this repository, please be sure to have execute
 the `./init-tests-after-clone.sh` script in the repository root. Otherwise
 you will encounter test failures.
 
-On _Windows_, make sure you have `git-daemon` in your PATH. For MINGW-git, the `git-daemon.exe`
-exists in `Git\mingw64\libexec\git-core\`.
-
 #### Install test dependencies
 
 Ensure testing libraries are installed. This is taken care of already if you installed with:

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -182,7 +182,7 @@ def git_daemon_launched(base_path, ip, port):
             # and then CANNOT DIE!
             # So, invoke it as a single command.
             daemon_cmd = [
-                "git-daemon",
+                osp.join(Git()._call_process("--exec-path"), "git-daemon"),
                 "--enable=receive-pack",
                 "--listen=%s" % ip,
                 "--port=%s" % port,


### PR DESCRIPTION
This changes the test helpers on Windows to use `git --exec-path` (with whatever `git` GitPython is using) to find the directory that contains `git-daemon.exe`, instead of finding `git-daemon.exe` in a PATH search.

Because it is only on Windows that the tests run `git-daemon` directly rather than using `git daemon`, this only affects Windows. Note that this does *not* affect Cygwin, which like other Unix-like systems uses `git daemon` for the tests.

This change has three benefits:

- **The documentation is shortened and simplified**, because the part on how to get `git-daemon` working on Windows is removed.
- **The effort required to set up GitPython for testing is reduced** because that no longer has to be done (but see below).
- **Users will not be tempted to put Git's `libexec\git-core` directory in their `PATH`.** This directory contains a number of `.dll` files, which are there for the executables in the directory that use them. But Windows includes all `PATH` directories when searching for *libraries* as well as programs, which can create very strange and confusing problems where completely unrelated programs end up using them instead of the versions of the libraries they should use.

Note, however, what it does *not* cover:

- **The tests that use `git-daemon` are still skipped by default on Windows.** These are exactly the tests that are skipped when `HIDE_WINDOWS_FREEZE_ERRORS` is set to `True`, which is the case by default on Windows. I temporarily changed its default value to `False` to test this PR. That change is deliberately not included in this PR and probably should not be made without further accompanying changes. (See [this comment](https://github.com/gitpython-developers/GitPython/issues/1676#issuecomment-1735052752), but also the information below about how the tests usually fail, which is not by freezing.)

- **The mechanism to skip them remains to be fixed.** The `HIDE_WINDOWS_KNOWN_ERRORS` and `HIDE_WINDOWS_FREEZE_ERRORS` variables are intended to be affected by the same-named environment variables, but this does not work properly. They are `True` by default, but the only way to use environment variables to set them to a false value is *to define the environment variable with an empty value* (since everything else, as a string, is truthy). In addition to being very unlikely to have been the intended behavior, this is also hard to do on Windows when using typical shells, because in both `cmd.exe` and PowerShell setting an environment variable as empty actually removes the variable altogether. Rather than attempting to fix that here, I tested by temporarily changing the default value instead of using an environment variable.

- **The tests that use `git-daemon` still usually fail on Windows.** The failure mode is the same as when they are run with `git-daemon.exe` in a directory in `PATH`, however. That is, [when `git-daemon` is not found it looks like this](https://gist.github.com/EliahKagan/53d00e28515cf2374c5501b03f7eb266#file-with-no-git-daemon-txt), while [when it is found by a `PATH` search it looks like this](https://gist.github.com/EliahKagan/53d00e28515cf2374c5501b03f7eb266#file-with-path-git-daemon-txt), and [the new way, finding it via `git --exec-path`, looks similar](https://gist.github.com/EliahKagan/53d00e28515cf2374c5501b03f7eb266#file-with-automatic-git-daemon-txt). Note how all errors of this form occur in the log `with-no-git-daemon.txt`:
  
  ```text
  git.exc.GitCommandNotFound: Cmd('git-daemon') not found due to: FileNotFoundError('[WinError 2] The system cannot find the file specified')
  ```

  The files can be compared with `diff` or with [this convenient diff tool](https://neil.fraser.name/software/diff_match_patch/demos/diff.html). I would also be happy to produce diffs using a particular technique, on request. Those diffs were also produced before rebasing this to include the changes from [#1693](https://github.com/gitpython-developers/GitPython/pull/1693), since I had neglected by merge that on my Windows system before working on this, but I believe none of the changes there are able to affect this.

That is to say that this PR is very narrow in its scope of effects--it automates, and at least as reliably achieves, the desired effect of a setup step that had to be done manually before, but it doesn't address any of the other problems related to it.

One aspect of the way I did this change deserves special scrutiny; I've made [a review comment](https://github.com/gitpython-developers/GitPython/pull/1697#pullrequestreview-1663077270) about it.