### PR TITLE
Fix small #1662 regression due to #1659

### DIFF
--- a/git/exc.py
+++ b/git/exc.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
-# the BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the BSD License: https://opensource.org/license/bsd-3-clause/
 """ Module containing all exceptions thrown throughout the git package """
 
 from gitdb.exc import (  # noqa: @UnusedImport


### PR DESCRIPTION
When #1659 was updated to pick up linting configuration changes, it inadvertently undid one of the URL changes made in #1662, putting the URL in the `git.exc` module back to the one that redirects to a different BSD license from the one this project uses.

Since only that one module was affected, the fix is simple. This only changes the URL back; it doesn't undo any other #1659 changes.