### PR TITLE
Fix bugs affecting exception wrapping in rmtree callback

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1,43 +1,37 @@
-# need a dict to set bloody .name field
 from io import BytesIO
 import logging
 import os
+import os.path as osp
 import stat
 import uuid
 
 import git
 from git.cmd import Git
-from git.compat import (
-    defenc,
-    is_win,
-)
-from git.config import SectionConstraint, GitConfigParser, cp
+from git.compat import defenc, is_win
+from git.config import GitConfigParser, SectionConstraint, cp
 from git.exc import (
+    BadName,
     InvalidGitRepositoryError,
     NoSuchPathError,
     RepositoryDirtyError,
-    BadName,
 )
 from git.objects.base import IndexObject, Object
 from git.objects.util import TraversableIterableObj
-
 from git.util import (
-    join_path_native,
-    to_native_path_linux,
-    RemoteProgress,
-    rmtree,
-    unbare_repo,
     IterableList,
+    RemoteProgress,
+    join_path_native,
+    rmtree,
+    to_native_path_linux,
+    unbare_repo,
 )
 
-import os.path as osp
-
 from .util import (
+    SubmoduleConfigParser,
+    find_first_remote_branch,
     mkhead,
     sm_name,
     sm_section,
-    SubmoduleConfigParser,
-    find_first_remote_branch,
 )
 
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -29,7 +29,6 @@ from git.util import (
     unbare_repo,
     IterableList,
 )
-from git.util import HIDE_WINDOWS_KNOWN_ERRORS
 
 import os.path as osp
 
@@ -1060,28 +1059,13 @@ class Submodule(IndexObject, TraversableIterableObj):
                     import gc
 
                     gc.collect()
-                    try:
-                        rmtree(str(wtd))
-                    except Exception as ex:
-                        if HIDE_WINDOWS_KNOWN_ERRORS:
-                            from unittest import SkipTest
-
-                            raise SkipTest("FIXME: fails with: PermissionError\n  {}".format(ex)) from ex
-                        raise
+                    rmtree(str(wtd))
                 # END delete tree if possible
             # END handle force
 
             if not dry_run and osp.isdir(git_dir):
                 self._clear_cache()
-                try:
-                    rmtree(git_dir)
-                except Exception as ex:
-                    if HIDE_WINDOWS_KNOWN_ERRORS:
-                        from unittest import SkipTest
-
-                        raise SkipTest(f"FIXME: fails with: PermissionError\n  {ex}") from ex
-                    else:
-                        raise
+                rmtree(git_dir)
             # end handle separate bare repository
         # END handle module deletion
 

--- a/git/util.py
+++ b/git/util.py
@@ -188,11 +188,11 @@ def rmtree(path: PathLike) -> None:
 
         try:
             func(path)  # Will scream if still not possible to delete.
-        except Exception as ex:
+        except PermissionError as ex:
             if HIDE_WINDOWS_KNOWN_ERRORS:
                 from unittest import SkipTest
 
-                raise SkipTest("FIXME: fails with: PermissionError\n  {}".format(ex)) from ex
+                raise SkipTest(f"FIXME: fails with: PermissionError\n  {ex}") from ex
             raise
 
     return shutil.rmtree(path, False, onerror)

--- a/git/util.py
+++ b/git/util.py
@@ -121,8 +121,14 @@ def _read_env_flag(name: str, default: bool) -> bool:
         name,
     )
 
-    # FIXME: This should treat some values besides "" as expressing falsehood.
-    return bool(value)
+    adjusted_value = value.strip().lower()
+
+    if adjusted_value in {"", "0", "false", "no"}:
+        return False
+    if adjusted_value in {"1", "true", "yes"}:
+        return True
+    log.warning("%s has unrecognized value %r, treating as %r.", name, value, default)
+    return default
 
 
 #: We need an easy way to see if Appveyor TCs start failing,

--- a/git/util.py
+++ b/git/util.py
@@ -5,24 +5,24 @@
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 
 from abc import abstractmethod
-import os.path as osp
-from .compat import is_win
 import contextlib
 from functools import wraps
 import getpass
 import logging
 import os
+import os.path as osp
+import pathlib
 import platform
-import subprocess
 import re
 import shutil
 import stat
-from sys import maxsize
+import subprocess
+import sys
 import time
 from urllib.parse import urlsplit, urlunsplit
 import warnings
 
-# from git.objects.util import Traversable
+from .compat import is_win
 
 # typing ---------------------------------------------------------
 
@@ -42,21 +42,16 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast,
     TYPE_CHECKING,
+    cast,
     overload,
 )
-
-import pathlib
 
 if TYPE_CHECKING:
     from git.remote import Remote
     from git.repo.base import Repo
     from git.config import GitConfigParser, SectionConstraint
     from git import Git
-
-    # from git.objects.base import IndexObject
-
 
 from .types import (
     Literal,
@@ -75,7 +70,6 @@ T_IterableObj = TypeVar("T_IterableObj", bound=Union["IterableObj", "Has_id_attr
 
 # ---------------------------------------------------------------------
 
-
 from gitdb.util import (  # NOQA @IgnorePep8
     make_sha,
     LockedFD,  # @UnusedImport
@@ -87,7 +81,6 @@ from gitdb.util import (  # NOQA @IgnorePep8
     bin_to_hex,  # @UnusedImport
     hex_to_bin,  # @UnusedImport
 )
-
 
 # NOTE:  Some of the unused imports might be used/imported by others.
 # Handle once test-cases are back up and running.
@@ -182,7 +175,7 @@ def rmtree(path: PathLike) -> None:
     :note: we use shutil rmtree but adjust its behaviour to see whether files that
         couldn't be deleted are read-only. Windows will not remove them in that case"""
 
-    def onerror(function: Callable, path: PathLike, _excinfo: Any) -> None:
+    def handler(function: Callable, path: PathLike, _excinfo: Any) -> None:
         # Is the error an access error ?
         os.chmod(path, stat.S_IWUSR)
 
@@ -195,7 +188,10 @@ def rmtree(path: PathLike) -> None:
                 raise SkipTest(f"FIXME: fails with: PermissionError\n  {ex}") from ex
             raise
 
-    shutil.rmtree(path, False, onerror)
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=handler)
+    else:
+        shutil.rmtree(path, onerror=handler)
 
 
 def rmfile(path: PathLike) -> None:
@@ -995,7 +991,7 @@ class BlockingLockFile(LockFile):
         self,
         file_path: PathLike,
         check_interval_s: float = 0.3,
-        max_block_time_s: int = maxsize,
+        max_block_time_s: int = sys.maxsize,
     ) -> None:
         """Configure the instance
 

--- a/git/util.py
+++ b/git/util.py
@@ -170,17 +170,18 @@ def patch_env(name: str, value: str) -> Generator[None, None, None]:
 
 
 def rmtree(path: PathLike) -> None:
-    """Remove the given recursively.
+    """Remove the given directory tree recursively.
 
-    :note: we use shutil rmtree but adjust its behaviour to see whether files that
-        couldn't be deleted are read-only. Windows will not remove them in that case"""
+    :note: We use :func:`shutil.rmtree` but adjust its behaviour to see whether files that
+        couldn't be deleted are read-only. Windows will not remove them in that case."""
 
     def handler(function: Callable, path: PathLike, _excinfo: Any) -> None:
-        # Is the error an access error ?
+        """Callback for :func:`shutil.rmtree`. Works either as ``onexc`` or ``onerror``."""
+        # Is the error an access error?
         os.chmod(path, stat.S_IWUSR)
 
         try:
-            function(path)  # Will scream if still not possible to delete.
+            function(path)
         except PermissionError as ex:
             if HIDE_WINDOWS_KNOWN_ERRORS:
                 from unittest import SkipTest

--- a/git/util.py
+++ b/git/util.py
@@ -109,14 +109,28 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-# types############################################################
+
+def _read_env_flag(name: str, default: bool) -> Union[bool, str]:
+    try:
+        value = os.environ[name]
+    except KeyError:
+        return default
+
+    log.warning(
+        "The %s environment variable is deprecated. Its effect has never been documented and changes without warning.",
+        name,
+    )
+
+    # FIXME: This should always return bool, as that is how it is used.
+    # FIXME: This should treat some values besides "" as expressing falsehood.
+    return value
 
 
 #: We need an easy way to see if Appveyor TCs start failing,
 #: so the errors marked with this var are considered "acknowledged" ones, awaiting remedy,
 #: till then, we wish to hide them.
-HIDE_WINDOWS_KNOWN_ERRORS = is_win and os.environ.get("HIDE_WINDOWS_KNOWN_ERRORS", True)
-HIDE_WINDOWS_FREEZE_ERRORS = is_win and os.environ.get("HIDE_WINDOWS_FREEZE_ERRORS", True)
+HIDE_WINDOWS_KNOWN_ERRORS = is_win and _read_env_flag("HIDE_WINDOWS_KNOWN_ERRORS", True)
+HIDE_WINDOWS_FREEZE_ERRORS = is_win and _read_env_flag("HIDE_WINDOWS_FREEZE_ERRORS", True)
 
 # { Utility Methods
 

--- a/git/util.py
+++ b/git/util.py
@@ -110,7 +110,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def _read_env_flag(name: str, default: bool) -> Union[bool, str]:
+def _read_env_flag(name: str, default: bool) -> bool:
     try:
         value = os.environ[name]
     except KeyError:
@@ -121,9 +121,8 @@ def _read_env_flag(name: str, default: bool) -> Union[bool, str]:
         name,
     )
 
-    # FIXME: This should always return bool, as that is how it is used.
     # FIXME: This should treat some values besides "" as expressing falsehood.
-    return value
+    return bool(value)
 
 
 #: We need an easy way to see if Appveyor TCs start failing,

--- a/git/util.py
+++ b/git/util.py
@@ -182,12 +182,12 @@ def rmtree(path: PathLike) -> None:
     :note: we use shutil rmtree but adjust its behaviour to see whether files that
         couldn't be deleted are read-only. Windows will not remove them in that case"""
 
-    def onerror(func: Callable, path: PathLike, exc_info: str) -> None:
+    def onerror(function: Callable, path: PathLike, _excinfo: Any) -> None:
         # Is the error an access error ?
         os.chmod(path, stat.S_IWUSR)
 
         try:
-            func(path)  # Will scream if still not possible to delete.
+            function(path)  # Will scream if still not possible to delete.
         except PermissionError as ex:
             if HIDE_WINDOWS_KNOWN_ERRORS:
                 from unittest import SkipTest
@@ -195,7 +195,7 @@ def rmtree(path: PathLike) -> None:
                 raise SkipTest(f"FIXME: fails with: PermissionError\n  {ex}") from ex
             raise
 
-    return shutil.rmtree(path, False, onerror)
+    shutil.rmtree(path, False, onerror)
 
 
 def rmfile(path: PathLike) -> None:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,5 @@ pre-commit
 pytest
 pytest-cov
 pytest-instafail
+pytest-subtests
 pytest-sugar

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -22,7 +22,7 @@ class Tutorials(TestBase):
         gc.collect()
 
     # ACTUALLY skipped by git.util.rmtree (in local onerror function), from the last call to it via
-    # git.objects.submodule.base.Submodule.remove (at "handle separate bare repository"), line 1068.
+    # git.objects.submodule.base.Submodule.remove (at "handle separate bare repository"), line 1062.
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -21,8 +21,8 @@ class Tutorials(TestBase):
 
         gc.collect()
 
-    # ACTUALLY skipped by git.objects.submodule.base.Submodule.remove, at the last
-    # rmtree call (in "handle separate bare repository"), line 1082.
+    # ACTUALLY skipped by git.util.rmtree (in local onerror function), from the last call to it via
+    # git.objects.submodule.base.Submodule.remove (at "handle separate bare repository"), line 1068.
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -21,7 +21,10 @@ class Tutorials(TestBase):
 
         gc.collect()
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,  ## ACTUALLY skipped by `git.submodule.base#L869`.
+    # ACTUALLY skipped by git.objects.submodule.base.Submodule.remove, at the last
+    # rmtree call (in "handle separate bare repository"), line 1082.
+    #
+    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "
     #         "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx")  # noqa E501
     @with_rw_directory

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -457,7 +457,10 @@ class TestSubmodule(TestBase):
             True,
         )
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,  ## ACTUALLY skipped by `git.submodule.base#L869`.
+    # ACTUALLY skipped by git.util.rmtree (in local onerror function), called via
+    # git.objects.submodule.base.Submodule.remove at "method(mp)", line 1018.
+    #
+    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: fails with: PermissionError: [WinError 32] The process cannot access the file because"
     #         "it is being used by another process: "
     #         "'C:\\Users\\ankostis\\AppData\\Local\\Temp\\tmp95c3z83bnon_bare_test_base_rw\\git\\ext\\gitdb\\gitdb\\ext\\smmap'")  # noqa E501

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -458,7 +458,7 @@ class TestSubmodule(TestBase):
         )
 
     # ACTUALLY skipped by git.util.rmtree (in local onerror function), called via
-    # git.objects.submodule.base.Submodule.remove at "method(mp)", line 1018.
+    # git.objects.submodule.base.Submodule.remove at "method(mp)", line 1017.
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: fails with: PermissionError: [WinError 32] The process cannot access the file because"

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -819,9 +819,11 @@ class TestSubmodule(TestBase):
         assert commit_sm.binsha == sm_too.binsha
         assert sm_too.binsha != sm.binsha
 
-    # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,  ## ACTUALLY skipped by `git.submodule.base#L869`.
-    #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "
-    #         "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx")  # noqa E501
+    @pytest.mark.xfail(
+        HIDE_WINDOWS_KNOWN_ERRORS,
+        reason='"The process cannot access the file because it is being used by another process" on call to sm.move',
+        raises=PermissionError,
+    )
     @with_rw_directory
     def test_git_submodule_compatibility(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -458,7 +458,7 @@ class TestSubmodule(TestBase):
         )
 
     # ACTUALLY skipped by git.util.rmtree (in local onerror function), called via
-    # git.objects.submodule.base.Submodule.remove at "method(mp)", line 1017.
+    # git.objects.submodule.base.Submodule.remove at "method(mp)", line 1011.
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: fails with: PermissionError: [WinError 32] The process cannot access the file because"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -529,15 +529,15 @@ class TestUtils(TestBase):
             ("true-seeming", "True"),
             ("true-seeming", "yes"),
             ("true-seeming", "YES"),
+        ]
+        falsy_cases = [
+            ("empty", ""),
+            ("whitespace", " "),
             ("false-seeming", "0"),
             ("false-seeming", "false"),
             ("false-seeming", "False"),
             ("false-seeming", "no"),
             ("false-seeming", "NO"),
-            ("whitespace", " "),
-        ]
-        falsy_cases = [
-            ("empty", ""),
         ]
 
         for msg, env_var_value in truthy_cases:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -58,7 +58,7 @@ class _Member:
 
 @contextlib.contextmanager
 def _tmpdir_to_force_permission_error():
-    """Context manager to test permission errors in situations where we do not fix them."""
+    """Context manager to test permission errors in situations where they are not overcome."""
     if sys.platform == "cygwin":
         raise SkipTest("Cygwin can't set the permissions that make the test meaningful.")
     if sys.version_info < (3, 8):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -520,7 +520,7 @@ class TestUtils(TestBase):
             )
             return ast.literal_eval(output)
 
-        assert_true_iff_win = self.assertTrue if os.name == "nt" else self.assertFalse
+        true_iff_win = os.name == "nt"  # Same as is_win, but don't depend on that here.
 
         truthy_cases = [
             ("unset", None),
@@ -542,8 +542,8 @@ class TestUtils(TestBase):
 
         for msg, env_var_value in truthy_cases:
             with self.subTest(msg, env_var_value=env_var_value):
-                assert_true_iff_win(run_parse(env_var_value))
+                self.assertIs(run_parse(env_var_value), true_iff_win)
 
         for msg, env_var_value in falsy_cases:
             with self.subTest(msg, env_var_value=env_var_value):
-                self.assertFalse(run_parse(env_var_value))
+                self.assertIs(run_parse(env_var_value), False)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -520,30 +520,22 @@ class TestUtils(TestBase):
             )
             return ast.literal_eval(output)
 
-        true_iff_win = os.name == "nt"  # Same as is_win, but don't depend on that here.
-
-        truthy_cases = [
-            ("unset", None),
-            ("true-seeming", "1"),
-            ("true-seeming", "true"),
-            ("true-seeming", "True"),
-            ("true-seeming", "yes"),
-            ("true-seeming", "YES"),
-        ]
-        falsy_cases = [
-            ("empty", ""),
-            ("whitespace", " "),
-            ("false-seeming", "0"),
-            ("false-seeming", "false"),
-            ("false-seeming", "False"),
-            ("false-seeming", "no"),
-            ("false-seeming", "NO"),
-        ]
-
-        for msg, env_var_value in truthy_cases:
-            with self.subTest(msg, env_var_value=env_var_value):
-                self.assertIs(run_parse(env_var_value), true_iff_win)
-
-        for msg, env_var_value in falsy_cases:
-            with self.subTest(msg, env_var_value=env_var_value):
-                self.assertIs(run_parse(env_var_value), False)
+        for env_var_value, expected_truth_value in (
+            (None, os.name == "nt"),  # True on Windows when the environment variable is unset.
+            ("", False),
+            (" ", False),
+            ("0", False),
+            ("1", os.name == "nt"),
+            ("false", False),
+            ("true", os.name == "nt"),
+            ("False", False),
+            ("True", os.name == "nt"),
+            ("no", False),
+            ("yes", os.name == "nt"),
+            ("NO", False),
+            ("YES", os.name == "nt"),
+            (" no  ", False),
+            (" yes  ", os.name == "nt"),
+        ):
+            with self.subTest(env_var_value=env_var_value):
+                self.assertIs(run_parse(env_var_value), expected_truth_value)


### PR DESCRIPTION
Fixes #1698
Fixes #1699
*May* close #1571

This takes the approaches I suggested in #1698 and #1699 for those two issues. It also adds tests for both the already-working behavior and the new behavior. For the tests of new behavior, I have manually verified they failed in the expected way, and now pass, on native Windows. (Other results can be seen on CI.)

For interpreting the `HIDE_WINDOWS_KNOWN_ERRORS` and `HIDE_WINDOWS_FREEZE_ERRORS` environment variables:

- I have kept `True` as the default (though we may be able to change that in the near future, even before fully addressing #790).
- `0`, `false`, and `no`, as well as the empty string, are treated as `False`. This is case-insensitive and ignoring leading and trailing whitespace.
- While other values are currently treated as `True`, values other than possibly padded and possibly case-varying `1`, `yes`, or `true` show a warning about being unrecognized. This warning is in addition to, not instead of, the warning that is shown from the environment variable being present *at all*.
- The attributes from those variables are always `bool`, now, too. They are never strings.

When limiting the exceptions the `rmtree` callback catches and reraises as `unittest.SkipTest` to `PermissionError`, I made a couple other changes as well:

- I eliminated the duplicated logic, which technically is an additional behavioral change, because in some cases a `PermissionError` was wrapped in a `SkipTest` that was *itself* wrapped in another `SkipTest`. But I don't think this will cause any problems because even if someone relied on that, the only thing they would likely do would have been to follow the chain to the first non-`SkipTest`.
- As noted in #1571, passing a callback as the *`onerror`* parameter to `shutil.rmtree` is deprecated starting in Python 3.12, and the documentation indicates that it is planned for removal in 3.14. So I have used the new *`onexc`* parameter on 3.12 (and later). Because this is not available on 3.11 and earlier, it continues to use `onerror` in those versions. This was easy to implement, because in this case the same callback function naturally works for both, as it does not inspect the error information it receives.

#1571 may or may not be resolved by this, which I think is to a large extent subjective. That issue does two things. It documents a problem from 3.12.0.alpha7, which I *believe* was fixed, as I commented there. It also notes the deprecated status of `shutil.rmtree`'s `onerror` argument and advocates that `onexc` be used instead. This was originally with the idea that using `onerror` caused or contributed to the observed test failures, but even though that was probably not the case, the issue might have been taken to stand for that as well.

I also fixed the type hints on the callback, renamed the callback itself as `handler` so it is no longer named after one of those two keyword arguments but not the other (which I think could cause confusing), and renamed its parameters to more closely match the documentation. As it is a local function that is not returned, this does not raise any compatibility issues. In a similar vein, I've included a number of low-stakes refactorings, mostly just to imports, in modules I was already modifying heavily, mainly in `test_util`.

This also adds a missing `xfail` and updates commented references to the callback-based skipping logic that already existed. Most tests that get skipped in this way, of which there are about eight, do not have comments like this, and I have not added them. The tests that did are those that had previously been marked with `@skipIf` decorators. Finally, I've updated the `git.util.rmtree` docstring, which will affect generated documentation.

This relates to, but only somewhat mitigates and definitely does not solve, #790.