### PR TITLE
Set submodule update cadence to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
 - package-ecosystem: "gitsubmodule"
   directory: "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"


### PR DESCRIPTION
This sets the Dependabot submodule update cadence from montly to weekly, as requested in https://github.com/gitpython-developers/GitPython/pull/1702#issuecomment-1761182333.

This change in GitPython corresponds directly to [#104](https://github.com/gitpython-developers/gitdb/pull/104) in gitdb. Just as there, I'm opening this PR separately from others so it can be merged at whatever point is most convenient, regardless of if and when other pull requests are merged.