### PR TITLE
Drop obsolete info on yanking from security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,7 @@
 
 ## Supported Versions
 
-Only the latest version of GitPython can receive security updates. If a vulnerability is discovered, a fix can be issued in a new release, while older releases
-are likely to be yanked.
+Only the latest version of GitPython can receive security updates. If a vulnerability is discovered, a fix can be issued in a new release.
 
 | Version | Supported          |
 | ------- | ------------------ |


### PR DESCRIPTION
Versions may still be yanked for security reasons under specific circumstances, but this is not the usual or most common practice in GitPython, at least currently. Recent security updates have not been accompanied by yanking older versions, and allowing these versions to be selected automatically even when not called for specifically can be good, such as to prevent an even older version with even more vulnerabilities from being selected in situations where for some reason the latest version cannot yet be used.

In general, users shouldn't (and don't) assume all non-yanked versions to be free of security fixes that later versions have received. This change updates SECURITY.md to avoid giving that impression, but of course some versions of GitPython may still be yanked in the future if circumstances warrant it.

#### Alternatives

You might prefer a more conservative change. For example, instead of altogether removing "are likely to be yanked," it could be changed to "may be yanked under some circumstances."

Going in the other direction, you might prefer that paragraph to be expanded to talk specifically about *patch* releases, and how only the latest major.minor release will be updated with a patch release.

The simple change here of removing what seems now to be the obsolete part of the description seemed like the best initial proposal, though. As usual, I am willing to make changes to this on request. (It could also of course be closed if, on balance, none of these alternatives seems better than the current wording.)