### PR TITLE
Update readme for milestone-less releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,12 @@ Please have a look at the [contributions file][contributing].
 ### How to make a new release
 
 - Update/verify the **version** in the `VERSION` file.
-- Update/verify that the `doc/source/changes.rst` changelog file was updated.
+- Update/verify that the `doc/source/changes.rst` changelog file was updated. It should include a link to the forthcoming release page: `https://github.com/gitpython-developers/GitPython/releases/tag/<version>`
 - Commit everything.
 - Run `git tag -s <version>` to tag the version in Git.
 - _Optionally_ create and activate a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) using `venv` or `virtualenv`.\
 (When run in a virtual environment, the next step will automatically take care of installing `build` and `twine` in it.)
 - Run `make release`.
-- Close the milestone mentioned in the _changelog_ and create a new one. _Do not reuse milestones by renaming them_.
 - Go to [GitHub Releases](https://github.com/gitpython-developers/GitPython/releases) and publish a new one with the recently pushed tag. Generate the changelog.
 
 ### How to verify a release (DEPRECATED)

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ Please have a look at the [contributions file][contributing].
 
 ### How to make a new release
 
-- Update/verify the **version** in the `VERSION` file.
-- Update/verify that the `doc/source/changes.rst` changelog file was updated. It should include a link to the forthcoming release page: `https://github.com/gitpython-developers/GitPython/releases/tag/<version>`
-- Commit everything.
-- Run `git tag -s <version>` to tag the version in Git.
-- _Optionally_ create and activate a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) using `venv` or `virtualenv`.\
+1. Update/verify the **version** in the `VERSION` file.
+2. Update/verify that the `doc/source/changes.rst` changelog file was updated. It should include a link to the forthcoming release page: `https://github.com/gitpython-developers/GitPython/releases/tag/<version>`
+3. Commit everything.
+4. Run `git tag -s <version>` to tag the version in Git.
+5. _Optionally_ create and activate a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) using `venv` or `virtualenv`.\
 (When run in a virtual environment, the next step will automatically take care of installing `build` and `twine` in it.)
-- Run `make release`.
-- Go to [GitHub Releases](https://github.com/gitpython-developers/GitPython/releases) and publish a new one with the recently pushed tag. Generate the changelog.
+6. Run `make release`.
+7. Go to [GitHub Releases](https://github.com/gitpython-developers/GitPython/releases) and publish a new one with the recently pushed tag. Generate the changelog.
 
 ### How to verify a release (DEPRECATED)
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,7 @@ Please have a look at the [contributions file][contributing].
 2. Update/verify that the `doc/source/changes.rst` changelog file was updated. It should include a link to the forthcoming release page: `https://github.com/gitpython-developers/GitPython/releases/tag/<version>`
 3. Commit everything.
 4. Run `git tag -s <version>` to tag the version in Git.
-5. _Optionally_ create and activate a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) using `venv` or `virtualenv`.\
-(When run in a virtual environment, the next step will automatically take care of installing `build` and `twine` in it.)
+5. _Optionally_ create and activate a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment). (Then the next step can install `build` and `twine`.)
 6. Run `make release`.
 7. Go to [GitHub Releases](https://github.com/gitpython-developers/GitPython/releases) and publish a new one with the recently pushed tag. Generate the changelog.
 


### PR DESCRIPTION
This updates the release-making instructions in the readme, to release without using milestones and to link to the GitHub release page rather than a milestone, as discussed in #1706.

I've also made those instructions a numbered list, since they consist of sequential steps, and decreased the amount of elaboration in one of the other steps, which I think will make it so the new important details in the changelog-writing step are less likely to be glossed over.

In addition to the changes here, `check-version.sh` could and, I think, should be extended to check that the top section in `changes.rst` properly links to the (forthcoming) release page on GitHub. That link contains the version number (rather than a milestone number) so it makes sense for the version check script to validate it. Furthermore, because the page will typically not exist yet, mistakes in the URL may be harder to catch. However, I have not included such a change in this pull request.