### PR TITLE
Add `__all__` in git.exc

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -6,7 +6,6 @@
 # flake8: noqa
 # @PydevCodeAnalysisIgnore
 from git.exc import *  # @NoMove @IgnorePep8
-import inspect
 import os
 import sys
 import os.path as osp

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -7,10 +7,10 @@
 # @PydevCodeAnalysisIgnore
 from git.exc import *  # @NoMove @IgnorePep8
 import os
-import sys
 import os.path as osp
+import sys
 
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 from git.types import PathLike
 
 __version__ = "git"
@@ -38,7 +38,10 @@ _init_externals()
 
 # { Imports
 
+from gitdb.util import to_hex_sha
+
 try:
+    from git.compat import safe_decode  # @NoMove @IgnorePep8
     from git.config import GitConfigParser  # @NoMove @IgnorePep8
     from git.objects import *  # @NoMove @IgnorePep8
     from git.refs import *  # @NoMove @IgnorePep8
@@ -53,6 +56,7 @@ try:
         BlockingLockFile,
         Stats,
         Actor,
+        remove_password_if_present,
         rmtree,
     )
 except GitError as _exc:

--- a/git/db.py
+++ b/git/db.py
@@ -1,7 +1,7 @@
 """Module with our own gitdb implementation - it uses the git command"""
 from git.util import bin_to_hex, hex_to_bin
 from gitdb.base import OInfo, OStream
-from gitdb.db import GitDB  # @UnusedImport
+from gitdb.db import GitDB
 from gitdb.db import LooseObjectDB
 
 from gitdb.exc import BadObject

--- a/git/exc.py
+++ b/git/exc.py
@@ -5,7 +5,34 @@
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 """ Module containing all exceptions thrown throughout the git package """
 
-from gitdb.exc import (  # noqa: @UnusedImport
+__all__ = [
+    # Defined in gitdb.exc:
+    "AmbiguousObjectName",
+    "BadName",
+    "BadObject",
+    "BadObjectType",
+    "InvalidDBRoot",
+    "ODBError",
+    "ParseError",
+    "UnsupportedOperation",
+    # Introduced in this module:
+    "GitError",
+    "InvalidGitRepositoryError",
+    "WorkTreeRepositoryUnsupported",
+    "NoSuchPathError",
+    "UnsafeProtocolError",
+    "UnsafeOptionError",
+    "CommandError",
+    "GitCommandNotFound",
+    "GitCommandError",
+    "CheckoutError",
+    "CacheError",
+    "UnmergedEntriesError",
+    "HookExecutionError",
+    "RepositoryDirtyError",
+]
+
+from gitdb.exc import (
     AmbiguousObjectName,
     BadName,
     BadObject,
@@ -14,7 +41,6 @@ from gitdb.exc import (  # noqa: @UnusedImport
     ODBError,
     ParseError,
     UnsupportedOperation,
-    to_hex_sha,
 )
 from git.compat import safe_decode
 from git.util import remove_password_if_present


### PR DESCRIPTION
Fixes #1718

This adds `__all__` in `git.exc`, and adjusts `__init__.py` imports.

The `git.exc` module imports exceptions from `gitdb.exc` to republish them, as well as defining its own (also for use from outside). But because it did not define `__all__`, the intent for the exceptions it imported was unclear, since names that are introduced by imports and not present in `__all__` are not generally considered public, even when `__all__` is absent and a `*` import would reimport them.

This rectifies that by adding `__all__` and listing both imported and newly introduced exceptions explicitly in it. Although this strictly expands which names are public under typical conventions, it strictly contracts which names are imported by a `*` import, because the presence of `__all__` suppresses names not listed in it from being imported that way. However, because under typical conventions those other names are not considered public, and they were not even weakly documented as public, this should be okay.

(Even though this is not a breaking change, in that code it would break would already technically be broken... if it turns out that it is common to wrongly rely on the availability of those names, then this may need to be revisited and slightly modified.)

This brings the readily identified public interface of `git.exc` in line with what is weakly implied (and intended) by its docstring.

This also modifies `__init__.py` accordingly: The top-level git module has for some time used a `*` import on `git.exc`, causing the extra names originally meant as implementation details to be included. Because its own `__all__` was dynamically generated until c862845, #1659 also added 8edc53b to retain the formerly present names in `__all__`. So the change here imports those names from the modules that deliberately provide them, to preserve compatibility.