### PR TITLE
Revise comments, docstrings, some messages, and a bit of code

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -170,7 +170,7 @@ htmlhelp_basename = "gitpythondoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-    ("index", "GitPython.tex", r"GitPython Documentation", r"Michael Trier", "manual"),
+    ("index", "GitPython.tex", "GitPython Documentation", "Michael Trier", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# GitPython documentation build configuration file, created by
+# GitPython documentation build configuration file, originally created by
 # sphinx-quickstart on Sat Jan 24 11:51:01 2009.
 #
 # This file is execfile()d with the current directory set to its containing dir.

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -413,7 +413,7 @@ If you obtained your submodule object by traversing a tree object which is not r
 you have to inform the submodule about its actual commit to retrieve the data from
 by using the ``set_parent_commit(...)`` method.
 
-The special :class:`RootModule <git.objects.submodule.root.RootModule>` type allows you to treat your master repository as root of a hierarchy of submodules, which allows very convenient submodule handling. Its ``update(...)`` method is reimplemented to provide an advanced way of updating submodules as they change their values over time. The update method will track changes and make sure your working tree and submodule checkouts stay consistent, which is very useful in case submodules get deleted or added to name just two of the handled cases.
+The special :class:`RootModule <git.objects.submodule.root.RootModule>` type allows you to treat your superproject (master repository) as root of a hierarchy of submodules, which allows very convenient submodule handling. Its ``update(...)`` method is reimplemented to provide an advanced way of updating submodules as they change their values over time. The update method will track changes and make sure your working tree and submodule checkouts stay consistent, which is very useful in case submodules get deleted or added to name just two of the handled cases.
 
 Additionally, GitPython adds functionality to track a specific branch, instead of just a commit. Supported by customized update methods, you are able to automatically update submodules to the latest revision available in the remote repository, as well as to keep track of changes and movements of these submodules. To use it, set the name of the branch you want to track to the ``submodule.$name.branch`` option of the *.gitmodules*  file, and use GitPython update methods on the resulting repository with the ``to_latest_revision`` parameter turned on. In the latter case, the sha of your submodule will be ignored, instead a local tracking branch will be updated to the respective remote branch automatically, provided there are no local changes. The resulting behaviour is much like the one of svn::externals, which can be useful in times.
 
@@ -545,4 +545,3 @@ And even more ...
 There is more functionality in there, like the ability to archive repositories, get stats and logs, blame, and probably a few other things that were not mentioned here.
 
 Check the unit tests for an in-depth introduction on how each function is supposed to be used.
-

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -3,8 +3,10 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 # flake8: noqa
 # @PydevCodeAnalysisIgnore
+
 from git.exc import *  # @NoMove @IgnorePep8
 from typing import List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 from git.types import PathLike

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -979,7 +979,7 @@ class Git(LazyMixin):
         else:
             cmd_not_found_exception = FileNotFoundError  # NOQA # exists, flake8 unknown @UndefinedVariable
             maybe_patch_caller_env = contextlib.nullcontext()
-        # end handle
+        # END handle
 
         stdout_sink = PIPE if with_stdout else getattr(subprocess, "DEVNULL", None) or open(os.devnull, "wb")
         if shell is None:
@@ -1048,7 +1048,7 @@ class Git(LazyMixin):
                 pass
             return
 
-        # end
+        # END def kill_process
 
         if kill_after_timeout is not None:
             kill_check = threading.Event()
@@ -1100,7 +1100,7 @@ class Git(LazyMixin):
             def as_text(stdout_value: Union[bytes, str]) -> str:
                 return not output_stream and safe_decode(stdout_value) or "<OUTPUT_STREAM>"
 
-            # end
+            # END def as_text
 
             if stderr_value:
                 log.info(
@@ -1304,9 +1304,9 @@ class Git(LazyMixin):
                     "Couldn't find argument '%s' in args %s to insert cmd options after"
                     % (insert_after_this_arg, str(ext_args))
                 ) from err
-            # end handle error
+            # END handle error
             args_list = ext_args[: index + 1] + opt_args + ext_args[index + 1 :]
-        # end handle opts_kwargs
+        # END handle opts_kwargs
 
         call = [self.GIT_PYTHON_GIT_EXECUTABLE]
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1048,7 +1048,7 @@ class Git(LazyMixin):
                 pass
             return
 
-        # END def kill_process
+        # END kill_process
 
         if kill_after_timeout is not None:
             kill_check = threading.Event()
@@ -1100,7 +1100,7 @@ class Git(LazyMixin):
             def as_text(stdout_value: Union[bytes, str]) -> str:
                 return not output_stream and safe_decode(stdout_value) or "<OUTPUT_STREAM>"
 
-            # END def as_text
+            # END as_text
 
             if stderr_value:
                 log.info(

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -490,7 +490,7 @@ class Git(LazyMixin):
                         f"{unsafe_option} is not allowed, use `allow_unsafe_options=True` to allow it."
                     )
 
-    class AutoInterrupt(object):
+    class AutoInterrupt:
         """Process wrapper that terminates the wrapped process on finalization.
 
         This kills/interrupts the stored process instance once this instance goes out of
@@ -602,7 +602,7 @@ class Git(LazyMixin):
 
     # END auto interrupt
 
-    class CatFileContentStream(object):
+    class CatFileContentStream:
         """Object representing a sized read-only stream returning the contents of
         an object.
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -264,7 +264,7 @@ class Git(LazyMixin):
 
     _excluded_ = ("cat_file_all", "cat_file_header", "_version_info")
 
-    re_unsafe_protocol = re.compile("(.+)::.+")
+    re_unsafe_protocol = re.compile(r"(.+)::.+")
 
     def __getstate__(self) -> Dict[str, Any]:
         return slots_to_dict(self, exclude=self._excluded_)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -610,7 +610,7 @@ class Git(LazyMixin):
         stream once our sized content region is empty.
 
         If not all data are read to the end of the object's lifetime, we read the
-        rest to assure the underlying stream continues to work.
+        rest to ensure the underlying stream continues to work.
         """
 
         __slots__: Tuple[str, ...] = ("_stream", "_nbr", "_size")

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -3,7 +3,9 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 from __future__ import annotations
+
 import re
 import contextlib
 import io
@@ -103,20 +105,21 @@ def handle_process_output(
     decode_streams: bool = True,
     kill_after_timeout: Union[None, float] = None,
 ) -> None:
-    """Registers for notifications to learn that process output is ready to read, and dispatches lines to
-    the respective line handlers.
+    """Register for notifications to learn that process output is ready to read, and
+    dispatch lines to the respective line handlers.
+
     This function returns once the finalizer returns.
 
-    :return: result of finalizer
-    :param process: subprocess.Popen instance
+    :return: Result of finalizer
+    :param process: :class:`subprocess.Popen` instance
     :param stdout_handler: f(stdout_line_string), or None
     :param stderr_handler: f(stderr_line_string), or None
     :param finalizer: f(proc) - wait for proc to finish
     :param decode_streams:
-        Assume stdout/stderr streams are binary and decode them before pushing \
+        Assume stdout/stderr streams are binary and decode them before pushing
         their contents to handlers.
-        Set it to False if `universal_newline == True` (then streams are in text-mode)
-        or if decoding must happen later (i.e. for Diffs).
+        Set it to False if ``universal_newlines == True`` (then streams are in
+        text mode) or if decoding must happen later (i.e. for Diffs).
     :param kill_after_timeout:
         float or None, Default = None
         To specify a timeout in seconds for the git command, after which the process
@@ -232,13 +235,11 @@ CREATE_NO_WINDOW = 0x08000000
 # see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal
 PROC_CREATIONFLAGS = (
     CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP if is_win else 0  # type: ignore[attr-defined]
-)  # mypy error if not windows
+)  # mypy error if not Windows.
 
 
 class Git(LazyMixin):
-
-    """
-    The Git class manages communication with the Git binary.
+    """The Git class manages communication with the Git binary.
 
     It provides a convenient interface to calling the Git binary, such as in::
 
@@ -274,44 +275,41 @@ class Git(LazyMixin):
 
     # CONFIGURATION
 
-    git_exec_name = "git"  # default that should work on linux and windows
+    git_exec_name = "git"  # Default that should work on Linux and Windows.
 
-    # Enables debugging of GitPython's git commands
+    # Enables debugging of GitPython's git commands.
     GIT_PYTHON_TRACE = os.environ.get("GIT_PYTHON_TRACE", False)
 
     # If True, a shell will be used when executing git commands.
     # This should only be desirable on Windows, see https://github.com/gitpython-developers/GitPython/pull/126
     # and check `git/test_repo.py:TestRepo.test_untracked_files()` TC for an example where it is required.
-    # Override this value using `Git.USE_SHELL = True`
+    # Override this value using `Git.USE_SHELL = True`.
     USE_SHELL = False
 
-    # Provide the full path to the git executable. Otherwise it assumes git is in the path
+    # Provide the full path to the git executable. Otherwise it assumes git is in the path.
     _git_exec_env_var = "GIT_PYTHON_GIT_EXECUTABLE"
     _refresh_env_var = "GIT_PYTHON_REFRESH"
     GIT_PYTHON_GIT_EXECUTABLE = None
-    # note that the git executable is actually found during the refresh step in
-    # the top level __init__
+    # Note that the git executable is actually found during the refresh step in
+    # the top level __init__.
 
     @classmethod
     def refresh(cls, path: Union[None, PathLike] = None) -> bool:
         """This gets called by the refresh function (see the top level __init__)."""
-        # discern which path to refresh with
+        # Discern which path to refresh with.
         if path is not None:
             new_git = os.path.expanduser(path)
             new_git = os.path.abspath(new_git)
         else:
             new_git = os.environ.get(cls._git_exec_env_var, cls.git_exec_name)
 
-        # keep track of the old and new git executable path
+        # Keep track of the old and new git executable path.
         old_git = cls.GIT_PYTHON_GIT_EXECUTABLE
         cls.GIT_PYTHON_GIT_EXECUTABLE = new_git
 
-        # test if the new git executable path is valid
-
-        # - a GitCommandNotFound error is spawned by ourselves
-        # - a PermissionError is spawned if the git executable provided
-        #   cannot be executed for whatever reason
-
+        # Test if the new git executable path is valid. A GitCommandNotFound error is
+        # spawned by us. A PermissionError is spawned if the git executable cannot be
+        # executed for whatever reason.
         has_git = False
         try:
             cls().version()
@@ -319,7 +317,7 @@ class Git(LazyMixin):
         except (GitCommandNotFound, PermissionError):
             pass
 
-        # warn or raise exception if test failed
+        # Warn or raise exception if test failed.
         if not has_git:
             err = (
                 dedent(
@@ -334,18 +332,18 @@ class Git(LazyMixin):
                 % cls._git_exec_env_var
             )
 
-            # revert to whatever the old_git was
+            # Revert to whatever the old_git was.
             cls.GIT_PYTHON_GIT_EXECUTABLE = old_git
 
             if old_git is None:
-                # on the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is
-                # None) we only are quiet, warn, or error depending on the
-                # GIT_PYTHON_REFRESH value
+                # On the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is None) we only
+                # are quiet, warn, or error depending on the GIT_PYTHON_REFRESH value.
 
-                # determine what the user wants to happen during the initial
-                # refresh we expect GIT_PYTHON_REFRESH to either be unset or
-                # be one of the following values:
-                #   0|q|quiet|s|silence
+                # Determine what the user wants to happen during the initial refresh we
+                # expect GIT_PYTHON_REFRESH to either be unset or be one of the
+                # following values:
+                #
+                #   0|q|quiet|s|silence|n|none
                 #   1|w|warn|warning
                 #   2|r|raise|e|error
 
@@ -410,14 +408,13 @@ class Git(LazyMixin):
                     )
                     raise ImportError(err)
 
-                # we get here if this was the init refresh and the refresh mode
-                # was not error, go ahead and set the GIT_PYTHON_GIT_EXECUTABLE
-                # such that we discern the difference between a first import
-                # and a second import
+                # We get here if this was the init refresh and the refresh mode was not
+                # error. Go ahead and set the GIT_PYTHON_GIT_EXECUTABLE such that we
+                # discern the difference between a first import and a second import.
                 cls.GIT_PYTHON_GIT_EXECUTABLE = cls.git_exec_name
             else:
-                # after the first refresh (when GIT_PYTHON_GIT_EXECUTABLE
-                # is no longer None) we raise an exception
+                # After the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is no longer
+                # None) we raise an exception.
                 raise GitCommandNotFound("git", err)
 
         return has_git
@@ -438,18 +435,18 @@ class Git(LazyMixin):
 
     @classmethod
     def polish_url(cls, url: str, is_cygwin: Union[None, bool] = None) -> PathLike:
+        """Remove any backslashes from urls to be written in config files.
+
+        Windows might create config files containing paths with backslashes,
+        but git stops liking them as it will escape the backslashes. Hence we
+        undo the escaping just to be sure.
+        """
         if is_cygwin is None:
             is_cygwin = cls.is_cygwin()
 
         if is_cygwin:
             url = cygpath(url)
         else:
-            """Remove any backslashes from urls to be written in config files.
-
-            Windows might create config files containing paths with backslashes,
-            but git stops liking them as it will escape the backslashes.
-            Hence we undo the escaping just to be sure.
-            """
             url = os.path.expandvars(url)
             if url.startswith("~"):
                 url = os.path.expanduser(url)
@@ -458,12 +455,11 @@ class Git(LazyMixin):
 
     @classmethod
     def check_unsafe_protocols(cls, url: str) -> None:
-        """
-        Check for unsafe protocols.
+        """Check for unsafe protocols.
 
         Apart from the usual protocols (http, git, ssh),
-        Git allows "remote helpers" that have the form ``<transport>::<address>``,
-        one of these helpers (``ext::``) can be used to invoke any arbitrary command.
+        Git allows "remote helpers" that have the form ``<transport>::<address>``.
+        One of these helpers (``ext::``) can be used to invoke any arbitrary command.
 
         See:
 
@@ -479,8 +475,7 @@ class Git(LazyMixin):
 
     @classmethod
     def check_unsafe_options(cls, options: List[str], unsafe_options: List[str]) -> None:
-        """
-        Check for unsafe options.
+        """Check for unsafe options.
 
         Some options that are passed to `git <command>` can be used to execute
         arbitrary commands, this are blocked by default.
@@ -496,17 +491,21 @@ class Git(LazyMixin):
                     )
 
     class AutoInterrupt(object):
-        """Kill/Interrupt the stored process instance once this instance goes out of scope. It is
-        used to prevent processes piling up in case iterators stop reading.
-        Besides all attributes are wired through to the contained process object.
+        """Process wrapper that terminates the wrapped process on finalization.
 
-        The wait method was overridden to perform automatic status code checking
-        and possibly raise."""
+        This kills/interrupts the stored process instance once this instance goes out of
+        scope. It is used to prevent processes piling up in case iterators stop reading.
+
+        All attributes are wired through to the contained process object.
+
+        The wait method is overridden to perform automatic status code checking and
+        possibly raise.
+        """
 
         __slots__ = ("proc", "args", "status")
 
         # If this is non-zero it will override any status code during
-        # _terminate, used to prevent race conditions in testing
+        # _terminate, used to prevent race conditions in testing.
         _status_code_if_terminate: int = 0
 
         def __init__(self, proc: Union[None, subprocess.Popen], args: Any) -> None:
@@ -527,7 +526,7 @@ class Git(LazyMixin):
                 proc.stdout.close()
             if proc.stderr:
                 proc.stderr.close()
-            # did the process finish already so we have a return code ?
+            # Did the process finish already so we have a return code?
             try:
                 if proc.poll() is not None:
                     self.status = self._status_code_if_terminate or proc.poll()
@@ -535,23 +534,23 @@ class Git(LazyMixin):
             except OSError as ex:
                 log.info("Ignored error after process had died: %r", ex)
 
-            # can be that nothing really exists anymore ...
+            # It can be that nothing really exists anymore...
             if os is None or getattr(os, "kill", None) is None:
                 return None
 
-            # try to kill it
+            # Try to kill it.
             try:
                 proc.terminate()
-                status = proc.wait()  # ensure process goes away
+                status = proc.wait()  # Ensure the process goes away.
 
                 self.status = self._status_code_if_terminate or status
             except OSError as ex:
                 log.info("Ignored error after process had died: %r", ex)
             except AttributeError:
-                # try windows
-                # for some reason, providing None for stdout/stderr still prints something. This is why
-                # we simply use the shell and redirect to nul. Its slower than CreateProcess, question
-                # is whether we really want to see all these messages. Its annoying no matter what.
+                # Try Windows.
+                # For some reason, providing None for stdout/stderr still prints something. This is why
+                # we simply use the shell and redirect to nul. Slower than CreateProcess. The question
+                # is whether we really want to see all these messages. It's annoying no matter what.
                 if is_win:
                     call(
                         ("TASKKILL /F /T /PID %s 2>nul 1>nul" % str(proc.pid)),
@@ -571,7 +570,8 @@ class Git(LazyMixin):
 
             :param stderr: Previously read value of stderr, in case stderr is already closed.
             :warn: May deadlock if output or error pipes are used and not handled separately.
-            :raise GitCommandError: if the return status is not 0"""
+            :raise GitCommandError: If the return status is not 0.
+            """
             if stderr is None:
                 stderr_b = b""
             stderr_b = force_bytes(data=stderr, encoding="utf-8")
@@ -579,7 +579,7 @@ class Git(LazyMixin):
             if self.proc is not None:
                 status = self.proc.wait()
                 p_stderr = self.proc.stderr
-            else:  # Assume the underlying proc was killed earlier or never existed
+            else:  # Assume the underlying proc was killed earlier or never existed.
                 status = self.status
                 p_stderr = None
 
@@ -605,19 +605,22 @@ class Git(LazyMixin):
     class CatFileContentStream(object):
         """Object representing a sized read-only stream returning the contents of
         an object.
-        It behaves like a stream, but counts the data read and simulates an empty
+
+        This behaves like a stream, but counts the data read and simulates an empty
         stream once our sized content region is empty.
-        If not all data is read to the end of the object's lifetime, we read the
-        rest to assure the underlying stream continues to work."""
+
+        If not all data are read to the end of the object's lifetime, we read the
+        rest to assure the underlying stream continues to work.
+        """
 
         __slots__: Tuple[str, ...] = ("_stream", "_nbr", "_size")
 
         def __init__(self, size: int, stream: IO[bytes]) -> None:
             self._stream = stream
             self._size = size
-            self._nbr = 0  # num bytes read
+            self._nbr = 0  # Number of bytes read.
 
-            # special case: if the object is empty, has null bytes, get the
+            # Special case: If the object is empty, has null bytes, get the
             # final newline right away.
             if size == 0:
                 stream.read(1)
@@ -628,16 +631,16 @@ class Git(LazyMixin):
             if bytes_left == 0:
                 return b""
             if size > -1:
-                # assure we don't try to read past our limit
+                # Ensure we don't try to read past our limit.
                 size = min(bytes_left, size)
             else:
-                # they try to read all, make sure its not more than what remains
+                # They try to read all, make sure it's not more than what remains.
                 size = bytes_left
             # END check early depletion
             data = self._stream.read(size)
             self._nbr += len(data)
 
-            # check for depletion, read our final byte to make the stream usable by others
+            # Check for depletion, read our final byte to make the stream usable by others.
             if self._size - self._nbr == 0:
                 self._stream.read(1)  # final newline
             # END finish reading
@@ -647,7 +650,7 @@ class Git(LazyMixin):
             if self._nbr == self._size:
                 return b""
 
-            # clamp size to lowest allowed value
+            # Clamp size to lowest allowed value.
             bytes_left = self._size - self._nbr
             if size > -1:
                 size = min(bytes_left, size)
@@ -658,7 +661,7 @@ class Git(LazyMixin):
             data = self._stream.readline(size)
             self._nbr += len(data)
 
-            # handle final byte
+            # Handle final byte.
             if self._size - self._nbr == 0:
                 self._stream.read(1)
             # END finish reading
@@ -669,7 +672,7 @@ class Git(LazyMixin):
             if self._nbr == self._size:
                 return []
 
-            # leave all additional logic to our readline method, we just check the size
+            # Leave all additional logic to our readline method, we just check the size.
             out = []
             nbr = 0
             while True:
@@ -701,8 +704,8 @@ class Git(LazyMixin):
         def __del__(self) -> None:
             bytes_left = self._size - self._nbr
             if bytes_left:
-                # read and discard - seeking is impossible within a stream
-                # includes terminating newline
+                # Read and discard - seeking is impossible within a stream.
+                # This includes any terminating newline.
                 self._stream.read(bytes_left + 1)
             # END handle incomplete read
 
@@ -711,9 +714,10 @@ class Git(LazyMixin):
 
         :param working_dir:
            Git directory we should work in. If None, we always work in the current
-           directory as returned by os.getcwd().
+           directory as returned by :func:`os.getcwd`.
            It is meant to be the working tree directory if available, or the
-           .git directory in case of bare repositories."""
+           ``.git`` directory in case of bare repositories.
+        """
         super(Git, self).__init__()
         self._working_dir = expand_path(working_dir)
         self._git_options: Union[List[str], Tuple[str, ...]] = ()
@@ -722,7 +726,7 @@ class Git(LazyMixin):
         # Extra environment variables to pass to git commands
         self._environment: Dict[str, str] = {}
 
-        # cached command slots
+        # Cached command slots
         self.cat_file_header: Union[None, TBD] = None
         self.cat_file_all: Union[None, TBD] = None
 
@@ -730,28 +734,30 @@ class Git(LazyMixin):
         """A convenience method as it allows to call the command as if it was
         an object.
 
-        :return: Callable object that will execute call _call_process with your arguments."""
+        :return:
+            Callable object that will execute call :meth:`_call_process` with
+            your arguments.
+        """
         if name[0] == "_":
             return LazyMixin.__getattr__(self, name)
         return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
 
     def set_persistent_git_options(self, **kwargs: Any) -> None:
-        """Specify command line options to the git executable
-        for subsequent subcommand calls.
+        """Specify command line options to the git executable for subsequent
+        subcommand calls.
 
         :param kwargs:
-            is a dict of keyword arguments.
-            These arguments are passed as in _call_process
-            but will be passed to the git command rather than
-            the subcommand.
+            A dict of keyword arguments.
+            These arguments are passed as in :meth:`_call_process`, but will be
+            passed to the git command rather than the subcommand.
         """
 
         self._persistent_git_options = self.transform_kwargs(split_single_char_options=True, **kwargs)
 
     def _set_cache_(self, attr: str) -> None:
         if attr == "_version_info":
-            # We only use the first 4 numbers, as everything else could be strings in fact (on windows)
-            process_version = self._call_process("version")  # should be as default *args and **kwargs used
+            # We only use the first 4 numbers, as everything else could be strings in fact (on Windows).
+            process_version = self._call_process("version")  # Should be as default *args and **kwargs used.
             version_numbers = process_version.split(" ")[2]
 
             self._version_info = cast(
@@ -772,7 +778,9 @@ class Git(LazyMixin):
         """
         :return: tuple(int, int, int, int) tuple with integers representing the major, minor
             and additional version numbers as parsed from git version.
-            This value is generated on demand and is cached."""
+
+            This value is generated on demand and is cached.
+        """
         return self._version_info
 
     @overload
@@ -839,7 +847,7 @@ class Git(LazyMixin):
         strip_newline_in_stdout: bool = True,
         **subprocess_kwargs: Any,
     ) -> Union[str, bytes, Tuple[int, Union[str, bytes], str], AutoInterrupt]:
-        """Handles executing the command and consumes and returns the returned
+        R"""Handle executing the command, and consume and return the returned
         information (stdout).
 
         :param command:
@@ -848,7 +856,7 @@ class Git(LazyMixin):
             program to execute is the first item in the args sequence or string.
 
         :param istream:
-            Standard input filehandle passed to `subprocess.Popen`.
+            Standard input filehandle passed to :class:`subprocess.Popen`.
 
         :param with_extended_output:
             Whether to return a (status, stdout, stderr) tuple.
@@ -858,17 +866,17 @@ class Git(LazyMixin):
 
         :param as_process:
             Whether to return the created process instance directly from which
-            streams can be read on demand. This will render with_extended_output and
-            with_exceptions ineffective - the caller will have to deal with the details.
-            It is important to note that the process will be placed into an AutoInterrupt
-            wrapper that will interrupt the process once it goes out of scope. If you
-            use the command in iterators, you should pass the whole process instance
-            instead of a single stream.
+            streams can be read on demand. This will render `with_extended_output`
+            and `with_exceptions` ineffective - the caller will have to deal with
+            the details. It is important to note that the process will be placed
+            into an :class:`AutoInterrupt` wrapper that will interrupt the process
+            once it goes out of scope. If you use the command in iterators, you
+            should pass the whole process instance instead of a single stream.
 
         :param output_stream:
             If set to a file-like object, data produced by the git command will be
             output to the given stream directly.
-            This feature only has any effect if as_process is False. Processes will
+            This feature only has any effect if `as_process` is False. Processes will
             always be created with a pipe due to issues with subprocess.
             This merely is a workaround as data will be copied from the
             output pipe to the given output stream directly.
@@ -881,13 +889,13 @@ class Git(LazyMixin):
 
         :param kill_after_timeout:
             Specifies a timeout in seconds for the git command, after which the process
-            should be killed. This will have no effect if as_process is set to True. It is
-            set to None by default and will let the process run until the timeout is
-            explicitly specified. This feature is not supported on Windows. It's also worth
-            noting that kill_after_timeout uses SIGKILL, which can have negative side
-            effects on a repository. For example, stale locks in case of ``git gc`` could
-            render the repository incapable of accepting changes until the lock is manually
-            removed.
+            should be killed. This will have no effect if `as_process` is set to True.
+            It is set to None by default and will let the process run until the timeout
+            is explicitly specified. This feature is not supported on Windows. It's also
+            worth noting that `kill_after_timeout` uses SIGKILL, which can have negative
+            side effects on a repository. For example, stale locks in case of ``git gc``
+            could render the repository incapable of accepting changes until the lock is
+            manually removed.
 
         :param with_stdout:
             If True, default True, we open stdout on the created process.
@@ -901,7 +909,7 @@ class Git(LazyMixin):
             It overrides :attr:`USE_SHELL` if it is not `None`.
 
         :param env:
-            A dictionary of environment variables to be passed to `subprocess.Popen`.
+            A dictionary of environment variables to be passed to :class:`subprocess.Popen`.
 
         :param max_chunk_size:
             Maximum number of bytes in one chunk of data passed to the output_stream in
@@ -909,11 +917,11 @@ class Git(LazyMixin):
             the default value is used.
 
         :param strip_newline_in_stdout:
-            Whether to strip the trailing ``\\n`` of the command stdout.
+            Whether to strip the trailing ``\n`` of the command stdout.
 
         :param subprocess_kwargs:
-            Keyword arguments to be passed to `subprocess.Popen`. Please note that
-            some of the valid kwargs are already set by this method; the ones you
+            Keyword arguments to be passed to :class:`subprocess.Popen`. Please note
+            that some of the valid kwargs are already set by this method; the ones you
             specify may not be the same ones.
 
         :return:
@@ -931,8 +939,9 @@ class Git(LazyMixin):
 
         :note:
            If you add additional keyword arguments to the signature of this method,
-           you must update the execute_kwargs tuple housed in this module."""
-        # Remove password for the command if present
+           you must update the execute_kwargs tuple housed in this module.
+        """
+        # Remove password for the command if present.
         redacted_command = remove_password_if_present(command)
         if self.GIT_PYTHON_TRACE and (self.GIT_PYTHON_TRACE != "full" or as_process):
             log.info(" ".join(redacted_command))
@@ -945,12 +954,12 @@ class Git(LazyMixin):
         except FileNotFoundError:
             cwd = None
 
-        # Start the process
+        # Start the process.
         inline_env = env
         env = os.environ.copy()
-        # Attempt to force all output to plain ascii english, which is what some parsing code
-        # may expect.
-        # According to stackoverflow (http://goo.gl/l74GC8), we are setting LANGUAGE as well
+        # Attempt to force all output to plain ASCII English, which is what some parsing
+        # code may expect.
+        # According to https://askubuntu.com/a/311796, we are setting LANGUAGE as well
         # just to be sure.
         env["LANGUAGE"] = "C"
         env["LC_ALL"] = "C"
@@ -994,7 +1003,7 @@ class Git(LazyMixin):
                     stderr=PIPE,
                     stdout=stdout_sink,
                     shell=shell,
-                    close_fds=is_posix,  # unsupported on windows
+                    close_fds=is_posix,  # Unsupported on Windows.
                     universal_newlines=universal_newlines,
                     creationflags=PROC_CREATIONFLAGS,
                     **subprocess_kwargs,
@@ -1002,7 +1011,7 @@ class Git(LazyMixin):
         except cmd_not_found_exception as err:
             raise GitCommandNotFound(redacted_command, err) from err
         else:
-            # replace with a typeguard for Popen[bytes]?
+            # Replace with a typeguard for Popen[bytes]?
             proc.stdout = cast(BinaryIO, proc.stdout)
             proc.stderr = cast(BinaryIO, proc.stderr)
 
@@ -1024,7 +1033,7 @@ class Git(LazyMixin):
                         if local_pid.isdigit():
                             child_pids.append(int(local_pid))
             try:
-                # Windows does not have SIGKILL, so use SIGTERM instead
+                # Windows does not have SIGKILL, so use SIGTERM instead.
                 sig = getattr(signal, "SIGKILL", signal.SIGTERM)
                 os.kill(pid, sig)
                 for child_pid in child_pids:
@@ -1032,7 +1041,7 @@ class Git(LazyMixin):
                         os.kill(child_pid, sig)
                     except OSError:
                         pass
-                kill_check.set()  # tell the main routine that the process was killed
+                kill_check.set()  # Tell the main routine that the process was killed.
             except OSError:
                 # It is possible that the process gets completed in the duration after timeout
                 # happens and before we try to kill the process.
@@ -1045,7 +1054,7 @@ class Git(LazyMixin):
             kill_check = threading.Event()
             watchdog = threading.Timer(kill_after_timeout, kill_process, args=(proc.pid,))
 
-        # Wait for the process to return
+        # Wait for the process to return.
         status = 0
         stdout_value: Union[str, bytes] = b""
         stderr_value: Union[str, bytes] = b""
@@ -1076,7 +1085,7 @@ class Git(LazyMixin):
                 stream_copy(proc.stdout, output_stream, max_chunk_size)
                 stdout_value = proc.stdout.read()
                 stderr_value = proc.stderr.read()
-                # strip trailing "\n"
+                # Strip trailing "\n".
                 if stderr_value.endswith(newline):  # type: ignore
                     stderr_value = stderr_value[:-1]
                 status = proc.wait()
@@ -1110,10 +1119,10 @@ class Git(LazyMixin):
         if with_exceptions and status != 0:
             raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
 
-        if isinstance(stdout_value, bytes) and stdout_as_string:  # could also be output_stream
+        if isinstance(stdout_value, bytes) and stdout_as_string:  # Could also be output_stream.
             stdout_value = safe_decode(stdout_value)
 
-        # Allow access to the command's status code
+        # Allow access to the command's status code.
         if with_extended_output:
             return (status, stdout_value, safe_decode(stderr_value))
         else:
@@ -1123,18 +1132,18 @@ class Git(LazyMixin):
         return self._environment
 
     def update_environment(self, **kwargs: Any) -> Dict[str, Union[str, None]]:
-        """
-        Set environment variables for future git invocations. Return all changed
-        values in a format that can be passed back into this function to revert
-        the changes:
+        """Set environment variables for future git invocations. Return all changed
+        values in a format that can be passed back into this function to revert the
+        changes.
 
         ``Examples``::
 
             old_env = self.update_environment(PWD='/tmp')
             self.update_environment(**old_env)
 
-        :param kwargs: environment variables to use for git processes
-        :return: dict that maps environment variables to their old values
+        :param kwargs: Environment variables to use for git processes
+
+        :return: Dict that maps environment variables to their old values
         """
         old_env = {}
         for key, value in kwargs.items():
@@ -1150,16 +1159,15 @@ class Git(LazyMixin):
 
     @contextlib.contextmanager
     def custom_environment(self, **kwargs: Any) -> Iterator[None]:
-        """
-        A context manager around the above ``update_environment`` method to restore the
-        environment back to its previous state after operation.
+        """A context manager around the above :meth:`update_environment` method to
+        restore the environment back to its previous state after operation.
 
         ``Examples``::
 
             with self.custom_environment(GIT_SSH='/bin/ssh_wrapper'):
                 repo.remotes.origin.fetch()
 
-        :param kwargs: see update_environment
+        :param kwargs: See :meth:`update_environment`
         """
         old_env = self.update_environment(**kwargs)
         try:
@@ -1184,7 +1192,7 @@ class Git(LazyMixin):
         return []
 
     def transform_kwargs(self, split_single_char_options: bool = True, **kwargs: Any) -> List[str]:
-        """Transforms Python style kwargs into git command line options."""
+        """Transform Python style kwargs into git command line options."""
         args = []
         for k, v in kwargs.items():
             if isinstance(v, (list, tuple)):
@@ -1206,23 +1214,22 @@ class Git(LazyMixin):
         return outlist
 
     def __call__(self, **kwargs: Any) -> "Git":
-        """Specify command line options to the git executable
-        for a subcommand call.
+        """Specify command line options to the git executable for a subcommand call.
 
         :param kwargs:
-            is a dict of keyword arguments.
-            these arguments are passed as in _call_process
-            but will be passed to the git command rather than
-            the subcommand.
+            A dict of keyword arguments.
+            These arguments are passed as in :meth:`_call_process`, but will be
+            passed to the git command rather than the subcommand.
 
         ``Examples``::
-            git(work_tree='/tmp').difftool()"""
+            git(work_tree='/tmp').difftool()
+        """
         self._git_options = self.transform_kwargs(split_single_char_options=True, **kwargs)
         return self
 
     @overload
     def _call_process(self, method: str, *args: None, **kwargs: None) -> str:
-        ...  # if no args given, execute called with all defaults
+        ...  # If no args were given, execute the call with all defaults.
 
     @overload
     def _call_process(
@@ -1248,20 +1255,20 @@ class Git(LazyMixin):
         the result as a string.
 
         :param method:
-            is the command. Contained "_" characters will be converted to dashes,
-            such as in 'ls_files' to call 'ls-files'.
+            The command. Contained ``_`` characters will be converted to dashes,
+            such as in ``ls_files`` to call ``ls-files``.
 
         :param args:
-            is the list of arguments. If None is included, it will be pruned.
+            The list of arguments. If None is included, it will be pruned.
             This allows your commands to call git more conveniently as None
             is realized as non-existent.
 
         :param kwargs:
-            It contains key-values for the following:
-            - the :meth:`execute()` kwds, as listed in :var:`execute_kwargs`;
-            - "command options" to be converted by :meth:`transform_kwargs()`;
-            - the `'insert_kwargs_after'` key which its value must match one of ``*args``
-            and any cmd-options will be appended after the matched arg.
+            Contains key-values for the following:
+            - The :meth:`execute()` kwds, as listed in :var:`execute_kwargs`.
+            - "Command options" to be converted by :meth:`transform_kwargs`.
+            - The `'insert_kwargs_after'` key which its value must match one of ``*args``.
+            It also contains any command options, to be appended after the matched arg.
 
         Examples::
 
@@ -1271,17 +1278,18 @@ class Git(LazyMixin):
 
            git rev-list max-count 10 --header master
 
-        :return: Same as ``execute``
-                 if no args given used execute default (esp. as_process = False, stdout_as_string = True)
-                 and return str"""
-        # Handle optional arguments prior to calling transform_kwargs
-        # otherwise these'll end up in args, which is bad.
+        :return: Same as :meth:`execute`.
+            If no args are given, used :meth:`execute`'s default (especially
+            ``as_process = False``, ``stdout_as_string = True``) and return str.
+        """
+        # Handle optional arguments prior to calling transform_kwargs.
+        # Otherwise these'll end up in args, which is bad.
         exec_kwargs = {k: v for k, v in kwargs.items() if k in execute_kwargs}
         opts_kwargs = {k: v for k, v in kwargs.items() if k not in execute_kwargs}
 
         insert_after_this_arg = opts_kwargs.pop("insert_kwargs_after", None)
 
-        # Prepare the argument list
+        # Prepare the argument list.
 
         opt_args = self.transform_kwargs(**opts_kwargs)
         ext_args = self._unpack_args([a for a in args if a is not None])
@@ -1302,11 +1310,10 @@ class Git(LazyMixin):
 
         call = [self.GIT_PYTHON_GIT_EXECUTABLE]
 
-        # add persistent git options
+        # Add persistent git options.
         call.extend(self._persistent_git_options)
 
-        # add the git options, then reset to empty
-        # to avoid side_effects
+        # Add the git options, then reset to empty to avoid side effects.
         call.extend(self._git_options)
         self._git_options = ()
 
@@ -1322,7 +1329,7 @@ class Git(LazyMixin):
 
         :return: (hex_sha, type_string, size_as_int)
 
-        :raise ValueError: if the header contains indication for an error due to
+        :raise ValueError: If the header contains indication for an error due to
             incorrect input sha"""
         tokens = header_line.split()
         if len(tokens) != 3:
@@ -1338,12 +1345,12 @@ class Git(LazyMixin):
         return (tokens[0], tokens[1], int(tokens[2]))
 
     def _prepare_ref(self, ref: AnyStr) -> bytes:
-        # required for command to separate refs on stdin, as bytes
+        # Required for command to separate refs on stdin, as bytes.
         if isinstance(ref, bytes):
-            # Assume 40 bytes hexsha - bin-to-ascii for some reason returns bytes, not text
+            # Assume 40 bytes hexsha - bin-to-ascii for some reason returns bytes, not text.
             refstr: str = ref.decode("ascii")
         elif not isinstance(ref, str):
-            refstr = str(ref)  # could be ref-object
+            refstr = str(ref)  # Could be ref-object.
         else:
             refstr = ref
 
@@ -1379,7 +1386,8 @@ class Git(LazyMixin):
         :note: The method will only suffer from the costs of command invocation
             once and reuses the command in subsequent calls.
 
-        :return: (hexsha, type_string, size_as_int)"""
+        :return: (hexsha, type_string, size_as_int)
+        """
         cmd = self._get_persistent_cmd("cat_file_header", "cat_file", batch_check=True)
         return self.__get_object_header(cmd, ref)
 
@@ -1387,7 +1395,8 @@ class Git(LazyMixin):
         """As get_object_header, but returns object data as well.
 
         :return: (hexsha, type_string, size_as_int, data_string)
-        :note: not threadsafe"""
+        :note: Not threadsafe.
+        """
         hexsha, typename, size, stream = self.stream_object_data(ref)
         data = stream.read(size)
         del stream
@@ -1397,7 +1406,8 @@ class Git(LazyMixin):
         """As get_object_header, but returns the data as a stream.
 
         :return: (hexsha, type_string, size_as_int, stream)
-        :note: This method is not threadsafe, you need one independent Command instance per thread to be safe!"""
+        :note: This method is not threadsafe, you need one independent Command instance per thread to be safe!
+        """
         cmd = self._get_persistent_cmd("cat_file_all", "cat_file", batch=True)
         hexsha, typename, size = self.__get_object_header(cmd, ref)
         cmd_stdout = cmd.stdout if cmd.stdout is not None else io.BytesIO()
@@ -1408,7 +1418,8 @@ class Git(LazyMixin):
 
         Currently persistent commands will be interrupted.
 
-        :return: self"""
+        :return: self
+        """
         for cmd in (self.cat_file_all, self.cat_file_header):
             if cmd:
                 cmd.__del__()

--- a/git/compat.py
+++ b/git/compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # compat.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/git/compat.py
+++ b/git/compat.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-# config.py
+# compat.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
-"""utilities to help provide compatibility with python 3"""
+
+"""Utilities to help provide compatibility with Python 3."""
+
 # flake8: noqa
 
 import locale
@@ -50,7 +52,7 @@ def safe_decode(s: AnyStr) -> str:
 
 
 def safe_decode(s: Union[AnyStr, None]) -> Optional[str]:
-    """Safely decodes a binary string to unicode"""
+    """Safely decode a binary string to Unicode."""
     if isinstance(s, str):
         return s
     elif isinstance(s, bytes):
@@ -72,7 +74,7 @@ def safe_encode(s: AnyStr) -> bytes:
 
 
 def safe_encode(s: Optional[AnyStr]) -> Optional[bytes]:
-    """Safely encodes a binary string to unicode"""
+    """Safely encode a binary string to Unicode."""
     if isinstance(s, str):
         return s.encode(defenc)
     elif isinstance(s, bytes):
@@ -94,7 +96,7 @@ def win_encode(s: AnyStr) -> bytes:
 
 
 def win_encode(s: Optional[AnyStr]) -> Optional[bytes]:
-    """Encode unicodes for process arguments on Windows."""
+    """Encode Unicode strings for process arguments on Windows."""
     if isinstance(s, str):
         return s.encode(locale.getpreferredencoding(False))
     elif isinstance(s, bytes):

--- a/git/config.py
+++ b/git/config.py
@@ -3,8 +3,9 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module containing module parser implementation able to properly read and write
-configuration files"""
+configuration files."""
 
 import sys
 import abc
@@ -85,12 +86,12 @@ CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbr
 
 
 class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
-    """Utility class wrapping base-class methods into decorators that assure read-only properties"""
+    """Utility class wrapping base-class methods into decorators that assure read-only properties."""
 
     def __new__(cls, name: str, bases: Tuple, clsdict: Dict[str, Any]) -> "MetaParserBuilder":
+        """Equip all base-class methods with a needs_values decorator, and all non-const
+        methods with a set_dirty_and_flush_changes decorator in addition to that.
         """
-        Equip all base-class methods with a needs_values decorator, and all non-const methods
-        with a set_dirty_and_flush_changes decorator in addition to that."""
         kmm = "_mutating_methods_"
         if kmm in clsdict:
             mutating_methods = clsdict[kmm]
@@ -114,7 +115,7 @@ class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
 
 
 def needs_values(func: Callable[..., _T]) -> Callable[..., _T]:
-    """Returns method assuring we read values (on demand) before we try to access them"""
+    """Return a method for ensuring we read values (on demand) before we try to access them."""
 
     @wraps(func)
     def assure_data_present(self: "GitConfigParser", *args: Any, **kwargs: Any) -> _T:
@@ -126,9 +127,10 @@ def needs_values(func: Callable[..., _T]) -> Callable[..., _T]:
 
 
 def set_dirty_and_flush_changes(non_const_func: Callable[..., _T]) -> Callable[..., _T]:
-    """Return method that checks whether given non constant function may be called.
-    If so, the instance will be set dirty.
-    Additionally, we flush the changes right to disk"""
+    """Return a method that checks whether given non constant function may be called.
+
+    If so, the instance will be set dirty. Additionally, we flush the changes right to disk.
+    """
 
     def flush_changes(self: "GitConfigParser", *args: Any, **kwargs: Any) -> _T:
         rval = non_const_func(self, *args, **kwargs)
@@ -142,14 +144,13 @@ def set_dirty_and_flush_changes(non_const_func: Callable[..., _T]) -> Callable[.
 
 
 class SectionConstraint(Generic[T_ConfigParser]):
-
     """Constrains a ConfigParser to only option commands which are constrained to
     always use the section we have been initialized with.
 
     It supports all ConfigParser methods that operate on an option.
 
-    :note:
-        If used as a context manager, will release the wrapped ConfigParser."""
+    :note: If used as a context manager, will release the wrapped ConfigParser.
+    """
 
     __slots__ = ("_config", "_section_name")
     _valid_attrs_ = (
@@ -183,16 +184,17 @@ class SectionConstraint(Generic[T_ConfigParser]):
 
     def _call_config(self, method: str, *args: Any, **kwargs: Any) -> Any:
         """Call the configuration at the given method which must take a section name
-        as first argument"""
+        as first argument."""
         return getattr(self._config, method)(self._section_name, *args, **kwargs)
 
     @property
     def config(self) -> T_ConfigParser:
-        """return: Configparser instance we constrain"""
+        """return: ConfigParser instance we constrain"""
         return self._config
 
     def release(self) -> None:
-        """Equivalent to GitConfigParser.release(), which is called on our underlying parser instance"""
+        """Equivalent to GitConfigParser.release(), which is called on our underlying
+        parser instance."""
         return self._config.release()
 
     def __enter__(self) -> "SectionConstraint[T_ConfigParser]":
@@ -248,8 +250,8 @@ class _OMD(OrderedDict_OMD):
 
 
 def get_config_path(config_level: Lit_config_levels) -> str:
-    # we do not support an absolute path of the gitconfig on windows ,
-    # use the global config instead
+    # We do not support an absolute path of the gitconfig on Windows.
+    # Use the global config instead.
     if is_win and config_level == "system":
         config_level = "global"
 
@@ -271,7 +273,6 @@ def get_config_path(config_level: Lit_config_levels) -> str:
 
 
 class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
-
     """Implements specifics required to read git style configuration files.
 
     This variation behaves much like the git.config command such that the configuration
@@ -286,7 +287,10 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     :note:
         The config is case-sensitive even when queried, hence section and option names
         must match perfectly.
-        If used as a context manager, will release the locked file."""
+
+    :note:
+        If used as a context manager, this will release the locked file.
+    """
 
     # { Configuration
     # The lock type determines the type of lock to use in new configuration readers.
@@ -317,29 +321,34 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         repo: Union["Repo", None] = None,
     ) -> None:
         """Initialize a configuration reader to read the given file_or_files and to
-        possibly allow changes to it by setting read_only False
+        possibly allow changes to it by setting read_only False.
 
         :param file_or_files:
-            A single file path or file objects or multiple of these
+            A file path or file object, or a sequence of possibly more than one of them.
 
         :param read_only:
-            If True, the ConfigParser may only read the data , but not change it.
-            If False, only a single file path or file object may be given. We will write back the changes
-            when they happen, or when the ConfigParser is released. This will not happen if other
-            configuration files have been included
-        :param merge_includes: if True, we will read files mentioned in [include] sections and merge their
-            contents into ours. This makes it impossible to write back an individual configuration file.
-            Thus, if you want to modify a single configuration file, turn this off to leave the original
-            dataset unaltered when reading it.
-        :param repo: Reference to repository to use if [includeIf] sections are found in configuration files.
+            If True, the ConfigParser may only read the data, but not change it.
+            If False, only a single file path or file object may be given. We will write
+            back the changes when they happen, or when the ConfigParser is released.
+            This will not happen if other configuration files have been included.
 
+        :param merge_includes:
+            If True, we will read files mentioned in ``[include]`` sections and merge
+            their contents into ours. This makes it impossible to write back an
+            individual configuration file. Thus, if you want to modify a single
+            configuration file, turn this off to leave the original dataset unaltered
+            when reading it.
+
+        :param repo:
+            Reference to repository to use if ``[includeIf]`` sections are found in
+            configuration files.
         """
         cp.RawConfigParser.__init__(self, dict_type=_OMD)
         self._dict: Callable[..., _OMD]  # type: ignore   # mypy/typeshed bug?
         self._defaults: _OMD
         self._sections: _OMD  # type: ignore  # mypy/typeshed bug?
 
-        # Used in python 3, needs to stay in sync with sections for underlying implementation to work
+        # Used in Python 3. Needs to stay in sync with sections for underlying implementation to work.
         if not hasattr(self, "_proxies"):
             self._proxies = self._dict()
 
@@ -377,7 +386,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     file_or_files = self._file_or_files.name
 
                 # END get filename from handle/stream
-                # initialize lock base - we want to write
+                # Initialize lock base - we want to write.
                 self._lock = self.t_lock(file_or_files)
             # END lock check
 
@@ -386,7 +395,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def __del__(self) -> None:
         """Write pending changes if required and release locks"""
-        # NOTE: only consistent in PY2
+        # NOTE: Only consistent in Python 2.
         self.release()
 
     def __enter__(self) -> "GitConfigParser":
@@ -398,10 +407,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def release(self) -> None:
         """Flush changes and release the configuration write lock. This instance must not be used anymore afterwards.
+
         In Python 3, it's required to explicitly release locks and flush changes, as __del__ is not called
         deterministically anymore."""
-        # checking for the lock here makes sure we do not raise during write()
-        # in case an invalid parser was created who could not get a lock
+        # Checking for the lock here makes sure we do not raise during write()
+        # in case an invalid parser was created who could not get a lock.
         if self.read_only or (self._lock and not self._lock._has_lock()):
             return
 
@@ -410,33 +420,31 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         except IOError:
             log.error("Exception during destruction of GitConfigParser", exc_info=True)
         except ReferenceError:
-            # This happens in PY3 ... and usually means that some state cannot be
-            # written as the sections dict cannot be iterated
-            # Usually when shutting down the interpreter, don't know how to fix this
+            # This happens in Python 3... and usually means that some state cannot be
+            # written as the sections dict cannot be iterated. This usually happens when
+            # the interpreter is shutting down. Can it be fixed?
             pass
         finally:
             if self._lock is not None:
                 self._lock._release_lock()
 
     def optionxform(self, optionstr: str) -> str:
-        """Do not transform options in any way when writing"""
+        """Do not transform options in any way when writing."""
         return optionstr
 
     def _read(self, fp: Union[BufferedReader, IO[bytes]], fpname: str) -> None:
-        """A direct copy of the py2.4 version of the super class's _read method
-        to assure it uses ordered dicts. Had to change one line to make it work.
+        """Originally a direct copy of the Python 2.4 version of RawConfigParser._read,
+        to ensure it uses ordered dicts.
 
-        Future versions have this fixed, but in fact its quite embarrassing for the
-        guys not to have done it right in the first place !
-
-        Removed big comments to make it more compact.
-
-        Made sure it ignores initial whitespace as git uses tabs"""
-        cursect = None  # None, or a dictionary
+        The ordering bug was fixed in Python 2.4, and dict itself keeps ordering since
+        Python 3.7. This has some other changes, especially that it ignores initial
+        whitespace, since git uses tabs. (Big comments are removed to be more compact.)
+        """
+        cursect = None  # None, or a dictionary.
         optname = None
         lineno = 0
         is_multi_line = False
-        e = None  # None, or an exception
+        e = None  # None, or an exception.
 
         def string_decode(v: str) -> str:
             if v[-1] == "\\":
@@ -449,19 +457,19 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         # end
 
         while True:
-            # we assume to read binary !
+            # We assume to read binary!
             line = fp.readline().decode(defenc)
             if not line:
                 break
             lineno = lineno + 1
-            # comment or blank line?
+            # Comment or blank line?
             if line.strip() == "" or self.re_comment.match(line):
                 continue
             if line.split(None, 1)[0].lower() == "rem" and line[0] in "rR":
-                # no leading whitespace
+                # No leading whitespace.
                 continue
 
-            # is it a section header?
+            # Is it a section header?
             mo = self.SECTCRE.match(line.strip())
             if not is_multi_line and mo:
                 sectname: str = mo.group("header").strip()
@@ -473,16 +481,16 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     cursect = self._dict((("__name__", sectname),))
                     self._sections[sectname] = cursect
                     self._proxies[sectname] = None
-                # So sections can't start with a continuation line
+                # So sections can't start with a continuation line.
                 optname = None
-            # no section header in the file?
+            # No section header in the file?
             elif cursect is None:
                 raise cp.MissingSectionHeaderError(fpname, lineno, line)
-            # an option line?
+            # An option line?
             elif not is_multi_line:
                 mo = self.OPTCRE.match(line)
                 if mo:
-                    # We might just have handled the last line, which could contain a quotation we want to remove
+                    # We might just have handled the last line, which could contain a quotation we want to remove.
                     optname, vi, optval = mo.group("option", "vi", "value")
                     if vi in ("=", ":") and ";" in optval and not optval.strip().startswith('"'):
                         pos = optval.find(";")
@@ -497,10 +505,10 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                         is_multi_line = True
                         optval = string_decode(optval[1:])
                     # end handle multi-line
-                    # preserves multiple values for duplicate optnames
+                    # Preserves multiple values for duplicate optnames.
                     cursect.add(optname, optval)
                 else:
-                    # check if it's an option with no value - it's just ignored by git
+                    # Check if it's an option with no value - it's just ignored by git.
                     if not self.OPTVALUEONLY.match(line):
                         if not e:
                             e = cp.ParsingError(fpname)
@@ -517,7 +525,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             # END parse section or option
         # END while reading
 
-        # if any parsing errors occurred, raise an exception
+        # If any parsing errors occurred, raise an exception.
         if e:
             raise e
 
@@ -525,8 +533,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return self._merge_includes and len(self._included_paths())
 
     def _included_paths(self) -> List[Tuple[str, str]]:
-        """Return List all paths that must be included to configuration
-        as Tuples of (option, value).
+        """List all paths that must be included to configuration.
+
+        :return: The list of paths, where each path is a tuple of ``(option, value)``.
         """
         paths = []
 
@@ -573,21 +582,24 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return paths
 
     def read(self) -> None:  # type: ignore[override]
-        """Reads the data stored in the files we have been initialized with. It will
-        ignore files that cannot be read, possibly leaving an empty configuration
+        """Read the data stored in the files we have been initialized with.
+
+        This will ignore files that cannot be read, possibly leaving an empty
+        configuration.
 
         :return: Nothing
-        :raise IOError: if a file cannot be handled"""
+        :raise IOError: If a file cannot be handled
+        """
         if self._is_initialized:
             return None
         self._is_initialized = True
 
         files_to_read: List[Union[PathLike, IO]] = [""]
         if isinstance(self._file_or_files, (str, os.PathLike)):
-            # for str or Path, as str is a type of Sequence
+            # For str or Path, as str is a type of Sequence.
             files_to_read = [self._file_or_files]
         elif not isinstance(self._file_or_files, (tuple, list, Sequence)):
-            # could merge with above isinstance once runtime type known
+            # Could merge with above isinstance once runtime type known.
             files_to_read = [self._file_or_files]
         else:  # for lists or tuples
             files_to_read = list(self._file_or_files)
@@ -600,11 +612,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             file_ok = False
 
             if hasattr(file_path, "seek"):
-                # must be a file objectfile-object
-                file_path = cast(IO[bytes], file_path)  # replace with assert to narrow type, once sure
+                # Must be a file objectfile-object.
+                file_path = cast(IO[bytes], file_path)  # TODO: Replace with assert to narrow type, once sure.
                 self._read(file_path, file_path.name)
             else:
-                # assume a path if it is not a file-object
+                # Assume a path if it is not a file-object.
                 file_path = cast(PathLike, file_path)
                 try:
                     with open(file_path, "rb") as fp:
@@ -613,8 +625,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 except IOError:
                     continue
 
-            # Read includes and append those that we didn't handle yet
-            # We expect all paths to be normalized and absolute (and will assure that is the case)
+            # Read includes and append those that we didn't handle yet.
+            # We expect all paths to be normalized and absolute (and will assure that is the case).
             if self._has_includes():
                 for _, include_path in self._included_paths():
                     if include_path.startswith("~"):
@@ -631,27 +643,27 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     if include_path in seen or not os.access(include_path, os.R_OK):
                         continue
                     seen.add(include_path)
-                    # insert included file to the top to be considered first
+                    # Insert included file to the top to be considered first.
                     files_to_read.insert(0, include_path)
                     num_read_include_files += 1
                 # each include path in configuration file
             # end handle includes
         # END for each file object to read
 
-        # If there was no file included, we can safely write back (potentially) the configuration file
-        # without altering it's meaning
+        # If there was no file included, we can safely write back (potentially) the
+        # configuration file without altering its meaning.
         if num_read_include_files == 0:
             self._merge_includes = False
         # end
 
     def _write(self, fp: IO) -> None:
         """Write an .ini-format representation of the configuration state in
-        git compatible format"""
+        git compatible format."""
 
         def write_section(name: str, section_dict: _OMD) -> None:
             fp.write(("[%s]\n" % name).encode(defenc))
 
-            values: Sequence[str]  # runtime only gets str in tests, but should be whatever _OMD stores
+            values: Sequence[str]  # Runtime only gets str in tests, but should be whatever _OMD stores.
             v: str
             for key, values in section_dict.items_all():
                 if key == "__name__":
@@ -692,9 +704,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     @needs_values
     def write(self) -> None:
-        """Write changes to our file, if there are changes at all
+        """Write changes to our file, if there are changes at all.
 
-        :raise IOError: if this is a read-only writer instance or if we could not obtain
+        :raise IOError: If this is a read-only writer instance or if we could not obtain
             a file lock"""
         self._assure_writable("write")
         if not self._dirty:
@@ -717,9 +729,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
         fp = self._file_or_files
 
-        # we have a physical file on disk, so get a lock
-        is_file_lock = isinstance(fp, (str, os.PathLike, IOBase))  # can't use Pathlike until 3.5 dropped
-        if is_file_lock and self._lock is not None:  # else raise Error?
+        # We have a physical file on disk, so get a lock.
+        is_file_lock = isinstance(fp, (str, os.PathLike, IOBase))  # TODO: Use PathLike (having dropped 3.5).
+        if is_file_lock and self._lock is not None:  # Else raise error?
             self._lock._obtain_lock()
 
         if not hasattr(fp, "seek"):
@@ -729,7 +741,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         else:
             fp = cast("BytesIO", fp)
             fp.seek(0)
-            # make sure we do not overwrite into an existing file
+            # Make sure we do not overwrite into an existing file.
             if hasattr(fp, "truncate"):
                 fp.truncate()
             self._write(fp)
@@ -747,13 +759,13 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """:return: True if this instance may change the configuration file"""
         return self._read_only
 
+    # FIXME: Figure out if default or return type can really include bool.
     def get_value(
         self,
         section: str,
         option: str,
         default: Union[int, float, str, bool, None] = None,
     ) -> Union[int, float, str, bool]:
-        # can default or return type include bool?
         """Get an option's value.
 
         If multiple values are specified for this option in the section, the
@@ -762,10 +774,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :param default:
             If not None, the given default value will be returned in case
             the option did not exist
+
         :return: a properly typed value, either int, float or string
 
         :raise TypeError: in case the value could not be understood
-            Otherwise the exceptions known to the ConfigParser will be raised."""
+            Otherwise the exceptions known to the ConfigParser will be raised.
+        """
         try:
             valuestr = self.get(section, option)
         except Exception:
@@ -789,10 +803,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :param default:
             If not None, a list containing the given default value will be
             returned in case the option did not exist
+
         :return: a list of properly typed values, either int, float or string
 
         :raise TypeError: in case the value could not be understood
-            Otherwise the exceptions known to the ConfigParser will be raised."""
+            Otherwise the exceptions known to the ConfigParser will be raised.
+        """
         try:
             self.sections()
             lst = self._sections[section].getall(option)
@@ -816,7 +832,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 continue
         # END for each numeric type
 
-        # try boolean values as git uses them
+        # Try boolean values as git uses them.
         vl = valuestr.lower()
         if vl == "false":
             return False
@@ -839,16 +855,17 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     @needs_values
     @set_dirty_and_flush_changes
     def set_value(self, section: str, option: str, value: Union[str, bytes, int, float, bool]) -> "GitConfigParser":
-        """Sets the given option in section to the given value.
-        It will create the section if required, and will not throw as opposed to the default
-        ConfigParser 'set' method.
+        """Set the given option in section to the given value.
+
+        This will create the section if required, and will not throw as opposed to the
+        default ConfigParser 'set' method.
 
         :param section: Name of the section in which the option resides or should reside
         :param option: Name of the options whose value to set
-
-        :param value: Value to set the option to. It must be a string or convertible
-            to a string
-        :return: this instance"""
+        :param value: Value to set the option to. It must be a string or convertible to
+            a string.
+        :return: This instance
+        """
         if not self.has_section(section):
             self.add_section(section)
         self.set(section, option, self._value_to_string(value))
@@ -857,27 +874,29 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     @needs_values
     @set_dirty_and_flush_changes
     def add_value(self, section: str, option: str, value: Union[str, bytes, int, float, bool]) -> "GitConfigParser":
-        """Adds a value for the given option in section.
-        It will create the section if required, and will not throw as opposed to the default
+        """Add a value for the given option in section.
+
+        This will create the section if required, and will not throw as opposed to the default
         ConfigParser 'set' method. The value becomes the new value of the option as returned
         by 'get_value', and appends to the list of values returned by 'get_values`'.
 
         :param section: Name of the section in which the option resides or should reside
         :param option: Name of the option
-
         :param value: Value to add to option. It must be a string or convertible
             to a string
-        :return: this instance"""
+        :return: This instance
+        """
         if not self.has_section(section):
             self.add_section(section)
         self._sections[section].add(option, self._value_to_string(value))
         return self
 
     def rename_section(self, section: str, new_name: str) -> "GitConfigParser":
-        """rename the given section to new_name
-        :raise ValueError: if section doesn't exit
-        :raise ValueError: if a section with new_name does already exist
-        :return: this instance
+        """Rename the given section to new_name.
+
+        :raise ValueError: If ``section`` doesn't exist
+        :raise ValueError: If a section with ``new_name`` does already exist
+        :return: This instance
         """
         if not self.has_section(section):
             raise ValueError("Source section '%s' doesn't exist" % section)
@@ -890,6 +909,6 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             new_section.setall(k, vs)
         # end for each value to copy
 
-        # This call writes back the changes, which is why we don't have the respective decorator
+        # This call writes back the changes, which is why we don't have the respective decorator.
         self.remove_section(section)
         return self

--- a/git/config.py
+++ b/git/config.py
@@ -56,7 +56,7 @@ T_ConfigParser = TypeVar("T_ConfigParser", bound="GitConfigParser")
 T_OMD_value = TypeVar("T_OMD_value", str, bytes, int, float, bool)
 
 if sys.version_info[:3] < (3, 7, 2):
-    # typing.Ordereddict not added until py 3.7.2
+    # typing.Ordereddict not added until Python 3.7.2.
     from collections import OrderedDict
 
     OrderedDict_OMD = OrderedDict
@@ -73,12 +73,9 @@ __all__ = ("GitConfigParser", "SectionConstraint")
 log = logging.getLogger("git.config")
 log.addHandler(logging.NullHandler())
 
-# invariants
-# represents the configuration level of a configuration file
 
-
+# The configuration level of a configuration file.
 CONFIG_LEVELS: ConfigLevels_Tup = ("system", "user", "global", "repository")
-
 
 # Section pattern to detect conditional includes.
 # https://git-scm.com/docs/git-config#_conditional_includes
@@ -603,7 +600,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             files_to_read = [self._file_or_files]
         else:  # for lists or tuples
             files_to_read = list(self._file_or_files)
-        # end assure we have a copy of the paths to handle
+        # end ensure we have a copy of the paths to handle
 
         seen = set(files_to_read)
         num_read_include_files = 0
@@ -612,7 +609,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             file_ok = False
 
             if hasattr(file_path, "seek"):
-                # Must be a file objectfile-object.
+                # Must be a file-object.
                 file_path = cast(IO[bytes], file_path)  # TODO: Replace with assert to narrow type, once sure.
                 self._read(file_path, file_path.name)
             else:
@@ -626,7 +623,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     continue
 
             # Read includes and append those that we didn't handle yet.
-            # We expect all paths to be normalized and absolute (and will assure that is the case).
+            # We expect all paths to be normalized and absolute (and will ensure that is the case).
             if self._has_includes():
                 for _, include_path in self._included_paths():
                     if include_path.startswith("~"):

--- a/git/config.py
+++ b/git/config.py
@@ -446,12 +446,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         def string_decode(v: str) -> str:
             if v[-1] == "\\":
                 v = v[:-1]
-            # end cut trailing escapes to prevent decode error
+            # END cut trailing escapes to prevent decode error
 
             return v.encode(defenc).decode("unicode_escape")
-            # end
 
-        # end
+        # END def string_decode
 
         while True:
             # We assume to read binary!
@@ -496,12 +495,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     optval = optval.strip()
                     if optval == '""':
                         optval = ""
-                    # end handle empty string
+                    # END handle empty string
                     optname = self.optionxform(optname.rstrip())
                     if len(optval) > 1 and optval[0] == '"' and optval[-1] != '"':
                         is_multi_line = True
                         optval = string_decode(optval[1:])
-                    # end handle multi-line
+                    # END handle multi-line
                     # Preserves multiple values for duplicate optnames.
                     cursect.add(optname, optval)
                 else:
@@ -516,7 +515,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 if line.endswith('"'):
                     is_multi_line = False
                     line = line[:-1]
-                # end handle quotations
+                # END handle quotations
                 optval = cursect.getlast(optname)
                 cursect.setlast(optname, optval + string_decode(line))
             # END parse section or option
@@ -600,7 +599,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             files_to_read = [self._file_or_files]
         else:  # for lists or tuples
             files_to_read = list(self._file_or_files)
-        # end ensure we have a copy of the paths to handle
+        # END ensure we have a copy of the paths to handle
 
         seen = set(files_to_read)
         num_read_include_files = 0
@@ -631,11 +630,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     if not osp.isabs(include_path):
                         if not file_ok:
                             continue
-                        # end ignore relative paths if we don't know the configuration file path
+                        # END ignore relative paths if we don't know the configuration file path
                         file_path = cast(PathLike, file_path)
                         assert osp.isabs(file_path), "Need absolute paths to be sure our cycle checks will work"
                         include_path = osp.join(osp.dirname(file_path), include_path)
-                    # end make include path absolute
+                    # END make include path absolute
                     include_path = osp.normpath(include_path)
                     if include_path in seen or not os.access(include_path, os.R_OK):
                         continue
@@ -643,15 +642,14 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     # Insert included file to the top to be considered first.
                     files_to_read.insert(0, include_path)
                     num_read_include_files += 1
-                # each include path in configuration file
-            # end handle includes
+                # END each include path in configuration file
+            # END handle includes
         # END for each file object to read
 
         # If there was no file included, we can safely write back (potentially) the
         # configuration file without altering its meaning.
         if num_read_include_files == 0:
             self._merge_includes = False
-        # end
 
     def _write(self, fp: IO) -> None:
         """Write an .ini-format representation of the configuration state in
@@ -714,7 +712,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 "Cannot write back if there is not exactly a single file to write to, have %i files"
                 % len(self._file_or_files)
             )
-        # end assert multiple files
+        # END assert multiple files
 
         if self._has_includes():
             log.debug(
@@ -722,7 +720,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 + "Set merge_includes=False to prevent this."
             )
             return None
-        # end
+        # END stop if we have include files
 
         fp = self._file_or_files
 
@@ -904,7 +902,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         new_section = self._sections[new_name]
         for k, vs in self.items_all(section):
             new_section.setall(k, vs)
-        # end for each value to copy
+        # END for each value to copy
 
         # This call writes back the changes, which is why we don't have the respective decorator.
         self.remove_section(section)

--- a/git/config.py
+++ b/git/config.py
@@ -450,7 +450,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
             return v.encode(defenc).decode("unicode_escape")
 
-        # END def string_decode
+        # END string_decode
 
         while True:
             # We assume to read binary!

--- a/git/db.py
+++ b/git/db.py
@@ -1,4 +1,5 @@
-"""Module with our own gitdb implementation - it uses the git command"""
+"""Module with our own gitdb implementation - it uses the git command."""
+
 from git.util import bin_to_hex, hex_to_bin
 from gitdb.base import OInfo, OStream
 from gitdb.db import GitDB
@@ -22,17 +23,17 @@ __all__ = ("GitCmdObjectDB", "GitDB")
 
 
 class GitCmdObjectDB(LooseObjectDB):
-
     """A database representing the default git object store, which includes loose
-    objects, pack files and an alternates file
+    objects, pack files and an alternates file.
 
     It will create objects only in the loose object database.
-    :note: for now, we use the git command to do all the lookup, just until he
-        have packs and the other implementations
+
+    :note: For now, we use the git command to do all the lookup, just until we
+        have packs and the other implementations.
     """
 
     def __init__(self, root_path: PathLike, git: "Git") -> None:
-        """Initialize this instance with the root and a git command"""
+        """Initialize this instance with the root and a git command."""
         super(GitCmdObjectDB, self).__init__(root_path)
         self._git = git
 
@@ -48,11 +49,15 @@ class GitCmdObjectDB(LooseObjectDB):
     # { Interface
 
     def partial_to_complete_sha_hex(self, partial_hexsha: str) -> bytes:
-        """:return: Full binary 20 byte sha from the given partial hexsha
+        """
+        :return: Full binary 20 byte sha from the given partial hexsha
+
         :raise AmbiguousObjectName:
         :raise BadObject:
-        :note: currently we only raise BadObject as git does not communicate
-            AmbiguousObjects separately"""
+
+        :note: Currently we only raise :class:`BadObject` as git does not communicate
+            AmbiguousObjects separately.
+        """
         try:
             hexsha, _typename, _size = self._git.get_object_header(partial_hexsha)
             return hex_to_bin(hexsha)

--- a/git/diff.py
+++ b/git/diff.py
@@ -486,10 +486,12 @@ class Diff(object):
 
     @classmethod
     def _index_from_patch_format(cls, repo: "Repo", proc: Union["Popen", "Git.AutoInterrupt"]) -> DiffIndex:
-        """Create a new DiffIndex from the given text which must be in patch format
-        :param repo: is the repository we are operating on - it is required
-        :param stream: result of 'git diff' as a stream (supporting file protocol)
-        :return: git.DiffIndex"""
+        """Create a new DiffIndex from the given process output which must be in patch format.
+
+        :param repo: The repository we are operating on
+        :param proc: ``git diff`` process to read from (supports :class:`Git.AutoInterrupt` wrapper)
+        :return: git.DiffIndex
+        """
 
         ## FIXME: Here SLURPING raw, need to re-phrase header-regexes linewise.
         text_list: List[bytes] = []
@@ -644,8 +646,12 @@ class Diff(object):
 
     @classmethod
     def _index_from_raw_format(cls, repo: "Repo", proc: "Popen") -> "DiffIndex":
-        """Create a new DiffIndex from the given stream which must be in raw format.
-        :return: git.DiffIndex"""
+        """Create a new DiffIndex from the given process output which must be in raw format.
+
+        :param repo: The repository we are operating on
+        :param proc: Process to read output from
+        :return: git.DiffIndex
+        """
         # handles
         # :100644 100644 687099101... 37c5e30c8... M    .gitignore
 

--- a/git/diff.py
+++ b/git/diff.py
@@ -467,7 +467,7 @@ class Diff:
     @property
     def renamed(self) -> bool:
         """
-        :returns: True if the blob of our diff has been renamed
+        :return: True if the blob of our diff has been renamed
 
         :note: This property is deprecated.
             Please use the :attr:`renamed_file` property instead.
@@ -476,7 +476,7 @@ class Diff:
 
     @property
     def renamed_file(self) -> bool:
-        """:returns: True if the blob of our diff has been renamed"""
+        """:return: True if the blob of our diff has been renamed"""
         return self.rename_from != self.rename_to
 
     @classmethod

--- a/git/diff.py
+++ b/git/diff.py
@@ -118,12 +118,12 @@ class Diffable:
             This the item to compare us with.
 
             * If None, we will be compared to the working tree.
-            * If :class:`Treeish <git.index.base.Treeish>`, it will be compared against
-              the respective tree.
-            * If :class:`Index <Diffable.Index>`, it will be compared against the index.
+            * If :class:`~git.index.base.Treeish`, it will be compared against the
+              respective tree.
+            * If :class:`~Diffable.Index`, it will be compared against the index.
             * If :attr:`git.NULL_TREE`, it will compare against the empty tree.
-            * It defaults to :class:`Index <Diffable.Index>` so that the method will not
-              by default fail on bare repositories.
+            * It defaults to :class:`~Diffable.Index` so that the method will not by
+              default fail on bare repositories.
 
         :param paths:
             This a list of paths or a single path to limit the diff to. It will only
@@ -141,11 +141,9 @@ class Diffable:
         :return: git.DiffIndex
 
         :note:
-            On a bare repository, 'other' needs to be provided
-            as :class:`Index <Diffable.Index>`,
-            or as :class:`Tree <git.objects.tree.Tree>`
-            or :class:`Commit <git.objects.commit.Commit>`, or a git command error will
-            occur.
+            On a bare repository, 'other' needs to be provided as
+            :class:`~Diffable.Index`, or as :class:`~git.objects.tree.Tree` or
+            :class:`~git.objects.commit.Commit`, or a git command error will occur.
         """
         args: List[Union[PathLike, Diffable, Type["Diffable.Index"], object]] = []
         args.append("--abbrev=40")  # We need full shas.
@@ -222,7 +220,7 @@ class DiffIndex(List[T_Diff]):
     def iter_change_type(self, change_type: Lit_change_type) -> Iterator[T_Diff]:
         """
         :return:
-            iterator yielding :class:`Diff` instances that match the given `change_type`
+            Iterator yielding :class:`Diff` instances that match the given `change_type`
 
         :param change_type:
             Member of :attr:`DiffIndex.change_type`, namely:

--- a/git/diff.py
+++ b/git/diff.py
@@ -50,7 +50,7 @@ Lit_change_type = Literal["A", "D", "C", "M", "R", "T", "U"]
 
 __all__ = ("Diffable", "DiffIndex", "Diff", "NULL_TREE")
 
-# Special object to compare against the empty tree in diffs
+# Special object to compare against the empty tree in diffs.
 NULL_TREE = object()
 
 _octal_byte_re = re.compile(rb"\\([0-9]{3})")
@@ -80,27 +80,28 @@ def decode_path(path: bytes, has_ab_prefix: bool = True) -> Optional[bytes]:
 
 
 class Diffable(object):
-
-    """Common interface for all object that can be diffed against another object of compatible type.
+    """Common interface for all objects that can be diffed against another object of
+    compatible type.
 
     :note:
-        Subclasses require a repo member as it is the case for Object instances, for practical
-        reasons we do not derive from Object."""
+        Subclasses require a repo member as it is the case for Object instances, for
+        practical reasons we do not derive from Object.
+    """
 
     __slots__ = ()
 
-    # standin indicating you want to diff against the index
     class Index(object):
-        pass
+        """Stand-in indicating you want to diff against the index."""
 
     def _process_diff_args(
         self, args: List[Union[str, "Diffable", Type["Diffable.Index"], object]]
     ) -> List[Union[str, "Diffable", Type["Diffable.Index"], object]]:
         """
         :return:
-            possibly altered version of the given args list.
-            Method is called right before git command execution.
-            Subclasses can use it to alter the behaviour of the superclass"""
+            Possibly altered version of the given args list.
+            This method is called right before git command execution.
+            Subclasses can use it to alter the behaviour of the superclass.
+        """
         return args
 
     def diff(
@@ -110,41 +111,47 @@ class Diffable(object):
         create_patch: bool = False,
         **kwargs: Any,
     ) -> "DiffIndex":
-        """Creates diffs between two items being trees, trees and index or an
-        index and the working tree. It will detect renames automatically.
+        """Create diffs between two items being trees, trees and index or an
+        index and the working tree. Detects renames automatically.
 
         :param other:
-            Is the item to compare us with.
-            If None, we will be compared to the working tree.
-            If Treeish, it will be compared against the respective tree
-            If Index ( type ), it will be compared against the index.
-            If git.NULL_TREE, it will compare against the empty tree.
-            It defaults to Index to assure the method will not by-default fail
-            on bare repositories.
+            This the item to compare us with.
+
+            * If None, we will be compared to the working tree.
+            * If :class:`Treeish <git.index.base.Treeish>`, it will be compared against
+              the respective tree.
+            * If :class:`Index <Diffable.Index>`, it will be compared against the index.
+            * If :attr:`git.NULL_TREE`, it will compare against the empty tree.
+            * It defaults to :class:`Index <Diffable.Index>` to assure the method will
+              not by-default fail on bare repositories.
 
         :param paths:
-            is a list of paths or a single path to limit the diff to.
-            It will only include at least one of the given path or paths.
+            This a list of paths or a single path to limit the diff to. It will only
+            include at least one of the given path or paths.
 
         :param create_patch:
-            If True, the returned Diff contains a detailed patch that if applied
-            makes the self to other. Patches are somewhat costly as blobs have to be read
-            and diffed.
+            If True, the returned :class:`Diff` contains a detailed patch that if
+            applied makes the self to other. Patches are somewhat costly as blobs have
+            to be read and diffed.
 
         :param kwargs:
-            Additional arguments passed to git-diff, such as
-            R=True to swap both sides of the diff.
+            Additional arguments passed to git-diff, such as ``R=True`` to swap both
+            sides of the diff.
 
         :return: git.DiffIndex
 
         :note:
-            On a bare repository, 'other' needs to be provided as Index or as
-            as Tree/Commit, or a git command error will occur"""
+            On a bare repository, 'other' needs to be provided
+            as :class:`Index <Diffable.Index>`,
+            or as :class:`Tree <git.objects.tree.Tree>`
+            or :class:`Commit <git.objects.commit.Commit>`, or a git command error will
+            occur.
+        """
         args: List[Union[PathLike, Diffable, Type["Diffable.Index"], object]] = []
-        args.append("--abbrev=40")  # we need full shas
-        args.append("--full-index")  # get full index paths, not only filenames
+        args.append("--abbrev=40")  # We need full shas.
+        args.append("--full-index")  # Get full index paths, not only filenames.
 
-        # remove default '-M' arg (check for renames) if user is overriding it
+        # Remove default '-M' arg (check for renames) if user is overriding it.
         if not any(x in kwargs for x in ("find_renames", "no_renames", "M")):
             args.append("-M")
 
@@ -154,8 +161,8 @@ class Diffable(object):
             args.append("--raw")
             args.append("-z")
 
-        # in any way, assure we don't see colored output,
-        # fixes https://github.com/gitpython-developers/GitPython/issues/172
+        # Ensure we never see colored output.
+        # Fixes: https://github.com/gitpython-developers/GitPython/issues/172
         args.append("--no-color")
 
         if paths is not None and not isinstance(paths, (tuple, list)):
@@ -168,17 +175,17 @@ class Diffable(object):
         if other is self.Index:
             args.insert(0, "--cached")
         elif other is NULL_TREE:
-            args.insert(0, "-r")  # recursive diff-tree
+            args.insert(0, "-r")  # Recursive diff-tree.
             args.insert(0, "--root")
             diff_cmd = self.repo.git.diff_tree
         elif other is not None:
-            args.insert(0, "-r")  # recursive diff-tree
+            args.insert(0, "-r")  # Recursive diff-tree.
             args.insert(0, other)
             diff_cmd = self.repo.git.diff_tree
 
         args.insert(0, self)
 
-        # paths is list here or None
+        # paths is list here, or None.
         if paths:
             args.append("--")
             args.extend(paths)
@@ -198,13 +205,13 @@ T_Diff = TypeVar("T_Diff", bound="Diff")
 
 
 class DiffIndex(List[T_Diff]):
+    """An Index for diffs, allowing a list of Diffs to be queried by the diff
+    properties.
 
-    """Implements an Index for diffs, allowing a list of Diffs to be queried by
-    the diff properties.
+    The class improves the diff handling convenience.
+    """
 
-    The class improves the diff handling convenience"""
-
-    # change type invariant identifying possible ways a blob can have changed
+    # Change type invariant identifying possible ways a blob can have changed:
     # A = Added
     # D = Deleted
     # R = Renamed
@@ -215,10 +222,10 @@ class DiffIndex(List[T_Diff]):
     def iter_change_type(self, change_type: Lit_change_type) -> Iterator[T_Diff]:
         """
         :return:
-            iterator yielding Diff instances that match the given change_type
+            iterator yielding :class:`Diff` instances that match the given `change_type`
 
         :param change_type:
-            Member of DiffIndex.change_type, namely:
+            Member of :attr:`DiffIndex.change_type`, namely:
 
             * 'A' for added paths
             * 'D' for deleted paths
@@ -246,11 +253,10 @@ class DiffIndex(List[T_Diff]):
 
 
 class Diff(object):
-
     """A Diff contains diff information between two Trees.
 
     It contains two sides a and b of the diff, members are prefixed with
-    "a" and "b" respectively to inidcate that.
+    "a" and "b" respectively to indicate that.
 
     Diffs keep information about the changed blob objects, the file mode, renames,
     deletions and new files.
@@ -273,11 +279,13 @@ class Diff(object):
 
         When comparing to working trees, the working tree blob will have a null hexsha
         as a corresponding object does not yet exist. The mode will be null as well.
-        But the path will be available though.
-        If it is listed in a diff the working tree version of the file must
-        be different to the version in the index or tree, and hence has been modified."""
+        The path will be available, though.
 
-    # precompiled regex
+        If it is listed in a diff, the working tree version of the file must
+        differ from the version in the index or tree, and hence has been modified.
+    """
+
+    # Precompiled regex.
     re_header = re.compile(
         rb"""
                                 ^diff[ ]--git
@@ -299,7 +307,8 @@ class Diff(object):
                             """,
         re.VERBOSE | re.MULTILINE,
     )
-    # can be used for comparisons
+
+    # These can be used for comparisons.
     NULL_HEX_SHA = "0" * 40
     NULL_BIN_SHA = b"\0" * 20
 
@@ -346,8 +355,8 @@ class Diff(object):
         self.a_mode = mode_str_to_int(a_mode) if a_mode else None
         self.b_mode = mode_str_to_int(b_mode) if b_mode else None
 
-        # Determine whether this diff references a submodule, if it does then
-        # we need to overwrite "repo" to the corresponding submodule's repo instead
+        # Determine whether this diff references a submodule. If it does then
+        # we need to overwrite "repo" to the corresponding submodule's repo instead.
         if repo and a_rawpath:
             for submodule in repo.submodules:
                 if submodule.path == a_rawpath.decode(defenc, "replace"):
@@ -371,7 +380,7 @@ class Diff(object):
         self.deleted_file: bool = deleted_file
         self.copied_file: bool = copied_file
 
-        # be clear and use None instead of empty strings
+        # Be clear and use None instead of empty strings.
         assert raw_rename_from is None or isinstance(raw_rename_from, bytes)
         assert raw_rename_to is None or isinstance(raw_rename_to, bytes)
         self.raw_rename_from = raw_rename_from or None
@@ -395,15 +404,15 @@ class Diff(object):
         return hash(tuple(getattr(self, n) for n in self.__slots__))
 
     def __str__(self) -> str:
-        h: str = "%s"
+        h = "%s"
         if self.a_blob:
             h %= self.a_blob.path
         elif self.b_blob:
             h %= self.b_blob.path
 
-        msg: str = ""
-        line = None  # temp line
-        line_length = 0  # line length
+        msg = ""
+        line = None
+        line_length = 0
         for b, n in zip((self.a_blob, self.b_blob), ("lhs", "rhs")):
             if b:
                 line = "\n%s: %o | %s" % (n, b.mode, b.hexsha)
@@ -414,7 +423,7 @@ class Diff(object):
             msg += line
         # END for each blob
 
-        # add headline
+        # Add headline.
         h += "\n" + "=" * line_length
 
         if self.deleted_file:
@@ -437,11 +446,7 @@ class Diff(object):
             msg += "\n---"
         # END diff info
 
-        # Python2 silliness: have to assure we convert our likely to be unicode object to a string with the
-        # right encoding. Otherwise it tries to convert it using ascii, which may fail ungracefully
-        res = h + msg
-        # end
-        return res
+        return h + msg
 
     @property
     def a_path(self) -> Optional[str]:
@@ -461,8 +466,11 @@ class Diff(object):
 
     @property
     def renamed(self) -> bool:
-        """:returns: True if the blob of our diff has been renamed
-        :note: This property is deprecated, please use ``renamed_file`` instead.
+        """
+        :returns: True if the blob of our diff has been renamed
+
+        :note: This property is deprecated.
+            Please use the :attr:`renamed_file` property instead.
         """
         return self.renamed_file
 
@@ -493,17 +501,17 @@ class Diff(object):
         :return: git.DiffIndex
         """
 
-        ## FIXME: Here SLURPING raw, need to re-phrase header-regexes linewise.
+        # FIXME: Here SLURPING raw, need to re-phrase header-regexes linewise.
         text_list: List[bytes] = []
         handle_process_output(proc, text_list.append, None, finalize_process, decode_streams=False)
 
-        # for now, we have to bake the stream
+        # For now, we have to bake the stream.
         text = b"".join(text_list)
         index: "DiffIndex" = DiffIndex()
         previous_header: Union[Match[bytes], None] = None
         header: Union[Match[bytes], None] = None
-        a_path, b_path = None, None  # for mypy
-        a_mode, b_mode = None, None  # for mypy
+        a_path, b_path = None, None  # For mypy.
+        a_mode, b_mode = None, None  # For mypy.
         for _header in cls.re_header.finditer(text):
             (
                 a_path_fallback,
@@ -532,13 +540,13 @@ class Diff(object):
             b_path = cls._pick_best_path(b_path, rename_to, b_path_fallback)
 
             # Our only means to find the actual text is to see what has not been matched by our regex,
-            # and then retro-actively assign it to our index
+            # and then retro-actively assign it to our index.
             if previous_header is not None:
                 index[-1].diff = text[previous_header.end() : _header.start()]
             # end assign actual diff
 
-            # Make sure the mode is set if the path is set. Otherwise the resulting blob is invalid
-            # We just use the one mode we should have parsed
+            # Make sure the mode is set if the path is set. Otherwise the resulting blob is invalid.
+            # We just use the one mode we should have parsed.
             a_mode = old_mode or deleted_file_mode or (a_path and (b_mode or new_mode or new_file_mode))
             b_mode = b_mode or new_mode or new_file_mode or (b_path and a_mode)
             index.append(
@@ -579,7 +587,7 @@ class Diff(object):
 
         for line in lines.split("\x00:"):
             if not line:
-                # The line data is empty, skip
+                # The line data is empty, skip.
                 continue
             meta, _, path = line.partition("\x00")
             path = path.rstrip("\x00")
@@ -603,7 +611,7 @@ class Diff(object):
             rename_to = None
 
             # NOTE: We cannot conclude from the existence of a blob to change type
-            # as diffs with the working do not have blobs yet
+            # as diffs with the working do not have blobs yet.
             if change_type == "D":
                 b_blob_id = None  # Optional[str]
                 deleted_file = True
@@ -621,7 +629,7 @@ class Diff(object):
                 b_path = b_path_str.encode(defenc)
                 rename_from, rename_to = a_path, b_path
             elif change_type == "T":
-                # Nothing to do
+                # Nothing to do.
                 pass
             # END add/remove handling
 

--- a/git/diff.py
+++ b/git/diff.py
@@ -79,7 +79,7 @@ def decode_path(path: bytes, has_ab_prefix: bool = True) -> Optional[bytes]:
     return path
 
 
-class Diffable(object):
+class Diffable:
     """Common interface for all objects that can be diffed against another object of
     compatible type.
 
@@ -90,7 +90,7 @@ class Diffable(object):
 
     __slots__ = ()
 
-    class Index(object):
+    class Index:
         """Stand-in indicating you want to diff against the index."""
 
     def _process_diff_args(
@@ -252,7 +252,7 @@ class DiffIndex(List[T_Diff]):
         # END for each diff
 
 
-class Diff(object):
+class Diff:
     """A Diff contains diff information between two Trees.
 
     It contains two sides a and b of the diff, members are prefixed with

--- a/git/diff.py
+++ b/git/diff.py
@@ -442,7 +442,7 @@ class Diff:
                 msg += self.diff.decode(defenc) if isinstance(self.diff, bytes) else self.diff
             except UnicodeDecodeError:
                 msg += "OMITTED BINARY DATA"
-            # end handle encoding
+            # END handle encoding
             msg += "\n---"
         # END diff info
 
@@ -543,7 +543,7 @@ class Diff:
             # and then retro-actively assign it to our index.
             if previous_header is not None:
                 index[-1].diff = text[previous_header.end() : _header.start()]
-            # end assign actual diff
+            # END assign actual diff
 
             # Make sure the mode is set if the path is set. Otherwise the resulting blob is invalid.
             # We just use the one mode we should have parsed.
@@ -571,10 +571,10 @@ class Diff:
 
             previous_header = _header
             header = _header
-        # end for each header we parse
+        # END for each header we parse
         if index and header:
             index[-1].diff = text[header.end() :]
-        # end assign last diff
+        # END assign last diff
 
         return index
 

--- a/git/diff.py
+++ b/git/diff.py
@@ -53,7 +53,7 @@ __all__ = ("Diffable", "DiffIndex", "Diff", "NULL_TREE")
 # Special object to compare against the empty tree in diffs
 NULL_TREE = object()
 
-_octal_byte_re = re.compile(b"\\\\([0-9]{3})")
+_octal_byte_re = re.compile(rb"\\([0-9]{3})")
 
 
 def _octal_repl(matchobj: Match) -> bytes:

--- a/git/diff.py
+++ b/git/diff.py
@@ -122,8 +122,8 @@ class Diffable:
               the respective tree.
             * If :class:`Index <Diffable.Index>`, it will be compared against the index.
             * If :attr:`git.NULL_TREE`, it will compare against the empty tree.
-            * It defaults to :class:`Index <Diffable.Index>` to assure the method will
-              not by-default fail on bare repositories.
+            * It defaults to :class:`Index <Diffable.Index>` so that the method will not
+              by default fail on bare repositories.
 
         :param paths:
             This a list of paths or a single path to limit the diff to. It will only

--- a/git/exc.py
+++ b/git/exc.py
@@ -3,7 +3,8 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
-""" Module containing all exceptions thrown throughout the git package """
+
+"""Module containing all exceptions thrown throughout the git package."""
 
 __all__ = [
     # Defined in gitdb.exc:
@@ -57,7 +58,7 @@ if TYPE_CHECKING:
 
 
 class GitError(Exception):
-    """Base class for all package exceptions"""
+    """Base class for all package exceptions."""
 
 
 class InvalidGitRepositoryError(GitError):
@@ -65,7 +66,7 @@ class InvalidGitRepositoryError(GitError):
 
 
 class WorkTreeRepositoryUnsupported(InvalidGitRepositoryError):
-    """Thrown to indicate we can't handle work tree repositories"""
+    """Thrown to indicate we can't handle work tree repositories."""
 
 
 class NoSuchPathError(GitError, OSError):
@@ -133,7 +134,7 @@ class CommandError(GitError):
 
 class GitCommandNotFound(CommandError):
     """Thrown if we cannot find the `git` executable in the PATH or at the path given by
-    the GIT_PYTHON_GIT_EXECUTABLE environment variable"""
+    the GIT_PYTHON_GIT_EXECUTABLE environment variable."""
 
     def __init__(self, command: Union[List[str], Tuple[str], str], cause: Union[str, Exception]) -> None:
         super(GitCommandNotFound, self).__init__(command, cause)
@@ -157,15 +158,15 @@ class CheckoutError(GitError):
     """Thrown if a file could not be checked out from the index as it contained
     changes.
 
-    The .failed_files attribute contains a list of relative paths that failed
-    to be checked out as they contained changes that did not exist in the index.
+    The :attr:`failed_files` attribute contains a list of relative paths that failed to
+    be checked out as they contained changes that did not exist in the index.
 
-    The .failed_reasons attribute contains a string informing about the actual
+    The :attr:`failed_reasons` attribute contains a string informing about the actual
     cause of the issue.
 
-    The .valid_files attribute contains a list of relative paths to files that
-    were checked out successfully and hence match the version stored in the
-    index"""
+    The :attr:`valid_files` attribute contains a list of relative paths to files that
+    were checked out successfully and hence match the version stored in the index.
+    """
 
     def __init__(
         self,
@@ -184,18 +185,20 @@ class CheckoutError(GitError):
 
 
 class CacheError(GitError):
-
-    """Base for all errors related to the git index, which is called cache internally"""
+    """Base for all errors related to the git index, which is called cache
+    internally."""
 
 
 class UnmergedEntriesError(CacheError):
     """Thrown if an operation cannot proceed as there are still unmerged
-    entries in the cache"""
+    entries in the cache."""
 
 
 class HookExecutionError(CommandError):
-    """Thrown if a hook exits with a non-zero exit code. It provides access to the exit code and the string returned
-    via standard output"""
+    """Thrown if a hook exits with a non-zero exit code.
+
+    This provides access to the exit code and the string returned via standard output.
+    """
 
     def __init__(
         self,
@@ -209,7 +212,8 @@ class HookExecutionError(CommandError):
 
 
 class RepositoryDirtyError(GitError):
-    """Thrown whenever an operation on a repository fails as it has uncommitted changes that would be overwritten"""
+    """Thrown whenever an operation on a repository fails as it has uncommitted changes
+    that would be overwritten."""
 
     def __init__(self, repo: "Repo", message: str) -> None:
         self.repo = repo

--- a/git/index/__init__.py
+++ b/git/index/__init__.py
@@ -1,4 +1,6 @@
-"""Initialize the index package"""
+"""Initialize the index package."""
+
 # flake8: noqa
+
 from .base import *
 from .typ import *

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1300,7 +1300,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             but if True, this method behaves like HEAD.reset.
 
         :param paths: if given as an iterable of absolute or repository-relative paths,
-            only these will be reset to their state at the given commit'ish.
+            only these will be reset to their state at the given commit-ish.
             The paths need to exist at the commit, otherwise an exception will be
             raised.
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -868,6 +868,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     # END for each entry index
 
                 # END closure
+
                 handle_null_entries(self)
             # END null_entry handling
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -406,7 +406,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 if S_ISLNK(st.st_mode):
                     yield abs_path.replace(rs, "")
                     continue
-            # end check symlink
+            # END check symlink
 
             # If the path is not already pointing to an existing file, resolve globs if possible.
             if not os.path.exists(abs_path) and ("?" in abs_path or "*" in abs_path or "[" in abs_path):
@@ -689,7 +689,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     gitrelative_path = path
                     if self.repo.working_tree_dir:
                         abspath = osp.join(self.repo.working_tree_dir, gitrelative_path)
-                # end obtain relative and absolute paths
+                # END obtain relative and absolute paths
 
                 blob = Blob(
                     self.repo,
@@ -867,7 +867,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                         )
                     # END for each entry index
 
-                # end closure
+                # END closure
                 handle_null_entries(self)
             # END null_entry handling
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1,4 +1,4 @@
-# index.py
+# base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -95,12 +95,11 @@ __all__ = ("IndexFile", "CheckoutError", "StageType")
 
 
 class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
-
     """
-    Implements an Index that can be manipulated using a native implementation in
-    order to save git command function calls wherever possible.
+    An Index that can be manipulated using a native implementation in order to save git
+    command function calls wherever possible.
 
-    It provides custom merging facilities allowing to merge without actually changing
+    This provides custom merging facilities allowing to merge without actually changing
     your index or your working tree. This way you can perform own test-merges based
     on the index only without having to deal with the working copy. This is useful
     in case of partial working trees.
@@ -115,18 +114,23 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         index.entries[index.entry_key(index_entry_instance)] = index_entry_instance
 
     Make sure you use index.write() once you are done manipulating the index directly
-    before operating on it using the git command"""
+    before operating on it using the git command.
+    """
 
     __slots__ = ("repo", "version", "entries", "_extension_data", "_file_path")
-    _VERSION = 2  # latest version we support
-    S_IFGITLINK = S_IFGITLINK  # a submodule
+
+    _VERSION = 2  # Latest version we support.
+
+    S_IFGITLINK = S_IFGITLINK  # A submodule.
 
     def __init__(self, repo: "Repo", file_path: Union[PathLike, None] = None) -> None:
         """Initialize this Index instance, optionally from the given ``file_path``.
+
         If no file_path is given, we will be created from the current index file.
 
         If a stream is not given, the stream will be initialized from the current
-        repository's index on demand."""
+        repository's index on demand.
+        """
         self.repo = repo
         self.version = self._VERSION
         self._extension_data = b""
@@ -137,7 +141,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             try:
                 fd = os.open(self._file_path, os.O_RDONLY)
             except OSError:
-                # in new repositories, there may be no index, which means we are empty
+                # In new repositories, there may be no index, which means we are empty.
                 self.entries: Dict[Tuple[PathLike, StageType], IndexEntry] = {}
                 return None
             # END exception handling
@@ -163,18 +167,19 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return self._file_path
 
     def _delete_entries_cache(self) -> None:
-        """Safely clear the entries cache so it can be recreated"""
+        """Safely clear the entries cache so it can be recreated."""
         try:
             del self.entries
         except AttributeError:
-            # fails in python 2.6.5 with this exception
+            # It failed in Python 2.6.5 with AttributeError.
+            # FIXME: Look into whether we can just remove this except clause now.
             pass
         # END exception handling
 
     # { Serializable Interface
 
     def _deserialize(self, stream: IO) -> "IndexFile":
-        """Initialize this instance with index values read from the given stream"""
+        """Initialize this instance with index values read from the given stream."""
         self.version, self.entries, self._extension_data, _conten_sha = read_cache(stream)
         return self
 
@@ -197,7 +202,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         file_path: Union[None, PathLike] = None,
         ignore_extension_data: bool = False,
     ) -> None:
-        """Write the current state to our file path or to the given one
+        """Write the current state to our file path or to the given one.
 
         :param file_path:
             If None, we will write to our stored file path from which we have
@@ -214,12 +219,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             If this data is present in the written index, git-write-tree
             will instead write the stored/cached tree.
             Alternatively, use IndexFile.write_tree() to handle this case
-            automatically
-
-        :return: self  # does it? or returns None?"""
-        # make sure we have our entries read before getting a write lock
-        # else it would be done when streaming. This can happen
-        # if one doesn't change the index, but writes it right away
+            automatically.
+        """
+        # Make sure we have our entries read before getting a write lock.
+        # Otherwise it would be done when streaming. This can happen if one
+        # doesn't change the index, but writes it right away.
         self.entries
         lfd = LockedFD(file_path or self._file_path)
         stream = lfd.open(write=True, stream=True)
@@ -232,7 +236,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         lfd.commit()
 
-        # make sure we represent what we have written
+        # Make sure we represent what we have written.
         if file_path is not None:
             self._file_path = file_path
 
@@ -242,26 +246,26 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Merge the given rhs treeish into the current index, possibly taking
         a common base treeish into account.
 
-        As opposed to the :func:`IndexFile.from_tree` method, this allows you to use an already
-        existing tree as the left side of the merge
+        As opposed to the :func:`IndexFile.from_tree` method, this allows you to use an
+        already existing tree as the left side of the merge.
 
         :param rhs:
-            treeish reference pointing to the 'other' side of the merge.
+            Treeish reference pointing to the 'other' side of the merge.
 
         :param base:
-            optional treeish reference pointing to the common base of 'rhs' and
-            this index which equals lhs
+            Optional treeish reference pointing to the common base of 'rhs' and this
+            index which equals lhs.
 
         :return:
-            self ( containing the merge and possibly unmerged entries in case of
-            conflicts )
+            self (containing the merge and possibly unmerged entries in case of
+            conflicts)
 
         :raise GitCommandError:
-            If there is a merge conflict. The error will
-            be raised at the first conflicting path. If you want to have proper
-            merge resolution to be done by yourself, you have to commit the changed
-            index ( or make a valid tree from it ) and retry with a three-way
-            index.from_tree call."""
+            If there is a merge conflict. The error will be raised at the first
+            conflicting path. If you want to have proper merge resolution to be done by
+            yourself, you have to commit the changed index (or make a valid tree from
+            it) and retry with a three-way index.from_tree call.
+        """
         # -i : ignore working tree status
         # --aggressive : handle more merge cases
         # -m : do an actual merge
@@ -276,22 +280,24 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     @classmethod
     def new(cls, repo: "Repo", *tree_sha: Union[str, Tree]) -> "IndexFile":
         """Merge the given treeish revisions into a new index which is returned.
-        This method behaves like git-read-tree --aggressive when doing the merge.
+
+        This method behaves like ``git-read-tree --aggressive`` when doing the merge.
 
         :param repo: The repository treeish are located in.
 
         :param tree_sha:
-            20 byte or 40 byte tree sha or tree objects
+            20 byte or 40 byte tree sha or tree objects.
 
         :return:
             New IndexFile instance. Its path will be undefined.
             If you intend to write such a merged Index, supply an alternate file_path
-            to its 'write' method."""
+            to its 'write' method.
+        """
         tree_sha_bytes: List[bytes] = [to_bin_sha(str(t)) for t in tree_sha]
         base_entries = aggressive_tree_merge(repo.odb, tree_sha_bytes)
 
         inst = cls(repo)
-        # convert to entries dict
+        # Convert to entries dict.
         entries: Dict[Tuple[PathLike, int], IndexEntry] = dict(
             zip(
                 ((e.path, e.stage) for e in base_entries),
@@ -305,7 +311,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     @classmethod
     def from_tree(cls, repo: "Repo", *treeish: Treeish, **kwargs: Any) -> "IndexFile":
         """Merge the given treeish revisions into a new index which is returned.
-        The original index will remain unaltered
+        The original index will remain unaltered.
 
         :param repo:
             The repository treeish are located in.
@@ -319,10 +325,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             one. It behaves like a fast-forward.
             If 3 Trees are given, a 3-way merge will be performed with the first tree
             being the common ancestor of tree 2 and tree 3. Tree 2 is the 'current' tree,
-            tree 3 is the 'other' one
+            tree 3 is the 'other' one.
 
         :param kwargs:
-            Additional arguments passed to git-read-tree
+            Additional arguments passed to git-read-tree.
 
         :return:
             New IndexFile instance. It will point to a temporary index location which
@@ -336,46 +342,49 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
             As the underlying git-read-tree command takes into account the current index,
             it will be temporarily moved out of the way to assure there are no unsuspected
-            interferences."""
+            interferences.
+        """
         if len(treeish) == 0 or len(treeish) > 3:
             raise ValueError("Please specify between 1 and 3 treeish, got %i" % len(treeish))
 
         arg_list: List[Union[Treeish, str]] = []
-        # ignore that working tree and index possibly are out of date
+        # Ignore that the working tree and index possibly are out of date.
         if len(treeish) > 1:
-            # drop unmerged entries when reading our index and merging
+            # Drop unmerged entries when reading our index and merging.
             arg_list.append("--reset")
-            # handle non-trivial cases the way a real merge does
+            # Handle non-trivial cases the way a real merge does.
             arg_list.append("--aggressive")
         # END merge handling
 
         # tmp file created in git home directory to be sure renaming
-        # works - /tmp/ dirs could be on another device
+        # works - /tmp/ dirs could be on another device.
         with ExitStack() as stack:
             tmp_index = stack.enter_context(tempfile.NamedTemporaryFile(dir=repo.git_dir))
             arg_list.append("--index-output=%s" % tmp_index.name)
             arg_list.extend(treeish)
 
-            # move current index out of the way - otherwise the merge may fail
-            # as it considers existing entries. moving it essentially clears the index.
+            # Move current index out of the way - otherwise the merge may fail
+            # as it considers existing entries. Moving it essentially clears the index.
             # Unfortunately there is no 'soft' way to do it.
-            # The TemporaryFileSwap assure the original file get put back
+            # The TemporaryFileSwap assure the original file get put back.
 
             stack.enter_context(TemporaryFileSwap(join_path_native(repo.git_dir, "index")))
             repo.git.read_tree(*arg_list, **kwargs)
             index = cls(repo, tmp_index.name)
-            index.entries  # force it to read the file as we will delete the temp-file
+            index.entries  # Force it to read the file as we will delete the temp-file.
             return index
             # END index merge handling
 
     # UTILITIES
     @unbare_repo
     def _iter_expand_paths(self: "IndexFile", paths: Sequence[PathLike]) -> Iterator[PathLike]:
-        """Expand the directories in list of paths to the corresponding paths accordingly,
+        """Expand the directories in list of paths to the corresponding paths accordingly.
 
-        Note: git will add items multiple times even if a glob overlapped
-        with manually specified paths or if paths where specified multiple
-        times - we respect that and do not prune"""
+        :note:
+            git will add items multiple times even if a glob overlapped
+            with manually specified paths or if paths where specified multiple
+            times - we respect that and do not prune.
+        """
 
         def raise_exc(e: Exception) -> NoReturn:
             raise e
@@ -389,9 +398,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # END make absolute path
 
             try:
-                st = os.lstat(abs_path)  # handles non-symlinks as well
+                st = os.lstat(abs_path)  # Handles non-symlinks as well.
             except OSError:
-                # the lstat call may fail as the path may contain globs as well
+                # The lstat call may fail as the path may contain globs as well.
                 pass
             else:
                 if S_ISLNK(st.st_mode):
@@ -399,7 +408,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     continue
             # end check symlink
 
-            # if the path is not already pointing to an existing file, resolve globs if possible
+            # If the path is not already pointing to an existing file, resolve globs if possible.
             if not os.path.exists(abs_path) and ("?" in abs_path or "*" in abs_path or "[" in abs_path):
                 resolved_paths = glob.glob(abs_path)
                 # not abs_path in resolved_paths:
@@ -416,12 +425,12 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             try:
                 for root, _dirs, files in os.walk(abs_path, onerror=raise_exc):
                     for rela_file in files:
-                        # add relative paths only
+                        # Add relative paths only.
                         yield osp.join(root.replace(rs, ""), rela_file)
                     # END for each file in subdir
                 # END for each subdirectory
             except OSError:
-                # was a file or something that could not be iterated
+                # It was a file or something that could not be iterated.
                 yield abs_path.replace(rs, "")
             # END path exception handling
         # END for each path
@@ -438,17 +447,20 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Write path to proc.stdin and make sure it processes the item, including progress.
 
         :return: stdout string
+
         :param read_from_stdout: if True, proc.stdout will be read after the item
-            was sent to stdin. In that case, it will return None
+            was sent to stdin. In that case, it will return None.
+
         :note: There is a bug in git-update-index that prevents it from sending
             reports just in time. This is why we have a version that tries to
             read stdout and one which doesn't. In fact, the stdout is not
-            important as the piped-in files are processed anyway and just in time
+            important as the piped-in files are processed anyway and just in time.
+
         :note: Newlines are essential here, gits behaviour is somewhat inconsistent
             on this depending on the version, hence we try our best to deal with
             newlines carefully. Usually the last newline will not be sent, instead
-            we will close stdin to break the pipe."""
-
+            we will close stdin to break the pipe.
+        """
         fprogress(filepath, False, item)
         rval: Union[None, str] = None
 
@@ -456,7 +468,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             try:
                 proc.stdin.write(("%s\n" % filepath).encode(defenc))
             except IOError as e:
-                # pipe broke, usually because some error happened
+                # Pipe broke, usually because some error happened.
                 raise fmakeexc() from e
             # END write exception handling
             proc.stdin.flush()
@@ -475,7 +487,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         :param predicate:
             Function(t) returning True if tuple(stage, Blob) should be yielded by the
             iterator. A default filter, the BlobFilter, allows you to yield blobs
-            only if they match a given list of paths."""
+            only if they match a given list of paths.
+        """
         for entry in self.entries.values():
             blob = entry.to_blob(self.repo)
             blob.size = entry.size
@@ -489,8 +502,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         :return:
             Dict(path : list( tuple( stage, Blob, ...))), being
             a dictionary associating a path in the index with a list containing
-            sorted stage/blob pairs
-
+            sorted stage/blob pairs.
 
         :note:
             Blobs that have been removed in one side simply do not exist in the
@@ -512,19 +524,21 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return entry_key(*entry)
 
     def resolve_blobs(self, iter_blobs: Iterator[Blob]) -> "IndexFile":
-        """Resolve the blobs given in blob iterator. This will effectively remove the
-        index entries of the respective path at all non-null stages and add the given
-        blob as new stage null blob.
+        """Resolve the blobs given in blob iterator.
+
+        This will effectively remove the index entries of the respective path at all
+        non-null stages and add the given blob as new stage null blob.
 
         For each path there may only be one blob, otherwise a ValueError will be raised
         claiming the path is already at stage 0.
 
         :raise ValueError: if one of the blobs already existed at stage 0
+
         :return: self
 
         :note:
             You will have to write the index manually once you are done, i.e.
-            index.resolve_blobs(blobs).write()
+            ``index.resolve_blobs(blobs).write()``.
         """
         for blob in iter_blobs:
             stage_null_key = (blob.path, 0)
@@ -532,7 +546,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 raise ValueError("Path %r already exists at stage 0" % str(blob.path))
             # END assert blob is not stage 0 already
 
-            # delete all possible stages
+            # Delete all possible stages.
             for stage in (1, 2, 3):
                 try:
                     del self.entries[(blob.path, stage)]
@@ -550,34 +564,40 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Reread the contents of our index file, discarding all cached information
         we might have.
 
-        :note: This is a possibly dangerious operations as it will discard your changes
-            to index.entries
-        :return: self"""
+        :note: This is a possibly dangerous operations as it will discard your changes
+            to index.entries.
+
+        :return: self
+        """
         self._delete_entries_cache()
-        # allows to lazily reread on demand
+        # Allows to lazily reread on demand.
         return self
 
     def write_tree(self) -> Tree:
-        """Writes this index to a corresponding Tree object into the repository's
+        """Write this index to a corresponding Tree object into the repository's
         object database and return it.
 
-        :return: Tree object representing this index
+        :return: Tree object representing this index.
+
         :note: The tree will be written even if one or more objects the tree refers to
             does not yet exist in the object database. This could happen if you added
             Entries to the index directly.
+
         :raise ValueError: if there are no entries in the cache
-        :raise UnmergedEntriesError:"""
-        # we obtain no lock as we just flush our contents to disk as tree
-        # If we are a new index, the entries access will load our data accordingly
+
+        :raise UnmergedEntriesError:
+        """
+        # We obtain no lock as we just flush our contents to disk as tree.
+        # If we are a new index, the entries access will load our data accordingly.
         mdb = MemoryDB()
         entries = self._entries_sorted()
         binsha, tree_items = write_tree_from_cache(entries, mdb, slice(0, len(entries)))
 
-        # copy changed trees only
+        # Copy changed trees only.
         mdb.stream_copy(mdb.sha_iter(), self.repo.odb)
 
-        # note: additional deserialization could be saved if write_tree_from_cache
-        # would return sorted tree entries
+        # Note: Additional deserialization could be saved if write_tree_from_cache
+        # would return sorted tree entries.
         root_tree = Tree(self.repo, binsha, path="")
         root_tree._cache = tree_items
         return root_tree
@@ -630,9 +650,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     def _store_path(self, filepath: PathLike, fprogress: Callable) -> BaseIndexEntry:
         """Store file at filepath in the database and return the base index entry
         Needs the git_working_dir decorator active ! This must be assured in the calling code"""
-        st = os.lstat(filepath)  # handles non-symlinks as well
+        st = os.lstat(filepath)  # Handles non-symlinks as well.
         if S_ISLNK(st.st_mode):
-            # in PY3, readlink is string, but we need bytes. In PY2, it's just OS encoded bytes, we assume UTF-8
+            # In PY3, readlink is a string, but we need bytes.
+            # In PY2, it was just OS encoded bytes, we assumed UTF-8.
             open_stream: Callable[[], BinaryIO] = lambda: BytesIO(force_bytes(os.readlink(filepath), encoding=defenc))
         else:
             open_stream = lambda: open(filepath, "rb")
@@ -708,51 +729,54 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             relative or absolute.
 
             - path string
-                strings denote a relative or absolute path into the repository pointing to
-                an existing file, i.e. CHANGES, lib/myfile.ext, '/home/gitrepo/lib/myfile.ext'.
+                Strings denote a relative or absolute path into the repository pointing
+                to an existing file, e.g., CHANGES, lib/myfile.ext,
+                '/home/gitrepo/lib/myfile.ext'.
 
-                Absolute paths must start with working tree directory of this index's repository
-                to be considered valid. For example, if it was initialized with a non-normalized path, like
-                `/root/repo/../repo`, absolute paths to be added must start with `/root/repo/../repo`.
+                Absolute paths must start with working tree directory of this index's
+                repository to be considered valid. For example, if it was initialized
+                with a non-normalized path, like ``/root/repo/../repo``, absolute paths
+                to be added must start with ``/root/repo/../repo``.
 
                 Paths provided like this must exist. When added, they will be written
                 into the object database.
 
-                PathStrings may contain globs, such as 'lib/__init__*' or can be directories
-                like 'lib', the latter ones will add all the files within the directory and
-                subdirectories.
+                PathStrings may contain globs, such as ``lib/__init__*``. Or they can be
+                directories like ``lib``, which will add all the files within the
+                directory and subdirectories.
 
                 This equals a straight git-add.
 
-                They are added at stage 0
+                They are added at stage 0.
 
             - Blob or Submodule object
                 Blobs are added as they are assuming a valid mode is set.
-                The file they refer to may or may not exist in the file system, but
-                must be a path relative to our repository.
 
-                If their sha is null ( 40*0 ), their path must exist in the file system
-                relative to the git repository as an object will be created from
-                the data at the path.
-                The handling now very much equals the way string paths are processed, except that
-                the mode you have set will be kept. This allows you to create symlinks
-                by settings the mode respectively and writing the target of the symlink
-                directly into the file. This equals a default Linux-Symlink which
-                is not dereferenced automatically, except that it can be created on
-                filesystems not supporting it as well.
+                The file they refer to may or may not exist in the file system, but must
+                be a path relative to our repository.
+
+                If their sha is null (40*0), their path must exist in the file system
+                relative to the git repository as an object will be created from the
+                data at the path.
+
+                The handling now very much equals the way string paths are processed,
+                except that the mode you have set will be kept. This allows you to
+                create symlinks by settings the mode respectively and writing the target
+                of the symlink directly into the file. This equals a default
+                Linux-Symlink which is not dereferenced automatically, except that it
+                can be created on filesystems not supporting it as well.
 
                 Please note that globs or directories are not allowed in Blob objects.
 
-                They are added at stage 0
+                They are added at stage 0.
 
             - BaseIndexEntry or type
-                Handling equals the one of Blob objects, but the stage may be
-                explicitly set. Please note that Index Entries require binary sha's.
+                Handling equals the one of Blob objects, but the stage may be explicitly
+                set. Please note that Index Entries require binary sha's.
 
         :param force:
             **CURRENTLY INEFFECTIVE**
-            If True, otherwise ignored or excluded files will be
-            added anyway.
+            If True, otherwise ignored or excluded files will be added anyway.
             As opposed to the git-add command, we enable this flag by default
             as the API user usually wants the item to be added even though
             they might be excluded.
@@ -766,26 +790,31 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             in the index already as the index is currently being processed.
 
         :param path_rewriter:
-            Function with signature (string) func(BaseIndexEntry) function returning a path
-            for each passed entry which is the path to be actually recorded for the
-            object created from entry.path. This allows you to write an index which
-            is not identical to the layout of the actual files on your hard-disk.
-            If not None and ``items`` contain plain paths, these paths will be
-            converted to Entries beforehand and passed to the path_rewriter.
-            Please note that entry.path is relative to the git repository.
+            Function with signature (string) func(BaseIndexEntry) function returning a
+            path for each passed entry which is the path to be actually recorded for the
+            object created from entry.path. This allows you to write an index which is
+            not identical to the layout of the actual files on your hard-disk. If not
+            None and ``items`` contain plain paths, these paths will be converted to
+            Entries beforehand and passed to the path_rewriter. Please note that
+            entry.path is relative to the git repository.
 
         :param write:
             If True, the index will be written once it was altered. Otherwise
             the changes only exist in memory and are not available to git commands.
 
         :param write_extension_data:
-            If True, extension data will be written back to the index. This can lead to issues in case
-            it is containing the 'TREE' extension, which will cause the `git commit` command to write an
-            old tree, instead of a new one representing the now changed index.
-            This doesn't matter if you use `IndexFile.commit()`, which ignores the `TREE` extension altogether.
-            You should set it to True if you intend to use `IndexFile.commit()` exclusively while maintaining
-            support for third-party extensions. Besides that, you can usually safely ignore the built-in
-            extensions when using GitPython on repositories that are not handled manually at all.
+            If True, extension data will be written back to the index. This can lead to
+            issues in case it is containing the 'TREE' extension, which will cause the
+            `git commit` command to write an old tree, instead of a new one representing
+            the now changed index.
+
+            This doesn't matter if you use :meth:`IndexFile.commit`, which ignores the
+            `TREE` extension altogether. You should set it to True if you intend to use
+            :meth:`IndexFile.commit` exclusively while maintaining support for
+            third-party extensions. Besides that, you can usually safely ignore the
+            built-in extensions when using GitPython on repositories that are not
+            handled manually at all.
+
             All current built-in extensions are listed here:
             http://opensource.apple.com/source/Git/Git-26/src/git-htmldocs/technical/index-format.txt
 
@@ -793,18 +822,17 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             List(BaseIndexEntries) representing the entries just actually added.
 
         :raise OSError:
-            if a supplied Path did not exist. Please note that BaseIndexEntry
+            If a supplied Path did not exist. Please note that BaseIndexEntry
             Objects that do not have a null sha will be added even if their paths
             do not exist.
         """
-        # sort the entries into strings and Entries, Blobs are converted to entries
-        # automatically
-        # paths can be git-added, for everything else we use git-update-index
+        # Sort the entries into strings and Entries. Blobs are converted to entries automatically.
+        # Paths can be git-added. For everything else we use git-update-index.
         paths, entries = self._preprocess_add_items(items)
         entries_added: List[BaseIndexEntry] = []
         # This code needs a working tree, therefore we try not to run it unless required.
         # That way, we are OK on a bare repository as well.
-        # If there are no paths, the rewriter has nothing to do either
+        # If there are no paths, the rewriter has nothing to do either.
         if paths:
             entries_added.extend(self._entries_for_paths(paths, path_rewriter, fprogress, entries))
 
@@ -818,7 +846,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # END null mode should be remove
 
             # HANDLE ENTRY OBJECT CREATION
-            # create objects if required, otherwise go with the existing shas
+            # Create objects if required, otherwise go with the existing shas.
             null_entries_indices = [i for i, e in enumerate(entries) if e.binsha == Object.NULL_BIN_SHA]
             if null_entries_indices:
 
@@ -828,7 +856,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                         null_entry = entries[ei]
                         new_entry = self._store_path(null_entry.path, fprogress)
 
-                        # update null entry
+                        # Update null entry.
                         entries[ei] = BaseIndexEntry(
                             (
                                 null_entry.mode,
@@ -844,15 +872,14 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # END null_entry handling
 
             # REWRITE PATHS
-            # If we have to rewrite the entries, do so now, after we have generated
-            # all object sha's
+            # If we have to rewrite the entries, do so now, after we have generated all object sha's.
             if path_rewriter:
                 for i, e in enumerate(entries):
                     entries[i] = BaseIndexEntry((e.mode, e.binsha, e.stage, path_rewriter(e)))
                 # END for each entry
             # END handle path rewriting
 
-            # just go through the remaining entries and provide progress info
+            # Just go through the remaining entries and provide progress info.
             for i, entry in enumerate(entries):
                 progress_sent = i in null_entries_indices
                 if not progress_sent:
@@ -864,7 +891,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         # END if there are base entries
 
         # FINALIZE
-        # add the new entries to this instance
+        # Add the new entries to this instance.
         for entry in entries_added:
             self.entries[(entry.path, 0)] = IndexEntry.from_base(entry)
 
@@ -879,9 +906,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         items: Union[PathLike, Sequence[Union[PathLike, BaseIndexEntry, Blob, Submodule]]],
     ) -> List[PathLike]:
         """Returns a list of repo-relative paths from the given items which
-        may be absolute or relative paths, entries or blobs"""
+        may be absolute or relative paths, entries or blobs."""
         paths = []
-        # if string put in list
+        # If string, put in list.
         if isinstance(items, (str, os.PathLike)):
             items = [items]
 
@@ -937,17 +964,18 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             List(path_string, ...) list of repository relative paths that have
             been removed effectively.
             This is interesting to know in case you have provided a directory or
-            globs. Paths are relative to the repository."""
+            globs. Paths are relative to the repository.
+        """
         args = []
         if not working_tree:
             args.append("--cached")
         args.append("--")
 
-        # preprocess paths
+        # Preprocess paths.
         paths = self._items_to_rela_paths(items)
         removed_paths = self.repo.git.rm(args, paths, **kwargs).splitlines()
 
-        # process output to gain proper paths
+        # Process output to gain proper paths.
         # rm 'path'
         return [p[4:-1] for p in removed_paths]
 
@@ -960,14 +988,14 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         **kwargs: Any,
     ) -> List[Tuple[str, str]]:
         """Rename/move the items, whereas the last item is considered the destination of
-        the move operation. If the destination is a file, the first item ( of two )
+        the move operation. If the destination is a file, the first item (of two)
         must be a file as well. If the destination is a directory, it may be preceded
         by one or more directories or files.
 
         The working tree will be affected in non-bare repositories.
 
         :parma items:
-            Multiple types of items are supported, please see the 'remove' method
+            Multiple types of items are supported, please see the :meth:`remove` method
             for reference.
         :param skip_errors:
             If True, errors such as ones resulting from missing source files will
@@ -981,7 +1009,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             actual destination. Relative to the repository root.
 
         :raise ValueError: If only one item was given
-        :raise GitCommandError: If git could not handle your request"""
+        :raise GitCommandError: If git could not handle your request
+        """
         args = []
         if skip_errors:
             args.append("-k")
@@ -993,13 +1022,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         was_dry_run = kwargs.pop("dry_run", kwargs.pop("n", None))
         kwargs["dry_run"] = True
 
-        # first execute rename in dryrun so the command tells us what it actually does
-        # ( for later output )
+        # First execute rename in dryrun so the command tells us what it actually does.
+        # (for later output)
         out = []
         mvlines = self.repo.git.mv(args, paths, **kwargs).splitlines()
 
-        # parse result - first 0:n/2 lines are 'checking ', the remaining ones
-        # are the 'renaming' ones which we parse
+        # Parse result - first 0:n/2 lines are 'checking ', the remaining ones
+        # are the 'renaming' ones which we parse.
         for ln in range(int(len(mvlines) / 2), len(mvlines)):
             tokens = mvlines[ln].split(" to ")
             assert len(tokens) == 2, "Too many tokens in %s" % mvlines[ln]
@@ -1009,12 +1038,12 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             out.append((tokens[0][9:], tokens[1]))
         # END for each line to parse
 
-        # either prepare for the real run, or output the dry-run result
+        # Either prepare for the real run, or output the dry-run result.
         if was_dry_run:
             return out
         # END handle dryrun
 
-        # now apply the actual operation
+        # Now apply the actual operation.
         kwargs.pop("dry_run")
         self.repo.git.mv(args, paths, **kwargs)
 
@@ -1031,14 +1060,18 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         commit_date: Union[datetime.datetime, str, None] = None,
         skip_hooks: bool = False,
     ) -> Commit:
-        """Commit the current default index file, creating a commit object.
-        For more information on the arguments, see Commit.create_from_tree().
+        """Commit the current default index file, creating a Commit object.
 
-        :note: If you have manually altered the .entries member of this instance,
-               don't forget to write() your changes to disk beforehand.
-               Passing skip_hooks=True is the equivalent of using `-n`
-               or `--no-verify` on the command line.
-        :return: Commit object representing the new commit"""
+        For more information on the arguments, see
+        :meth:`Commit.create_from_tree <git.objects.commit.Commit.create_from_tree>`.
+
+        :note: If you have manually altered the :attr:`entries` member of this instance,
+               don't forget to :meth:`write` your changes to disk beforehand.
+               Passing ``skip_hooks=True`` is the equivalent of using ``-n``
+               or ``--no-verify`` on the command line.
+
+        :return: :class:`Commit` object representing the new commit
+        """
         if not skip_hooks:
             run_commit_hook("pre-commit", self)
 
@@ -1099,11 +1132,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         fprogress: Callable = lambda *args: None,
         **kwargs: Any,
     ) -> Union[None, Iterator[PathLike], Sequence[PathLike]]:
-        """Checkout the given paths or all files from the version known to the index into
-        the working tree.
+        """Check out the given paths or all files from the version known to the index
+        into the working tree.
 
-        :note: Be sure you have written pending changes using the ``write`` method
-            in case you have altered the enties dictionary directly
+        :note: Be sure you have written pending changes using the :meth:`write` method
+            in case you have altered the entries dictionary directly.
 
         :param paths:
             If None, all paths in the index will be checked out. Otherwise an iterable
@@ -1112,20 +1145,20 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         :param force:
             If True, existing files will be overwritten even if they contain local modifications.
-            If False, these will trigger a CheckoutError.
+            If False, these will trigger a :class:`CheckoutError`.
 
         :param fprogress:
             see :func:`IndexFile.add` for signature and explanation.
             The provided progress information will contain None as path and item if no
             explicit paths are given. Otherwise progress information will be send
-            prior and after a file has been checked out
+            prior and after a file has been checked out.
 
         :param kwargs:
-            Additional arguments to be passed to git-checkout-index
+            Additional arguments to be passed to git-checkout-index.
 
         :return:
             iterable yielding paths to files which have been checked out and are
-            guaranteed to match the version stored in the index
+            guaranteed to match the version stored in the index.
 
         :raise exc.CheckoutError:
             If at least one file failed to be checked out. This is a summary,
@@ -1133,7 +1166,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             If one of files or directories do not exist in the index
             ( as opposed to the  original git command who ignores them ).
             Raise GitCommandError if error lines could not be parsed - this truly is
-            an exceptional state
+            an exceptional state.
 
         .. note:: The checkout is limited to checking out the files in the
             index. Files which are not in the index anymore and exist in
@@ -1307,9 +1340,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         :param kwargs:
             Additional keyword arguments passed to git-reset
 
-        .. note:: IndexFile.reset, as opposed to HEAD.reset, will not delete anyfiles
+        .. note:: IndexFile.reset, as opposed to HEAD.reset, will not delete any files
             in order to maintain a consistent working tree. Instead, it will just
-            checkout the files according to their state in the index.
+            check out the files according to their state in the index.
             If you want git-reset like behaviour, use *HEAD.reset* instead.
 
         :return: self"""
@@ -1355,40 +1388,40 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         create_patch: bool = False,
         **kwargs: Any,
     ) -> git_diff.DiffIndex:
-        """Diff this index against the working copy or a Tree or Commit object
+        """Diff this index against the working copy or a Tree or Commit object.
 
-        For a documentation of the parameters and return values, see,
-        Diffable.diff
+        For a documentation of the parameters and return values, see
+        :meth:`Diffable.diff <git.diff.Diffable.diff>`.
 
         :note:
             Will only work with indices that represent the default git index as
             they have not been initialized with a stream.
         """
 
-        # only run if we are the default repository index
+        # Only run if we are the default repository index.
         if self._file_path != self._index_path():
             raise AssertionError("Cannot call %r on indices that do not represent the default git index" % self.diff())
-        # index against index is always empty
+        # Index against index is always empty.
         if other is self.Index:
             return git_diff.DiffIndex()
 
-        # index against anything but None is a reverse diff with the respective
+        # Index against anything but None is a reverse diff with the respective
         # item. Handle existing -R flags properly. Transform strings to the object
-        # so that we can call diff on it
+        # so that we can call diff on it.
         if isinstance(other, str):
             other = self.repo.rev_parse(other)
         # END object conversion
 
         if isinstance(other, Object):  # for Tree or Commit
-            # invert the existing R flag
+            # Invert the existing R flag.
             cur_val = kwargs.get("R", False)
             kwargs["R"] = not cur_val
             return other.diff(self.Index, paths, create_patch, **kwargs)
         # END diff against other item handling
 
-        # if other is not None here, something is wrong
+        # If other is not None here, something is wrong.
         if other is not None:
             raise ValueError("other must be None, Diffable.Index, a Tree or Commit, was %r" % other)
 
-        # diff against working copy - can be handled by superclass natively
+        # Diff against working copy - can be handled by superclass natively.
         return super(IndexFile, self).diff(other, paths, create_patch, **kwargs)

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -340,9 +340,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             resolve more cases in a commonly correct manner. Specify trivial=True as kwarg
             to override that.
 
-            As the underlying git-read-tree command takes into account the current index,
-            it will be temporarily moved out of the way to assure there are no unsuspected
-            interferences.
+            As the underlying git-read-tree command takes into account the current
+            index, it will be temporarily moved out of the way to prevent any unexpected
+            interference.
         """
         if len(treeish) == 0 or len(treeish) > 3:
             raise ValueError("Please specify between 1 and 3 treeish, got %i" % len(treeish))
@@ -366,7 +366,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # Move current index out of the way - otherwise the merge may fail
             # as it considers existing entries. Moving it essentially clears the index.
             # Unfortunately there is no 'soft' way to do it.
-            # The TemporaryFileSwap assure the original file get put back.
+            # The TemporaryFileSwap ensures the original file gets put back.
 
             stack.enter_context(TemporaryFileSwap(join_path_native(repo.git_dir, "index")))
             repo.git.read_tree(*arg_list, **kwargs)

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1023,8 +1023,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         was_dry_run = kwargs.pop("dry_run", kwargs.pop("n", None))
         kwargs["dry_run"] = True
 
-        # First execute rename in dryrun so the command tells us what it actually does.
-        # (for later output)
+        # First execute rename in dryrun so the command tells us what it actually does
+        # (for later output).
         out = []
         mvlines = self.repo.git.mv(args, paths, **kwargs).splitlines()
 
@@ -1186,7 +1186,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         def handle_stderr(proc: "Popen[bytes]", iter_checked_out_files: Iterable[PathLike]) -> None:
             stderr_IO = proc.stderr
             if not stderr_IO:
-                return None  # return early if stderr empty
+                return None  # Return early if stderr empty.
             else:
                 stderr_bytes = stderr_IO.read()
             # line contents:
@@ -1252,9 +1252,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             if isinstance(paths, str):
                 paths = [paths]
 
-            # make sure we have our entries loaded before we start checkout_index
+            # Make sure we have our entries loaded before we start checkout_index,
             # which will hold a lock on it. We try to get the lock as well during
-            # our entries initialization
+            # our entries initialization.
             self.entries
 
             args.append("--stdin")
@@ -1267,7 +1267,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
             for path in paths:
                 co_path = to_native_path_linux(self._to_relative_path(path))
-                # if the item is not in the index, it could be a directory
+                # If the item is not in the index, it could be a directory.
                 path_is_directory = False
 
                 try:
@@ -1347,8 +1347,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             If you want git-reset like behaviour, use *HEAD.reset* instead.
 
         :return: self"""
-        # what we actually want to do is to merge the tree into our existing
-        # index, which is what git-read-tree does
+        # What we actually want to do is to merge the tree into our existing
+        # index, which is what git-read-tree does.
         new_inst = type(self).from_tree(self.repo, commit)
         if not paths:
             self.entries = new_inst.entries
@@ -1360,7 +1360,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                     key = entry_key(path, 0)
                     self.entries[key] = nie[key]
                 except KeyError:
-                    # if key is not in theirs, it musn't be in ours
+                    # If key is not in theirs, it musn't be in ours.
                     try:
                         del self.entries[key]
                     except KeyError:
@@ -1391,7 +1391,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     ) -> git_diff.DiffIndex:
         """Diff this index against the working copy or a Tree or Commit object.
 
-        For a documentation of the parameters and return values, see
+        For documentation of the parameters and return values, see
         :meth:`Diffable.diff <git.diff.Diffable.diff>`.
 
         :note:
@@ -1413,7 +1413,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             other = self.repo.rev_parse(other)
         # END object conversion
 
-        if isinstance(other, Object):  # for Tree or Commit
+        if isinstance(other, Object):  # For Tree or Commit.
             # Invert the existing R flag.
             cur_val = kwargs.get("R", False)
             kwargs["R"] = not cur_val

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -123,7 +123,7 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
             stdout = force_text(stdout, defenc)
             stderr = force_text(stderr, defenc)
             raise HookExecutionError(hp, process.returncode, stderr, stdout)
-    # end handle return code
+    # END handle return code
 
 
 def stat_mode_to_index_mode(mode: int) -> int:

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -1,6 +1,5 @@
-# Contains standalone functions to accompany the index implementation and make it
-# more versatile
-# NOTE: Autodoc hates it if this is a docstring
+# Standalone functions to accompany the index implementation and make it more versatile.
+# NOTE: Autodoc hates it if this is a docstring.
 
 from io import BytesIO
 from pathlib import Path
@@ -56,7 +55,7 @@ if TYPE_CHECKING:
 # ------------------------------------------------------------------------------------
 
 
-S_IFGITLINK = S_IFLNK | S_IFDIR  # a submodule
+S_IFGITLINK = S_IFLNK | S_IFDIR  # A submodule.
 CE_NAMEMASK_INV = ~CE_NAMEMASK
 
 __all__ = (
@@ -81,12 +80,13 @@ def _has_file_extension(path: str) -> str:
 
 
 def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
-    """Run the commit hook of the given name. Silently ignores hooks that do not exist.
+    """Run the commit hook of the given name. Silently ignore hooks that do not exist.
 
     :param name: name of hook, like 'pre-commit'
     :param index: IndexFile instance
-    :param args: arguments passed to hook file
-    :raises HookExecutionError:"""
+    :param args: Arguments passed to hook file
+    :raises HookExecutionError:
+    """
     hp = hook_path(name, index.repo.git_dir)
     if not os.access(hp, os.X_OK):
         return None
@@ -128,7 +128,7 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
 
 def stat_mode_to_index_mode(mode: int) -> int:
     """Convert the given mode from a stat call to the corresponding index mode
-    and return it"""
+    and return it."""
     if S_ISLNK(mode):  # symlinks
         return S_IFLNK
     if S_ISDIR(mode) or S_IFMT(mode) == S_IFGITLINK:  # submodules
@@ -142,9 +142,10 @@ def write_cache(
     extension_data: Union[None, bytes] = None,
     ShaStreamCls: Type[IndexFileSHA1Writer] = IndexFileSHA1Writer,
 ) -> None:
-    """Write the cache represented by entries to a stream
+    """Write the cache represented by entries to a stream.
 
     :param entries: **sorted** list of entries
+
     :param stream: stream to wrap into the AdapterStreamCls - it is used for
         final output.
 
@@ -152,28 +153,29 @@ def write_cache(
         while writing to it, before the data is passed on to the wrapped stream
 
     :param extension_data: any kind of data to write as a trailer, it must begin
-        a 4 byte identifier, followed by its size ( 4 bytes )"""
-    # wrap the stream into a compatible writer
+        a 4 byte identifier, followed by its size (4 bytes).
+    """
+    # Wrap the stream into a compatible writer.
     stream_sha = ShaStreamCls(stream)
 
     tell = stream_sha.tell
     write = stream_sha.write
 
-    # header
+    # Header
     version = 2
     write(b"DIRC")
     write(pack(">LL", version, len(entries)))
 
-    # body
+    # Body
     for entry in entries:
         beginoffset = tell()
         write(entry.ctime_bytes)  # ctime
         write(entry.mtime_bytes)  # mtime
         path_str = str(entry.path)
         path: bytes = force_bytes(path_str, encoding=defenc)
-        plen = len(path) & CE_NAMEMASK  # path length
+        plen = len(path) & CE_NAMEMASK  # Path length
         assert plen == len(path), "Path %s too long to fit into index" % entry.path
-        flags = plen | (entry.flags & CE_NAMEMASK_INV)  # clear possible previous values
+        flags = plen | (entry.flags & CE_NAMEMASK_INV)  # Clear possible previous values.
         write(
             pack(
                 ">LLLLLL20sH",
@@ -192,11 +194,11 @@ def write_cache(
         write(b"\0" * ((beginoffset + real_size) - tell()))
     # END for each entry
 
-    # write previously cached extensions data
+    # Write previously cached extensions data.
     if extension_data is not None:
         stream_sha.write(extension_data)
 
-    # write the sha over the content
+    # Write the sha over the content.
     stream_sha.write_sha()
 
 
@@ -208,14 +210,16 @@ def read_header(stream: IO[bytes]) -> Tuple[int, int]:
     unpacked = cast(Tuple[int, int], unpack(">LL", stream.read(4 * 2)))
     version, num_entries = unpacked
 
-    # TODO: handle version 3: extended data, see read-cache.c
+    # TODO: Handle version 3: extended data, see read-cache.c.
     assert version in (1, 2)
     return version, num_entries
 
 
 def entry_key(*entry: Union[BaseIndexEntry, PathLike, int]) -> Tuple[PathLike, int]:
     """:return: Key suitable to be used for the index.entries dictionary
-    :param entry: One instance of type BaseIndexEntry or the path and the stage"""
+
+    :param entry: One instance of type BaseIndexEntry or the path and the stage
+    """
 
     # def is_entry_key_tup(entry_key: Tuple) -> TypeGuard[Tuple[PathLike, int]]:
     #     return isinstance(entry_key, tuple) and len(entry_key) == 2
@@ -234,14 +238,15 @@ def entry_key(*entry: Union[BaseIndexEntry, PathLike, int]) -> Tuple[PathLike, i
 def read_cache(
     stream: IO[bytes],
 ) -> Tuple[int, Dict[Tuple[PathLike, int], "IndexEntry"], bytes, bytes]:
-    """Read a cache file from the given stream
+    """Read a cache file from the given stream.
 
     :return: tuple(version, entries_dict, extension_data, content_sha)
 
-      * version is the integer version number
-      * entries dict is a dictionary which maps IndexEntry instances to a path at a stage
-      * extension_data is '' or 4 bytes of type + 4 bytes of size + size bytes
-      * content_sha is a 20 byte sha on all cache file contents"""
+      * version is the integer version number.
+      * entries dict is a dictionary which maps IndexEntry instances to a path at a stage.
+      * extension_data is '' or 4 bytes of type + 4 bytes of size + size bytes.
+      * content_sha is a 20 byte sha on all cache file contents.
+    """
     version, num_entries = read_header(stream)
     count = 0
     entries: Dict[Tuple[PathLike, int], "IndexEntry"] = {}
@@ -259,17 +264,17 @@ def read_cache(
         real_size = (tell() - beginoffset + 8) & ~7
         read((beginoffset + real_size) - tell())
         entry = IndexEntry((mode, sha, flags, path, ctime, mtime, dev, ino, uid, gid, size))
-        # entry_key would be the method to use, but we safe the effort
+        # entry_key would be the method to use, but we save the effort.
         entries[(path, entry.stage)] = entry
         count += 1
     # END for each entry
 
-    # the footer contains extension data and a sha on the content so far
-    # Keep the extension footer,and verify we have a sha in the end
+    # The footer contains extension data and a sha on the content so far.
+    # Keep the extension footer,and verify we have a sha in the end.
     # Extension data format is:
-    # 4 bytes ID
-    # 4 bytes length of chunk
-    # repeated 0 - N times
+    #   4 bytes ID
+    #   4 bytes length of chunk
+    #   Repeated 0 - N times
     extension_data = stream.read(~0)
     assert (
         len(extension_data) > 19
@@ -277,7 +282,7 @@ def read_cache(
 
     content_sha = extension_data[-20:]
 
-    # truncate the sha in the end as we will dynamically create it anyway
+    # Truncate the sha in the end as we will dynamically create it anyway.
     extension_data = extension_data[:-20]
 
     return (version, entries, extension_data, content_sha)
@@ -287,14 +292,15 @@ def write_tree_from_cache(
     entries: List[IndexEntry], odb: "GitCmdObjectDB", sl: slice, si: int = 0
 ) -> Tuple[bytes, List["TreeCacheTup"]]:
     """Create a tree from the given sorted list of entries and put the respective
-    trees into the given object database
+    trees into the given object database.
 
-    :param entries: **sorted** list of IndexEntries
-    :param odb: object database to store the trees in
-    :param si: start index at which we should start creating subtrees
-    :param sl: slice indicating the range we should process on the entries list
+    :param entries: **Sorted** list of IndexEntries
+    :param odb: Object database to store the trees in
+    :param si: Start index at which we should start creating subtrees
+    :param sl: Slice indicating the range we should process on the entries list
     :return: tuple(binsha, list(tree_entry, ...)) a tuple of a sha and a list of
-        tree entries being a tuple of hexsha, mode, name"""
+        tree entries being a tuple of hexsha, mode, name
+    """
     tree_items: List["TreeCacheTup"] = []
 
     ci = sl.start
@@ -307,10 +313,10 @@ def write_tree_from_cache(
         ci += 1
         rbound = entry.path.find("/", si)
         if rbound == -1:
-            # its not a tree
+            # It's not a tree.
             tree_items.append((entry.binsha, entry.mode, entry.path[si:]))
         else:
-            # find common base range
+            # Find common base range.
             base = entry.path[si:rbound]
             xi = ci
             while xi < end:
@@ -322,19 +328,19 @@ def write_tree_from_cache(
                 xi += 1
             # END find common base
 
-            # enter recursion
-            # ci - 1 as we want to count our current item as well
+            # Enter recursion.
+            # ci - 1 as we want to count our current item as well.
             sha, _tree_entry_list = write_tree_from_cache(entries, odb, slice(ci - 1, xi), rbound + 1)
             tree_items.append((sha, S_IFDIR, base))
 
-            # skip ahead
+            # Skip ahead.
             ci = xi
         # END handle bounds
     # END for each entry
 
-    # finally create the tree
+    # Finally create the tree.
     sio = BytesIO()
-    tree_to_stream(tree_items, sio.write)  # writes to stream as bytes, but doesn't change tree_items
+    tree_to_stream(tree_items, sio.write)  # Writes to stream as bytes, but doesn't change tree_items.
     sio.seek(0)
 
     istream = odb.store(IStream(str_tree_type, len(sio.getvalue()), sio))
@@ -347,16 +353,18 @@ def _tree_entry_to_baseindexentry(tree_entry: "TreeCacheTup", stage: int) -> Bas
 
 def aggressive_tree_merge(odb: "GitCmdObjectDB", tree_shas: Sequence[bytes]) -> List[BaseIndexEntry]:
     """
-    :return: list of BaseIndexEntries representing the aggressive merge of the given
+    :return: List of BaseIndexEntries representing the aggressive merge of the given
         trees. All valid entries are on stage 0, whereas the conflicting ones are left
         on stage 1, 2 or 3, whereas stage 1 corresponds to the common ancestor tree,
         2 to our tree and 3 to 'their' tree.
-    :param tree_shas: 1, 2 or 3 trees as identified by their binary 20 byte shas
-        If 1 or two, the entries will effectively correspond to the last given tree
-        If 3 are given, a 3 way merge is performed"""
+
+    :param tree_shas: 1, 2 or 3 trees as identified by their binary 20 byte shas.
+        If 1 or two, the entries will effectively correspond to the last given tree.
+        If 3 are given, a 3 way merge is performed.
+    """
     out: List[BaseIndexEntry] = []
 
-    # one and two way is the same for us, as we don't have to handle an existing
+    # One and two way is the same for us, as we don't have to handle an existing
     # index, instrea
     if len(tree_shas) in (1, 2):
         for entry in traverse_tree_recursive(odb, tree_shas[-1], ""):
@@ -368,72 +376,72 @@ def aggressive_tree_merge(odb: "GitCmdObjectDB", tree_shas: Sequence[bytes]) -> 
     if len(tree_shas) > 3:
         raise ValueError("Cannot handle %i trees at once" % len(tree_shas))
 
-    # three trees
+    # Three trees.
     for base, ours, theirs in traverse_trees_recursive(odb, tree_shas, ""):
         if base is not None:
-            # base version exists
+            # Base version exists.
             if ours is not None:
-                # ours exists
+                # Ours exists.
                 if theirs is not None:
-                    # it exists in all branches, if it was changed in both
-                    # its a conflict, otherwise we take the changed version
-                    # This should be the most common branch, so it comes first
+                    # It exists in all branches. Ff it was changed in both
+                    # its a conflict. Otherwise, we take the changed version.
+                    # This should be the most common branch, so it comes first.
                     if (base[0] != ours[0] and base[0] != theirs[0] and ours[0] != theirs[0]) or (
                         base[1] != ours[1] and base[1] != theirs[1] and ours[1] != theirs[1]
                     ):
-                        # changed by both
+                        # Changed by both.
                         out.append(_tree_entry_to_baseindexentry(base, 1))
                         out.append(_tree_entry_to_baseindexentry(ours, 2))
                         out.append(_tree_entry_to_baseindexentry(theirs, 3))
                     elif base[0] != ours[0] or base[1] != ours[1]:
-                        # only we changed it
+                        # Only we changed it.
                         out.append(_tree_entry_to_baseindexentry(ours, 0))
                     else:
-                        # either nobody changed it, or they did. In either
-                        # case, use theirs
+                        # Either nobody changed it, or they did. In either
+                        # case, use theirs.
                         out.append(_tree_entry_to_baseindexentry(theirs, 0))
                     # END handle modification
                 else:
                     if ours[0] != base[0] or ours[1] != base[1]:
-                        # they deleted it, we changed it, conflict
+                        # They deleted it, we changed it, conflict.
                         out.append(_tree_entry_to_baseindexentry(base, 1))
                         out.append(_tree_entry_to_baseindexentry(ours, 2))
                     # else:
-                    #   we didn't change it, ignore
+                    #   # We didn't change it, ignore.
                     #   pass
                     # END handle our change
                 # END handle theirs
             else:
                 if theirs is None:
-                    # deleted in both, its fine - its out
+                    # Deleted in both, its fine - it's out.
                     pass
                 else:
                     if theirs[0] != base[0] or theirs[1] != base[1]:
-                        # deleted in ours, changed theirs, conflict
+                        # Deleted in ours, changed theirs, conflict.
                         out.append(_tree_entry_to_baseindexentry(base, 1))
                         out.append(_tree_entry_to_baseindexentry(theirs, 3))
                     # END theirs changed
                     # else:
-                    #   theirs didn't change
+                    #   # Theirs didn't change.
                     #   pass
                 # END handle theirs
             # END handle ours
         else:
-            # all three can't be None
+            # All three can't be None.
             if ours is None:
-                # added in their branch
+                # Added in their branch.
                 assert theirs is not None
                 out.append(_tree_entry_to_baseindexentry(theirs, 0))
             elif theirs is None:
-                # added in our branch
+                # Added in our branch.
                 out.append(_tree_entry_to_baseindexentry(ours, 0))
             else:
-                # both have it, except for the base, see whether it changed
+                # Both have it, except for the base, see whether it changed.
                 if ours[0] != theirs[0] or ours[1] != theirs[1]:
                     out.append(_tree_entry_to_baseindexentry(ours, 2))
                     out.append(_tree_entry_to_baseindexentry(theirs, 3))
                 else:
-                    # it was added the same in both
+                    # It was added the same in both.
                     out.append(_tree_entry_to_baseindexentry(ours, 0))
                 # END handle two items
             # END handle heads

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -32,7 +32,7 @@ CE_STAGESHIFT = 12
 # } END invariants
 
 
-class BlobFilter(object):
+class BlobFilter:
     """
     Predicate to be used by iter_blobs allowing to filter only return blobs which
     match the given list of directories or files.

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -1,4 +1,4 @@
-"""Module with additional types used by the index"""
+"""Module with additional types used by the index."""
 
 from binascii import b2a_hex
 from pathlib import Path
@@ -33,7 +33,6 @@ CE_STAGESHIFT = 12
 
 
 class BlobFilter(object):
-
     """
     Predicate to be used by iter_blobs allowing to filter only return blobs which
     match the given list of directories or files.
@@ -46,7 +45,7 @@ class BlobFilter(object):
     def __init__(self, paths: Sequence[PathLike]) -> None:
         """
         :param paths:
-            tuple or list of paths which are either pointing to directories or
+            Tuple or list of paths which are either pointing to directories or
             to files relative to the current repository
         """
         self.paths = paths
@@ -84,8 +83,7 @@ class BaseIndexEntryHelper(NamedTuple):
 
 
 class BaseIndexEntry(BaseIndexEntryHelper):
-
-    """Small Brother of an index entry which can be created to describe changes
+    """Small brother of an index entry which can be created to describe changes
     done to the index in which case plenty of additional information is not required.
 
     As the first 4 data members match exactly to the IndexEntry type, methods
@@ -138,25 +136,26 @@ class BaseIndexEntry(BaseIndexEntryHelper):
 
 
 class IndexEntry(BaseIndexEntry):
-
     """Allows convenient access to IndexEntry data without completely unpacking it.
 
-    Attributes usully accessed often are cached in the tuple whereas others are
+    Attributes usually accessed often are cached in the tuple whereas others are
     unpacked on demand.
 
-    See the properties for a mapping between names and tuple indices."""
+    See the properties for a mapping between names and tuple indices.
+    """
 
     @property
     def ctime(self) -> Tuple[int, int]:
         """
         :return:
             Tuple(int_time_seconds_since_epoch, int_nano_seconds) of the
-            file's creation time"""
+            file's creation time
+        """
         return cast(Tuple[int, int], unpack(">LL", self.ctime_bytes))
 
     @property
     def mtime(self) -> Tuple[int, int]:
-        """See ctime property, but returns modification time"""
+        """See ctime property, but returns modification time."""
         return cast(Tuple[int, int], unpack(">LL", self.mtime_bytes))
 
     @classmethod
@@ -164,9 +163,10 @@ class IndexEntry(BaseIndexEntry):
         """
         :return:
             Minimal entry as created from the given BaseIndexEntry instance.
-            Missing values will be set to null-like values
+            Missing values will be set to null-like values.
 
-        :param base: Instance of type BaseIndexEntry"""
+        :param base: Instance of type :class:`BaseIndexEntry`
+        """
         time = pack(">LL", 0, 0)
         return IndexEntry((base.mode, base.binsha, base.flags, base.path, time, time, 0, 0, 0, 0, 0))
 

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -40,7 +40,7 @@ class BlobFilter:
     The given paths are given relative to the repository.
     """
 
-    __slots__ = "paths"
+    __slots__ = ("paths",)
 
     def __init__(self, paths: Sequence[PathLike]) -> None:
         """

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -1,4 +1,5 @@
-"""Module containing index utilities"""
+"""Module containing index utilities."""
+
 from functools import wraps
 import os
 import struct
@@ -33,7 +34,6 @@ unpack = struct.unpack
 
 
 class TemporaryFileSwap(object):
-
     """Utility class moving a file to a temporary location within the same directory
     and moving it back on to where on object deletion."""
 
@@ -42,7 +42,7 @@ class TemporaryFileSwap(object):
     def __init__(self, file_path: PathLike) -> None:
         self.file_path = file_path
         self.tmp_file_path = str(self.file_path) + tempfile.mktemp("", "", "")
-        # it may be that the source does not exist
+        # It may be that the source does not exist.
         try:
             os.rename(self.file_path, self.tmp_file_path)
         except OSError:
@@ -90,9 +90,11 @@ def post_clear_cache(func: Callable[..., _T]) -> Callable[..., _T]:
 
 
 def default_index(func: Callable[..., _T]) -> Callable[..., _T]:
-    """Decorator assuring the wrapped method may only run if we are the default
-    repository index. This is as we rely on git commands that operate
-    on that index only."""
+    """Decorator ensuring the wrapped method may only run if we are the default
+    repository index.
+
+    This is as we rely on git commands that operate on that index only.
+    """
 
     @wraps(func)
     def check_default_index(self: "IndexFile", *args: Any, **kwargs: Any) -> _T:
@@ -109,7 +111,7 @@ def default_index(func: Callable[..., _T]) -> Callable[..., _T]:
 
 def git_working_dir(func: Callable[..., _T]) -> Callable[..., _T]:
     """Decorator which changes the current working dir to the one of the git
-    repository in order to assure relative paths are handled correctly"""
+    repository in order to ensure relative paths are handled correctly."""
 
     @wraps(func)
     def set_git_working_dir(self: "IndexFile", *args: Any, **kwargs: Any) -> _T:

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -33,7 +33,7 @@ unpack = struct.unpack
 # } END aliases
 
 
-class TemporaryFileSwap(object):
+class TemporaryFileSwap:
     """Utility class moving a file to a temporary location within the same directory
     and moving it back on to where on object deletion."""
 

--- a/git/objects/__init__.py
+++ b/git/objects/__init__.py
@@ -1,7 +1,7 @@
-"""
-Import all submodules main classes into the package space
-"""
+"""Import all submodules' main classes into the package space."""
+
 # flake8: noqa
+
 import inspect
 
 from .base import *
@@ -14,11 +14,10 @@ from .tag import *
 from .tree import *
 
 # Fix import dependency - add IndexObject to the util module, so that it can be
-# imported by the submodule.base
+# imported by the submodule.base.
 smutil.IndexObject = IndexObject  # type: ignore[attr-defined]
 smutil.Object = Object  # type: ignore[attr-defined]
 del smutil
 
-# must come after submodule was made available
-
+# Must come after submodule was made available.
 __all__ = [name for name, obj in locals().items() if not (name.startswith("_") or inspect.ismodule(obj))]

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -221,4 +221,4 @@ class IndexObject(Object):
         if self.repo.working_tree_dir is not None:
             return join_path_native(self.repo.working_tree_dir, self.path)
         else:
-            raise WorkTreeRepositoryUnsupported("Working_tree_dir was None or empty")
+            raise WorkTreeRepositoryUnsupported("working_tree_dir was None or empty")

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -178,7 +178,7 @@ class IndexObject(Object):
     ) -> None:
         """Initialize a newly instanced IndexObject.
 
-        :param repo: The :class:`Repo <git.repo.base.Repo>` we are located in.
+        :param repo: The :class:`~git.repo.base.Repo` we are located in.
         :param binsha: 20 byte sha1.
         :param mode:
             The stat compatible file mode as int, use the :mod:`stat` module to evaluate

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -212,7 +212,7 @@ class IndexObject(Object):
 
     @property
     def abspath(self) -> PathLike:
-        """
+        R"""
         :return:
             Absolute path to this index object in the file system ( as opposed to the
             .path field which is a path relative to the git repository ).

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -38,8 +38,7 @@ __all__ = ("Object", "IndexObject")
 
 
 class Object(LazyMixin):
-
-    """Implements an Object which may be Blobs, Trees, Commits and Tags"""
+    """An Object which may be Blobs, Trees, Commits and Tags."""
 
     NULL_HEX_SHA = "0" * 40
     NULL_BIN_SHA = b"\0" * 20
@@ -50,7 +49,9 @@ class Object(LazyMixin):
         dbtyp.str_commit_type,
         dbtyp.str_tag_type,
     )
+
     __slots__ = ("repo", "binsha", "size")
+
     type: Union[Lit_commit_ish, None] = None
 
     def __init__(self, repo: "Repo", binsha: bytes):
@@ -59,7 +60,8 @@ class Object(LazyMixin):
 
         :param repo: repository this object is located in
 
-        :param binsha: 20 byte SHA1"""
+        :param binsha: 20 byte SHA1
+        """
         super(Object, self).__init__()
         self.repo = repo
         self.binsha = binsha
@@ -71,14 +73,15 @@ class Object(LazyMixin):
     @classmethod
     def new(cls, repo: "Repo", id: Union[str, "Reference"]) -> Commit_ish:
         """
-        :return: New Object instance of a type appropriate to the object type behind
-            id. The id of the newly created object will be a binsha even though
-            the input id may have been a Reference or Rev-Spec
+        :return: New :class:`Object`` instance of a type appropriate to the object type
+            behind `id`. The id of the newly created object will be a binsha even though
+            the input id may have been a Reference or Rev-Spec.
 
         :param id: reference, rev-spec, or hexsha
 
-        :note: This cannot be a __new__ method as it would always call __init__
-            with the input id which is not necessarily a binsha."""
+        :note: This cannot be a ``__new__`` method as it would always call
+            :meth:`__init__` with the input id which is not necessarily a binsha.
+        """
         return repo.rev_parse(str(id))
 
     @classmethod
@@ -86,9 +89,11 @@ class Object(LazyMixin):
         """
         :return: new object instance of a type appropriate to represent the given
             binary sha1
-        :param sha1: 20 byte binary sha1"""
+
+        :param sha1: 20 byte binary sha1
+        """
         if sha1 == cls.NULL_BIN_SHA:
-            # the NULL binsha is always the root commit
+            # The NULL binsha is always the root commit.
             return get_object_type_by_name(b"commit")(repo, sha1)
         # END handle special case
         oinfo = repo.odb.info(sha1)
@@ -97,7 +102,7 @@ class Object(LazyMixin):
         return inst
 
     def _set_cache_(self, attr: str) -> None:
-        """Retrieve object information"""
+        """Retrieve object information."""
         if attr == "size":
             oinfo = self.repo.odb.info(self.binsha)
             self.size = oinfo.size  # type:  int
@@ -137,28 +142,31 @@ class Object(LazyMixin):
 
     @property
     def data_stream(self) -> "OStream":
-        """:return:  File Object compatible stream to the uncompressed raw data of the object
-        :note: returned streams must be read in order"""
+        """
+        :return: File Object compatible stream to the uncompressed raw data of the object
+
+        :note: Returned streams must be read in order.
+        """
         return self.repo.odb.stream(self.binsha)
 
     def stream_data(self, ostream: "OStream") -> "Object":
-        """Writes our data directly to the given output stream
+        """Write our data directly to the given output stream.
 
         :param ostream: File object compatible stream object.
-        :return: self"""
+        :return: self
+        """
         istream = self.repo.odb.stream(self.binsha)
         stream_copy(istream, ostream)
         return self
 
 
 class IndexObject(Object):
-
-    """Base for all objects that can be part of the index file , namely Tree, Blob and
-    SubModule objects"""
+    """Base for all objects that can be part of the index file, namely Tree, Blob and
+    SubModule objects."""
 
     __slots__ = ("path", "mode")
 
-    # for compatibility with iterable lists
+    # For compatibility with iterable lists.
     _id_attribute_ = "path"
 
     def __init__(
@@ -168,19 +176,20 @@ class IndexObject(Object):
         mode: Union[None, int] = None,
         path: Union[None, PathLike] = None,
     ) -> None:
-        """Initialize a newly instanced IndexObject
+        """Initialize a newly instanced IndexObject.
 
-        :param repo: is the Repo we are located in
-        :param binsha: 20 byte sha1
+        :param repo: The :class:`Repo <git.repo.base.Repo>` we are located in.
+        :param binsha: 20 byte sha1.
         :param mode:
-            is the stat compatible file mode as int, use the stat module
-            to evaluate the information
+            The stat compatible file mode as int, use the :mod:`stat` module to evaluate
+            the information.
         :param path:
-            is the path to the file in the file system, relative to the git repository root, i.e.
-            file.ext or folder/other.ext
+            The path to the file in the file system, relative to the git repository
+            root, like ``file.ext`` or ``folder/other.ext``.
         :note:
-            Path may not be set of the index object has been created directly as it cannot
-            be retrieved without knowing the parent tree."""
+            Path may not be set if the index object has been created directly, as it
+            cannot be retrieved without knowing the parent tree.
+        """
         super(IndexObject, self).__init__(repo, binsha)
         if mode is not None:
             self.mode = mode
@@ -191,7 +200,8 @@ class IndexObject(Object):
         """
         :return:
             Hash of our path as index items are uniquely identifiable by path, not
-            by their data !"""
+            by their data!
+        """
         return hash(self.path)
 
     def _set_cache_(self, attr: str) -> None:
@@ -214,10 +224,11 @@ class IndexObject(Object):
     def abspath(self) -> PathLike:
         R"""
         :return:
-            Absolute path to this index object in the file system ( as opposed to the
-            .path field which is a path relative to the git repository ).
+            Absolute path to this index object in the file system (as opposed to the
+            :attr:`path` field which is a path relative to the git repository).
 
-            The returned path will be native to the system and contains '\' on windows."""
+            The returned path will be native to the system and contains '\' on Windows.
+        """
         if self.repo.working_tree_dir is not None:
             return join_path_native(self.repo.working_tree_dir, self.path)
         else:

--- a/git/objects/blob.py
+++ b/git/objects/blob.py
@@ -3,6 +3,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 from mimetypes import guess_type
 from . import base
 
@@ -12,13 +13,12 @@ __all__ = ("Blob",)
 
 
 class Blob(base.IndexObject):
-
-    """A Blob encapsulates a git blob object"""
+    """A Blob encapsulates a git blob object."""
 
     DEFAULT_MIME_TYPE = "text/plain"
     type: Literal["blob"] = "blob"
 
-    # valid blob modes
+    # Valid blob modes
     executable_mode = 0o100755
     file_mode = 0o100644
     link_mode = 0o120000
@@ -29,7 +29,9 @@ class Blob(base.IndexObject):
     def mime_type(self) -> str:
         """
         :return: String describing the mime type of this file (based on the filename)
-        :note: Defaults to 'text/plain' in case the actual file type is unknown."""
+
+        :note: Defaults to 'text/plain' in case the actual file type is unknown.
+        """
         guesses = None
         if self.path:
             guesses = guess_type(str(self.path))

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -688,10 +688,6 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         return self
 
     def _deserialize(self, stream: BytesIO) -> "Commit":
-        """
-        :param from_rev_list: if true, the stream format is coming from the rev-list command
-            Otherwise it is assumed to be a plain data stream from our object
-        """
         readline = stream.readline
         self.tree = Tree(self.repo, hex_to_bin(readline().split()[1]), Tree.tree_id << 12, "")
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -3,6 +3,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import datetime
 import re
 from subprocess import Popen, PIPE
@@ -66,7 +67,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     value on demand only if it involves calling the git binary."""
 
     # ENVIRONMENT VARIABLES
-    # read when creating new commits
+    # Read when creating new commits.
     env_author_date = "GIT_AUTHOR_DATE"
     env_committer_date = "GIT_COMMITTER_DATE"
 
@@ -113,36 +114,38 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         be implicitly set on first query.
 
         :param binsha: 20 byte sha1
-        :param parents: tuple( Commit, ... )
-            is a tuple of commit ids or actual Commits
+        :param parents: tuple(Commit, ...)
+            A tuple of commit ids or actual Commits
         :param tree: Tree object
         :param author: Actor
-            is the author Actor object
+            The author Actor object
         :param authored_date: int_seconds_since_epoch
-            is the authored DateTime - use time.gmtime() to convert it into a
+            The authored DateTime - use time.gmtime() to convert it into a
             different format
         :param author_tz_offset: int_seconds_west_of_utc
-            is the timezone that the authored_date is in
+            The timezone that the authored_date is in
         :param committer: Actor
-            is the committer string
+            The committer string
         :param committed_date: int_seconds_since_epoch
-            is the committed DateTime - use time.gmtime() to convert it into a
+            The committed DateTime - use time.gmtime() to convert it into a
             different format
         :param committer_tz_offset: int_seconds_west_of_utc
-            is the timezone that the committed_date is in
+            The timezone that the committed_date is in
         :param message: string
-            is the commit message
+            The commit message
         :param encoding: string
-            encoding of the message, defaults to UTF-8
+            Encoding of the message, defaults to UTF-8
         :param parents:
             List or tuple of Commit objects which are our parent(s) in the commit
             dependency graph
+
         :return: git.Commit
 
         :note:
             Timezone information is in the same format and in the same sign
             as what time.altzone returns. The sign is inverted compared to git's
-            UTC timezone."""
+            UTC timezone.
+        """
         super(Commit, self).__init__(repo, binsha)
         self.binsha = binsha
         if tree is not None:
@@ -211,7 +214,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     def _set_cache_(self, attr: str) -> None:
         if attr in Commit.__slots__:
-            # read the data in a chunk, its faster - then provide a file wrapper
+            # Read the data in a chunk, its faster - then provide a file wrapper.
             _binsha, _typename, self.size, stream = self.repo.odb.stream(self.binsha)
             self._deserialize(BytesIO(stream.read()))
         else:
@@ -235,17 +238,19 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             return self.message.split(b"\n", 1)[0]
 
     def count(self, paths: Union[PathLike, Sequence[PathLike]] = "", **kwargs: Any) -> int:
-        """Count the number of commits reachable from this commit
+        """Count the number of commits reachable from this commit.
 
         :param paths:
-            is an optional path or a list of paths restricting the return value
-            to commits actually containing the paths
+            An optional path or a list of paths restricting the return value
+            to commits actually containing the paths.
 
         :param kwargs:
             Additional options to be passed to git-rev-list. They must not alter
-            the output style of the command, or parsing will yield incorrect results
-        :return: int defining the number of reachable commits"""
-        # yes, it makes a difference whether empty paths are given or not in our case
+            the output style of the command, or parsing will yield incorrect results.
+
+        :return: An int defining the number of reachable commits
+        """
+        # Yes, it makes a difference whether empty paths are given or not in our case
         # as the empty paths version will ignore merge commits for some reason.
         if paths:
             return len(self.repo.git.rev_list(self.hexsha, "--", paths, **kwargs).splitlines())
@@ -256,7 +261,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """
         :return:
             String describing the commits hex sha based on the closest Reference.
-            Mostly useful for UI purposes"""
+            Mostly useful for UI purposes
+        """
         return self.repo.git.name_rev(self)
 
     @classmethod
@@ -269,23 +275,29 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     ) -> Iterator["Commit"]:
         """Find all commits matching the given criteria.
 
-        :param repo: is the Repo
-        :param rev: revision specifier, see git-rev-parse for viable options
+        :param repo: The Repo
+
+        :param rev: Revision specifier, see git-rev-parse for viable options.
+
         :param paths:
-            is an optional path or list of paths, if set only Commits that include the path
-            or paths will be considered
+            An optional path or list of paths, if set only Commits that include the path
+            or paths will be considered.
+
         :param kwargs:
-            optional keyword arguments to git rev-list where
-            ``max_count`` is the maximum number of commits to fetch
-            ``skip`` is the number of commits to skip
-            ``since`` all commits since i.e. '1970-01-01'
-        :return: iterator yielding Commit items"""
+            Optional keyword arguments to ``git rev-list`` where:
+
+            * ``max_count`` is the maximum number of commits to fetch
+            * ``skip`` is the number of commits to skip
+            * ``since`` all commits since e.g. '1970-01-01'
+
+        :return: Iterator yielding :class:`Commit` items.
+        """
         if "pretty" in kwargs:
             raise ValueError("--pretty cannot be used as parsing expects single sha's only")
         # END handle pretty
 
-        # use -- in any case, to prevent possibility of ambiguous arguments
-        # see https://github.com/gitpython-developers/GitPython/issues/264
+        # Use -- in all cases, to prevent possibility of ambiguous arguments.
+        # See https://github.com/gitpython-developers/GitPython/issues/264.
 
         args_list: List[PathLike] = ["--"]
 
@@ -309,7 +321,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             Optional path or list of paths limiting the Commits to those that
             contain at least one of the paths
         :param kwargs: All arguments allowed by git-rev-list
-        :return: Iterator yielding Commit objects which are parents of self"""
+        :return: Iterator yielding Commit objects which are parents of self
+        """
         # skip ourselves
         skip = kwargs.get("skip", 1)
         if skip == 0:  # skip ourselves
@@ -323,7 +336,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """Create a git stat from changes between this commit and its first parent
         or from all changes done if this is the very first commit.
 
-        :return: git.Stats"""
+        :return: git.Stats
+        """
         if not self.parents:
             text = self.repo.git.diff_tree(self.hexsha, "--", numstat=True, no_renames=True, root=True)
             text2 = ""
@@ -339,17 +353,18 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def trailers(self) -> Dict[str, str]:
         """Get the trailers of the message as a dictionary
 
-        :note: This property is deprecated, please use either ``Commit.trailers_list`` or ``Commit.trailers_dict``.
+        :note: This property is deprecated, please use either ``Commit.trailers_list``
+            or ``Commit.trailers_dict``.
 
         :return:
-            Dictionary containing whitespace stripped trailer information.
-            Only contains the latest instance of each trailer key.
+            Dictionary containing whitespace stripped trailer information. Only contains
+            the latest instance of each trailer key.
         """
         return {k: v[0] for k, v in self.trailers_dict.items()}
 
     @property
     def trailers_list(self) -> List[Tuple[str, str]]:
-        """Get the trailers of the message as a list
+        """Get the trailers of the message as a list.
 
         Git messages can contain trailer information that are similar to RFC 822
         e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
@@ -399,7 +414,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     @property
     def trailers_dict(self) -> Dict[str, List[str]]:
-        """Get the trailers of the message as a dictionary
+        """Get the trailers of the message as a dictionary.
 
         Git messages can contain trailer information that are similar to RFC 822
         e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
@@ -440,12 +455,14 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     @classmethod
     def _iter_from_process_or_stream(cls, repo: "Repo", proc_or_stream: Union[Popen, IO]) -> Iterator["Commit"]:
-        """Parse out commit information into a list of Commit objects
+        """Parse out commit information into a list of Commit objects.
+
         We expect one-line per commit, and parse the actual commit information directly
-        from our lighting fast object database
+        from our lighting fast object database.
 
         :param proc: git-rev-list process instance - one sha per line
-        :return: iterator returning Commit objects"""
+        :return: iterator supplying :class:`Commit` objects
+        """
 
         # def is_proc(inp) -> TypeGuard[Popen]:
         #     return hasattr(proc_or_stream, 'wait') and not hasattr(proc_or_stream, 'readline')
@@ -468,15 +485,16 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 break
             hexsha = line.strip()
             if len(hexsha) > 40:
-                # split additional information, as returned by bisect for instance
+                # Split additional information, as returned by bisect for instance.
                 hexsha, _ = line.split(None, 1)
             # END handle extra info
 
             assert len(hexsha) == 40, "Invalid line: %s" % hexsha
             yield cls(repo, hex_to_bin(hexsha))
         # END for each line in stream
+
         # TODO: Review this - it seems process handling got a bit out of control
-        # due to many developers trying to fix the open file handles issue
+        # due to many developers trying to fix the open file handles issue.
         if hasattr(proc_or_stream, "wait"):
             proc_or_stream = cast(Popen, proc_or_stream)
             finalize_process(proc_or_stream)
@@ -497,38 +515,38 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """Commit the given tree, creating a commit object.
 
         :param repo: Repo object the commit should be part of
-        :param tree: Tree object or hex or bin sha
-            the tree of the new commit
-        :param message: Commit message. It may be an empty string if no message is provided.
-            It will be converted to a string , in any case.
+        :param tree: Tree object or hex or bin sha. The tree of the new commit.
+        :param message: Commit message. It may be an empty string if no message is
+            provided. It will be converted to a string, in any case.
         :param parent_commits:
-            Optional Commit objects to use as parents for the new commit.
+            Optional :class:`Commit` objects to use as parents for the new commit.
             If empty list, the commit will have no parents at all and become
             a root commit.
-            If None , the current head commit will be the parent of the
-            new commit object
+            If None, the current head commit will be the parent of the
+            new commit object.
         :param head:
             If True, the HEAD will be advanced to the new commit automatically.
-            Else the HEAD will remain pointing on the previous commit. This could
+            Otherwise the HEAD will remain pointing on the previous commit. This could
             lead to undesired results when diffing files.
         :param author: The name of the author, optional. If unset, the repository
             configuration is used to obtain this value.
         :param committer: The name of the committer, optional. If unset, the
             repository configuration is used to obtain this value.
-        :param author_date: The timestamp for the author field
-        :param commit_date: The timestamp for the committer field
+        :param author_date: The timestamp for the author field.
+        :param commit_date: The timestamp for the committer field.
 
-        :return: Commit object representing the new commit
+        :return: Commit object representing the new commit.
 
         :note:
             Additional information about the committer and Author are taken from the
             environment or from the git configuration, see git-commit-tree for
-            more information"""
+            more information.
+        """
         if parent_commits is None:
             try:
                 parent_commits = [repo.head.commit]
             except ValueError:
-                # empty repositories have no head commit
+                # Empty repositories have no head commit.
                 parent_commits = []
             # END handle parent commits
         else:
@@ -538,11 +556,10 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             # end check parent commit types
         # END if parent commits are unset
 
-        # retrieve all additional information, create a commit object, and
-        # serialize it
+        # Retrieve all additional information, create a commit object, and serialize it.
         # Generally:
-        # * Environment variables override configuration values
-        # * Sensible defaults are set according to the git documentation
+        # * Environment variables override configuration values.
+        # * Sensible defaults are set according to the git documentation.
 
         # COMMITTER AND AUTHOR INFO
         cr = repo.config_reader()
@@ -574,14 +591,14 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             committer_time, committer_offset = unix_time, offset
         # END set committer time
 
-        # assume utf8 encoding
+        # Assume UTF-8 encoding.
         enc_section, enc_option = cls.conf_encoding.split(".")
         conf_encoding = cr.get_value(enc_section, enc_option, cls.default_encoding)
         if not isinstance(conf_encoding, str):
             raise TypeError("conf_encoding could not be coerced to str")
 
-        # if the tree is no object, make sure we create one - otherwise
-        # the created commit object is invalid
+        # If the tree is no object, make sure we create one - otherwise
+        # the created commit object is invalid.
         if isinstance(tree, str):
             tree = repo.tree(tree)
         # END tree conversion
@@ -605,15 +622,15 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         new_commit.binsha = cls._calculate_sha_(repo, new_commit)
 
         if head:
-            # need late import here, importing git at the very beginning throws
-            # as well ...
+            # Need late import here, importing git at the very beginning throws
+            # as well...
             import git.refs
 
             try:
                 repo.head.set_commit(new_commit, logmsg=message)
             except ValueError:
-                # head is not yet set to the ref our HEAD points to
-                # Happens on first commit
+                # head is not yet set to the ref our HEAD points to.
+                # Happens on first commit.
                 master = git.refs.Head.create(
                     repo,
                     repo.head.ref,
@@ -651,7 +668,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             ).encode(self.encoding)
         )
 
-        # encode committer
+        # Encode committer.
         aname = c.name
         write(
             (
@@ -679,7 +696,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
         write(b"\n")
 
-        # write plain bytes, be sure its encoded according to our encoding
+        # Write plain bytes, be sure its encoded according to our encoding.
         if isinstance(self.message, str):
             write(self.message.encode(self.encoding))
         else:
@@ -703,11 +720,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         # END for each parent line
         self.parents = tuple(self.parents)
 
-        # we don't know actual author encoding before we have parsed it, so keep the lines around
+        # We don't know actual author encoding before we have parsed it, so keep the lines around.
         author_line = next_line
         committer_line = readline()
 
-        # we might run into one or more mergetag blocks, skip those for now
+        # We might run into one or more mergetag blocks, skip those for now.
         next_line = readline()
         while next_line.startswith(b"mergetag "):
             next_line = readline()
@@ -715,12 +732,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 next_line = readline()
         # end skip mergetags
 
-        # now we can have the encoding line, or an empty line followed by the optional
-        # message.
+        # Now we can have the encoding line, or an empty line followed by the optional message.
         self.encoding = self.default_encoding
         self.gpgsig = ""
 
-        # read headers
+        # Read headers.
         enc = next_line
         buf = enc.strip()
         while buf:
@@ -743,8 +759,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 if is_next_header:
                     continue
             buf = readline().strip()
-        # decode the authors name
 
+        # Decode the author's name.
         try:
             (
                 self.author,
@@ -774,8 +790,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             )
         # END handle author's encoding
 
-        # a stream from our data simply gives us the plain message
-        # The end of our message stream is marked with a newline that we strip
+        # A stream from our data simply gives us the plain message.
+        # The end of our message stream is marked with a newline that we strip.
         self.message = stream.read()
         try:
             self.message = self.message.decode(self.encoding, "replace")
@@ -796,6 +812,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def co_authors(self) -> List[Actor]:
         """
         Search the commit message for any co-authors of this commit.
+
         Details on co-authors: https://github.blog/2018-01-29-commit-together-with-co-authors/
 
         :return: List of co-authors for this commit (as Actor objects).

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -553,7 +553,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             for p in parent_commits:
                 if not isinstance(p, cls):
                     raise ValueError(f"Parent commit '{p!r}' must be of type {cls}")
-            # end check parent commit types
+            # END check parent commit types
         # END if parent commits are unset
 
         # Retrieve all additional information, create a commit object, and serialize it.
@@ -730,7 +730,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             next_line = readline()
             while next_line.startswith(b" "):
                 next_line = readline()
-        # end skip mergetags
+        # END skip mergetags
 
         # Now we can have the encoding line, or an empty line followed by the optional message.
         self.encoding = self.default_encoding
@@ -754,7 +754,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                         is_next_header = True
                         break
                     sig += sigbuf[1:]
-                # end read all signature
+                # END read all signature
                 self.gpgsig = sig.rstrip(b"\n").decode(self.encoding, "ignore")
                 if is_next_header:
                     continue

--- a/git/objects/submodule/__init__.py
+++ b/git/objects/submodule/__init__.py
@@ -1,2 +1,2 @@
-# NOTE: Cannot import anything here as the top-level _init_ has to handle
-# our dependencies
+# NOTE: Cannot import anything here as the top-level __init__ has to handle
+# our dependencies.

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -57,9 +57,8 @@ log.addHandler(logging.NullHandler())
 
 
 class UpdateProgress(RemoteProgress):
-
     """Class providing detailed progress information to the caller who should
-    derive from it and implement the ``update(...)`` message"""
+    derive from it and implement the ``update(...)`` message."""
 
     CLONE, FETCH, UPDWKTREE = [1 << x for x in range(RemoteProgress._num_op_codes, RemoteProgress._num_op_codes + 3)]
     _num_op_codes: int = RemoteProgress._num_op_codes + 3
@@ -78,25 +77,27 @@ UPDWKTREE = UpdateProgress.UPDWKTREE
 # mechanism which cause plenty of trouble of the only reason for packages and
 # modules is refactoring - subpackages shouldn't depend on parent packages
 class Submodule(IndexObject, TraversableIterableObj):
-
     """Implements access to a git submodule. They are special in that their sha
     represents a commit in the submodule's repository which is to be checked out
     at the path of this instance.
+
     The submodule type does not have a string type associated with it, as it exists
     solely as a marker in the tree and index.
 
-    All methods work in bare and non-bare repositories."""
+    All methods work in bare and non-bare repositories.
+    """
 
     _id_attribute_ = "name"
     k_modules_file = ".gitmodules"
     k_head_option = "branch"
     k_head_default = "master"
-    k_default_mode = stat.S_IFDIR | stat.S_IFLNK  # submodules are directories with link-status
+    k_default_mode = stat.S_IFDIR | stat.S_IFLNK  # Submodules are directories with link-status.
 
-    # this is a bogus type for base class compatibility
+    # This is a bogus type for base class compatibility.
     type: Literal["submodule"] = "submodule"  # type: ignore
 
     __slots__ = ("_parent_commit", "_url", "_branch_path", "_name", "__weakref__")
+
     _cache_attrs = ("path", "_url", "_branch_path")
 
     def __init__(
@@ -110,14 +111,17 @@ class Submodule(IndexObject, TraversableIterableObj):
         url: Union[str, None] = None,
         branch_path: Union[PathLike, None] = None,
     ) -> None:
-        """Initialize this instance with its attributes. We only document the ones
-        that differ from ``IndexObject``
+        """Initialize this instance with its attributes.
+
+        We only document the parameters that differ
+        from :class:`IndexObject <git.objects.base.IndexObject>`.
 
         :param repo: Our parent repository
         :param binsha: binary sha referring to a commit in the remote repository, see url parameter
         :param parent_commit: see set_parent_commit()
         :param url: The url to the remote repository which is the submodule
-        :param branch_path: full (relative) path to ref to checkout when cloning the remote repository"""
+        :param branch_path: full (relative) path to ref to checkout when cloning the remote repository
+        """
         super(Submodule, self).__init__(repo, binsha, mode, path)
         self.size = 0
         self._parent_commit = parent_commit
@@ -165,18 +169,18 @@ class Submodule(IndexObject, TraversableIterableObj):
         return git.version_info[:3] >= (1, 7, 5)
 
     def __eq__(self, other: Any) -> bool:
-        """Compare with another submodule"""
-        # we may only compare by name as this should be the ID they are hashed with
-        # Otherwise this type wouldn't be hashable
+        """Compare with another submodule."""
+        # We may only compare by name as this should be the ID they are hashed with.
+        # Otherwise this type wouldn't be hashable.
         # return self.path == other.path and self.url == other.url and super(Submodule, self).__eq__(other)
         return self._name == other._name
 
     def __ne__(self, other: object) -> bool:
-        """Compare with another submodule for inequality"""
+        """Compare with another submodule for inequality."""
         return not (self == other)
 
     def __hash__(self) -> int:
-        """Hash this instance using its logical id, not the sha"""
+        """Hash this instance using its logical id, not the sha."""
         return hash(self._name)
 
     def __str__(self) -> str:
@@ -195,16 +199,19 @@ class Submodule(IndexObject, TraversableIterableObj):
     def _config_parser(
         cls, repo: "Repo", parent_commit: Union[Commit_ish, None], read_only: bool
     ) -> SubmoduleConfigParser:
-        """:return: Config Parser constrained to our submodule in read or write mode
-        :raise IOError: If the .gitmodules file cannot be found, either locally or in the repository
-            at the given parent commit. Otherwise the exception would be delayed until the first
-            access of the config parser"""
+        """
+        :return: Config Parser constrained to our submodule in read or write mode
+
+        :raise IOError: If the .gitmodules file cannot be found, either locally or in
+            the repository at the given parent commit. Otherwise the exception would be
+            delayed until the first access of the config parser.
+        """
         parent_matches_head = True
         if parent_commit is not None:
             try:
                 parent_matches_head = repo.head.commit == parent_commit
             except ValueError:
-                # We are most likely in an empty repository, so the HEAD doesn't point to a valid ref
+                # We are most likely in an empty repository, so the HEAD doesn't point to a valid ref.
                 pass
         # end handle parent_commit
         fp_module: Union[str, BytesIO]
@@ -228,7 +235,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         return SubmoduleConfigParser(fp_module, read_only=read_only)
 
     def _clear_cache(self) -> None:
-        # clear the possibly changed values
+        """Clear the possibly changed values."""
         for name in self._cache_attrs:
             try:
                 delattr(self, name)
@@ -275,14 +282,16 @@ class Submodule(IndexObject, TraversableIterableObj):
         allow_unsafe_protocols: bool = False,
         **kwargs: Any,
     ) -> "Repo":
-        """:return: Repo instance of newly cloned repository
-        :param repo: our parent repository
-        :param url: url to clone from
-        :param path: repository - relative path to the submodule checkout location
-        :param name: canonical of the submodule
+        """
+        :return: Repo instance of newly cloned repository
+        :param repo: Our parent repository
+        :param url: URL to clone from
+        :param path: Repository - relative path to the submodule checkout location
+        :param name: Canonical name of the submodule
         :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
         :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :param kwargs: additional arguments given to git.clone"""
+        :param kwargs: Additional arguments given to git.clone
+        """
         module_abspath = cls._module_abspath(repo, path, name)
         module_checkout_path = module_abspath
         if cls._need_gitfile_submodules(repo.git):
@@ -331,14 +340,16 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _write_git_file_and_module_config(cls, working_tree_dir: PathLike, module_abspath: PathLike) -> None:
-        """Writes a .git file containing a(preferably) relative path to the actual git module repository.
+        """Write a .git file containing a(preferably) relative path to the actual git module repository.
+
         It is an error if the module_abspath cannot be made into a relative path, relative to the working_tree_dir
-        :note: will overwrite existing files !
+
+        :note: This will overwrite existing files!
         :note: as we rewrite both the git file as well as the module configuration, we might fail on the configuration
             and will not roll back changes done to the git file. This should be a non - issue, but may easily be fixed
-            if it becomes one
-        :param working_tree_dir: directory to write the .git file into
-        :param module_abspath: absolute path to the bare repository
+            if it becomes one.
+        :param working_tree_dir: Directory to write the .git file into
+        :param module_abspath: Absolute path to the bare repository
         """
         git_file = osp.join(working_tree_dir, ".git")
         rela_path = osp.relpath(module_abspath, start=working_tree_dir)
@@ -377,15 +388,15 @@ class Submodule(IndexObject, TraversableIterableObj):
         If the submodule already exists, no matter if the configuration differs
         from the one provided, the existing submodule will be returned.
 
-        :param repo: Repository instance which should receive the submodule
-        :param name: The name/identifier for the submodule
-        :param path: repository-relative or absolute path at which the submodule
-            should be located
+        :param repo: Repository instance which should receive the submodule.
+        :param name: The name/identifier for the submodule.
+        :param path: Repository-relative or absolute path at which the submodule
+            should be located.
             It will be created as required during the repository initialization.
-        :param url: git-clone compatible URL, see git-clone reference for more information
+        :param url: git-clone compatible URL, see git-clone reference for more information.
             If None, the repository is assumed to exist, and the url of the first
             remote is taken instead. This is useful if you want to make an existing
-            repository a submodule of anotherone.
+            repository a submodule of another one.
         :param branch: name of branch at which the submodule should (later) be checked out.
             The given branch must exist in the remote repository, and will be checked
             out locally as a tracking branch.
@@ -393,24 +404,25 @@ class Submodule(IndexObject, TraversableIterableObj):
             when the checked out branch will be the one the remote HEAD pointed to.
             The result you get in these situation is somewhat fuzzy, and it is recommended
             to specify at least 'master' here.
-            Examples are 'master' or 'feature/new'
-        :param no_checkout: if True, and if the repository has to be cloned manually,
-            no checkout will be performed
+            Examples are 'master' or 'feature/new'.
+        :param no_checkout: If True, and if the repository has to be cloned manually,
+            no checkout will be performed.
         :param depth: Create a shallow clone with a history truncated to the
             specified number of commits.
         :param env: Optional dictionary containing the desired environment variables.
-            Note: Provided variables will be used to update the execution
-            environment for `git`. If some variable is not specified in `env`
-            and is defined in `os.environ`, value from `os.environ` will be used.
-            If you want to unset some variable, consider providing empty string
-            as its value.
-        :param clone_multi_options: A list of Clone options. Please see ``git.repo.base.Repo.clone``
-            for details.
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
+            Note: Provided variables will be used to update the execution environment
+            for ``git``. If some variable is not specified in `env` and is defined in
+            attr:`os.environ`, the value from attr:`os.environ` will be used. If you
+            want to unset some variable, consider providing an empty string as its
+            value.
+        :param clone_multi_options: A list of Clone options. Please see
+            :meth:`Repo.clone <git.repo.base.Repo.clone>` for details.
+        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
         :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :return: The newly created submodule instance
-        :note: works atomically, such that no change will be done if the repository
-            update fails for instance"""
+        :return: The newly created submodule instance.
+        :note: Works atomically, such that no change will be done if the repository
+            update fails for instance.
+        """
 
         if repo.bare:
             raise InvalidGitRepositoryError("Cannot add submodules to bare repositories")
@@ -418,11 +430,11 @@ class Submodule(IndexObject, TraversableIterableObj):
 
         path = cls._to_relative_path(repo, path)
 
-        # assure we never put backslashes into the url, as some operating systems
-        # like it ...
+        # Ensure we never put backslashes into the URL, as some operating systems
+        # like it...
         if url is not None:
             url = to_native_path_linux(url)
-        # END assure url correctness
+        # END ensure URL correctness
 
         # INSTANTIATE INTERMEDIATE SM
         sm = cls(
@@ -434,13 +446,13 @@ class Submodule(IndexObject, TraversableIterableObj):
             url="invalid-temporary",
         )
         if sm.exists():
-            # reretrieve submodule from tree
+            # Reretrieve submodule from tree.
             try:
                 sm = repo.head.commit.tree[str(path)]
                 sm._name = name
                 return sm
             except KeyError:
-                # could only be in index
+                # Could only be in index.
                 index = repo.index
                 entry = index.entries[index.entry_key(path, 0)]
                 sm.binsha = entry.binsha
@@ -448,7 +460,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END handle exceptions
         # END handle existing
 
-        # fake-repo - we only need the functionality on the branch instance
+        # fake-repo - we only need the functionality on the branch instance.
         br = git.Head(repo, git.Head.to_full_path(str(branch) or cls.k_head_default))
         has_module = sm.module_exists()
         branch_is_default = branch is None
@@ -501,11 +513,11 @@ class Submodule(IndexObject, TraversableIterableObj):
             )
         # END verify url
 
-        ## See #525 for ensuring git urls in config-files valid under Windows.
+        ## See #525 for ensuring git URLs in config-files are valid under Windows.
         url = Git.polish_url(url)
 
         # It's important to add the URL to the parent config, to let `git submodule` know.
-        # otherwise there is a '-' character in front of the submodule listing
+        # Otherwise there is a '-' character in front of the submodule listing:
         #  a38efa84daef914e4de58d1905a500d8d14aaf45 mymodule (v0.9.0-1-ga38efa8)
         # -a38efa84daef914e4de58d1905a500d8d14aaf45 submodules/intermediate/one
         writer: Union[GitConfigParser, SectionConstraint]
@@ -513,7 +525,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         with sm.repo.config_writer() as writer:
             writer.set_value(sm_section(name), "url", url)
 
-        # update configuration and index
+        # Update configuration and index.
         index = sm.repo.index
         with sm.config_writer(index=index, write=False) as writer:
             writer.set_value("url", url)
@@ -525,7 +537,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                 writer.set_value(cls.k_head_option, br.path)
                 sm._branch_path = br.path
 
-        # we deliberately assume that our head matches our index !
+        # We deliberately assume that our head matches our index!
         if mrepo:
             sm.binsha = mrepo.head.commit.binsha
         index.add([sm], write=True)
@@ -549,40 +561,54 @@ class Submodule(IndexObject, TraversableIterableObj):
         """Update the repository of this submodule to point to the checkout
         we point at with the binsha of this instance.
 
-        :param recursive: if True, we will operate recursively and update child-
-            modules as well.
-        :param init: if True, the module repository will be cloned into place if necessary
-        :param to_latest_revision: if True, the submodule's sha will be ignored during checkout.
-            Instead, the remote will be fetched, and the local tracking branch updated.
-            This only works if we have a local tracking branch, which is the case
-            if the remote repository had a master branch, or of the 'branch' option
-            was specified for this submodule and the branch existed remotely
-        :param progress: UpdateProgress instance or None if no progress should be shown
-        :param dry_run: if True, the operation will only be simulated, but not performed.
-            All performed operations are read - only
+        :param recursive:
+            If True, we will operate recursively and update child modules as well.
+        :param init:
+            If True, the module repository will be cloned into place if necessary.
+        :param to_latest_revision:
+            If True, the submodule's sha will be ignored during checkout. Instead, the
+            remote will be fetched, and the local tracking branch updated. This only
+            works if we have a local tracking branch, which is the case if the remote
+            repository had a master branch, or of the 'branch' option was specified for
+            this submodule and the branch existed remotely.
+        :param progress:
+            UpdateProgress instance or None if no progress should be shown.
+        :param dry_run:
+            If True, the operation will only be simulated, but not performed.
+            All performed operations are read-only.
         :param force:
-            If True, we may reset heads even if the repository in question is dirty. Additinoally we will be allowed
-            to set a tracking branch which is ahead of its remote branch back into the past or the location of the
-            remote branch. This will essentially 'forget' commits.
-            If False, local tracking branches that are in the future of their respective remote branches will simply
-            not be moved.
-        :param keep_going: if True, we will ignore but log all errors, and keep going recursively.
-            Unless dry_run is set as well, keep_going could cause subsequent / inherited errors you wouldn't see
-            otherwise.
-            In conjunction with dry_run, it can be useful to anticipate all errors when updating submodules
+            If True, we may reset heads even if the repository in question is dirty.
+            Additionally we will be allowed to set a tracking branch which is ahead of
+            its remote branch back into the past or the location of the remote branch.
+            This will essentially 'forget' commits.
+            If False, local tracking branches that are in the future of their respective
+            remote branches will simply not be moved.
+        :param keep_going:
+            If True, we will ignore but log all errors, and keep going recursively.
+            Unless dry_run is set as well, keep_going could cause subsequent / inherited
+            errors you wouldn't see otherwise.
+            In conjunction with dry_run, it can be useful to anticipate all errors when
+            updating submodules.
         :param env: Optional dictionary containing the desired environment variables.
-            Note: Provided variables will be used to update the execution
-            environment for `git`. If some variable is not specified in `env`
-            and is defined in `os.environ`, value from `os.environ` will be used.
-            If you want to unset some variable, consider providing empty string
-            as its value.
-        :param clone_multi_options:  list of Clone options. Please see ``git.repo.base.Repo.clone``
-            for details. Only take effect with `init` option.
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :note: does nothing in bare repositories
-        :note: method is definitely not atomic if recurisve is True
-        :return: self"""
+            Note: Provided variables will be used to update the execution environment
+            for ``git``. If some variable is not specified in `env` and is defined in
+            attr:`os.environ`, value from attr:`os.environ` will be used.
+            If you want to unset some variable, consider providing the empty string as
+            its value.
+        :param clone_multi_options:
+            List of Clone options.
+            Please see :meth:`Repo.clone <git.repo.base.Repo.clone>` for details.
+            They only take effect with the `init` option.
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ext.
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like --upload-pack.
+
+        :note: Does nothing in bare repositories.
+        :note: This method is definitely not atomic if `recursive` is True.
+
+        :return: self
+        """
         if self.repo.bare:
             return self
         # END pass in bare mode
@@ -595,14 +621,14 @@ class Submodule(IndexObject, TraversableIterableObj):
             prefix = "DRY-RUN: "
         # END handle prefix
 
-        # to keep things plausible in dry-run mode
+        # To keep things plausible in dry-run mode.
         if dry_run:
             mrepo = None
         # END init mrepo
 
         try:
-            # ASSURE REPO IS PRESENT AND UPTODATE
-            #####################################
+            # ENSURE REPO IS PRESENT AND UP-TO-DATE
+            #######################################
             try:
                 mrepo = self.module()
                 rmts = mrepo.remotes
@@ -640,7 +666,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     return self
                 # END early abort if init is not allowed
 
-                # there is no git-repository yet - but delete empty paths
+                # There is no git-repository yet - but delete empty paths.
                 checkout_module_abspath = self.abspath
                 if not dry_run and osp.isdir(checkout_module_abspath):
                     try:
@@ -652,8 +678,8 @@ class Submodule(IndexObject, TraversableIterableObj):
                     # END handle OSError
                 # END handle directory removal
 
-                # don't check it out at first - nonetheless it will create a local
-                # branch according to the remote-HEAD if possible
+                # Don't check it out at first - nonetheless it will create a local
+                # branch according to the remote-HEAD if possible.
                 progress.update(
                     BEGIN | CLONE,
                     0,
@@ -682,19 +708,19 @@ class Submodule(IndexObject, TraversableIterableObj):
                 )
 
                 if not dry_run:
-                    # see whether we have a valid branch to checkout
+                    # See whether we have a valid branch to check out.
                     try:
                         mrepo = cast("Repo", mrepo)
-                        # find  a remote which has our branch - we try to be flexible
+                        # Find a remote which has our branch - we try to be flexible.
                         remote_branch = find_first_remote_branch(mrepo.remotes, self.branch_name)
                         local_branch = mkhead(mrepo, self.branch_path)
 
-                        # have a valid branch, but no checkout - make sure we can figure
-                        # that out by marking the commit with a null_sha
+                        # Have a valid branch, but no checkout - make sure we can figure
+                        # that out by marking the commit with a null_sha.
                         local_branch.set_object(Object(mrepo, self.NULL_BIN_SHA))
                         # END initial checkout + branch creation
 
-                        # make sure HEAD is not detached
+                        # Make sure HEAD is not detached.
                         mrepo.head.set_reference(
                             local_branch,
                             logmsg="submodule: attaching head to %s" % local_branch,
@@ -704,21 +730,21 @@ class Submodule(IndexObject, TraversableIterableObj):
                         log.warning("Failed to checkout tracking branch %s", self.branch_path)
                     # END handle tracking branch
 
-                    # NOTE: Have to write the repo config file as well, otherwise
-                    # the default implementation will be offended and not update the repository
-                    # Maybe this is a good way to assure it doesn't get into our way, but
-                    # we want to stay backwards compatible too ... . Its so redundant !
+                    # NOTE: Have to write the repo config file as well, otherwise the
+                    # default implementation will be offended and not update the repository.
+                    # Maybe this is a good way to ensure it doesn't get into our way, but
+                    # we want to stay backwards compatible too... It's so redundant!
                     with self.repo.config_writer() as writer:
                         writer.set_value(sm_section(self.name), "url", self.url)
                 # END handle dry_run
             # END handle initialization
 
-            # DETERMINE SHAS TO CHECKOUT
-            ############################
+            # DETERMINE SHAS TO CHECK OUT
+            #############################
             binsha = self.binsha
             hexsha = self.hexsha
             if mrepo is not None:
-                # mrepo is only set if we are not in dry-run mode or if the module existed
+                # mrepo is only set if we are not in dry-run mode or if the module existed.
                 is_detached = mrepo.head.is_detached
             # END handle dry_run
 
@@ -742,13 +768,13 @@ class Submodule(IndexObject, TraversableIterableObj):
                 # END handle detached head
             # END handle to_latest_revision option
 
-            # update the working tree
-            # handles dry_run
+            # Update the working tree.
+            # Handles dry_run.
             if mrepo is not None and mrepo.head.commit.binsha != binsha:
-                # We must assure that our destination sha (the one to point to) is in the future of our current head.
-                # Otherwise, we will reset changes that might have been done on the submodule, but were not yet pushed
+                # We must ensure that our destination sha (the one to point to) is in the future of our current head.
+                # Otherwise, we will reset changes that might have been done on the submodule, but were not yet pushed.
                 # We also handle the case that history has been rewritten, leaving no merge-base. In that case
-                # we behave conservatively, protecting possible changes the user had done
+                # we behave conservatively, protecting possible changes the user had done.
                 may_reset = True
                 if mrepo.head.commit.binsha != self.NULL_BIN_SHA:
                     base_commit = mrepo.merge_base(mrepo.head.commit, hexsha)
@@ -785,7 +811,7 @@ class Submodule(IndexObject, TraversableIterableObj):
 
                 if not dry_run and may_reset:
                     if is_detached:
-                        # NOTE: for now we force, the user is no supposed to change detached
+                        # NOTE: For now we force. The user is not supposed to change detached
                         # submodules anyway. Maybe at some point this becomes an option, to
                         # properly handle user modifications - see below for future options
                         # regarding rebase and merge.
@@ -793,7 +819,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     else:
                         mrepo.head.reset(hexsha, index=True, working_tree=True)
                     # END handle checkout
-                # if we may reset/checkout
+                # If we may reset/checkout.
                 progress.update(
                     END | UPDWKTREE,
                     0,
@@ -810,7 +836,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         # HANDLE RECURSION
         ##################
         if recursive:
-            # in dry_run mode, the module might not exist
+            # In dry_run mode, the module might not exist.
             if mrepo is not None:
                 for submodule in self.iter_items(self.module()):
                     submodule.update(
@@ -834,19 +860,19 @@ class Submodule(IndexObject, TraversableIterableObj):
         the repository at our current path, changing the configuration, as well as
         adjusting our index entry accordingly.
 
-        :param module_path: the path to which to move our module in the parent repostory's working tree,
-            given as repository - relative or absolute path. Intermediate directories will be created
-            accordingly. If the path already exists, it must be empty.
-            Trailing(back)slashes are removed automatically
-        :param configuration: if True, the configuration will be adjusted to let
+        :param module_path: The path to which to move our module in the parent
+            repository's working tree, given as repository - relative or absolute path.
+            Intermediate directories will be created accordingly. If the path already
+            exists, it must be empty. Trailing (back)slashes are removed automatically.
+        :param configuration: If True, the configuration will be adjusted to let
             the submodule point to the given path.
-        :param module: if True, the repository managed by this submodule
-            will be moved as well. If False, we don't move the submodule's checkout, which may leave
-            the parent repository in an inconsistent state.
+        :param module: If True, the repository managed by this submodule
+            will be moved as well. If False, we don't move the submodule's checkout,
+            which may leave the parent repository in an inconsistent state.
         :return: self
-        :raise ValueError: if the module path existed and was not empty, or was a file
+        :raise ValueError: If the module path existed and was not empty, or was a file.
         :note: Currently the method is not atomic, and it could leave the repository
-            in an inconsistent state if a sub - step fails for some reason
+            in an inconsistent state if a sub-step fails for some reason.
         """
         if module + configuration < 1:
             raise ValueError("You must specify to move at least the module or the configuration of the submodule")
@@ -871,7 +897,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             raise ValueError("Index entry for target path did already exist")
         # END handle index key already there
 
-        # remove existing destination
+        # Remove existing destination.
         if module:
             if osp.exists(module_checkout_abspath):
                 if len(os.listdir(module_checkout_abspath)):
@@ -884,13 +910,13 @@ class Submodule(IndexObject, TraversableIterableObj):
                     os.rmdir(module_checkout_abspath)
                 # END handle link
             else:
-                # recreate parent directories
-                # NOTE: renames() does that now
+                # Recreate parent directories.
+                # NOTE: renames() does that now.
                 pass
             # END handle existence
         # END handle module
 
-        # move the module into place if possible
+        # Move the module into place if possible.
         cur_path = self.abspath
         renamed_module = False
         if module and osp.exists(cur_path):
@@ -903,8 +929,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             # end handle git file rewrite
         # END move physical module
 
-        # rename the index entry - have to manipulate the index directly as
-        # git-mv cannot be used on submodules ... yeah
+        # Rename the index entry - we have to manipulate the index directly as
+        # git-mv cannot be used on submodules... yeah.
         previous_sm_path = self.path
         try:
             if configuration:
@@ -918,8 +944,8 @@ class Submodule(IndexObject, TraversableIterableObj):
                     raise InvalidGitRepositoryError("Submodule's entry at %r did not exist" % (self.path)) from e
                 # END handle submodule doesn't exist
 
-                # update configuration
-                with self.config_writer(index=index) as writer:  # auto-write
+                # Update configuration.
+                with self.config_writer(index=index) as writer:  # Auto-write.
                     writer.set_value("path", module_checkout_path)
                     self.path = module_checkout_path
             # END handle configuration flag
@@ -930,7 +956,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             raise
         # END handle undo rename
 
-        # Auto-rename submodule if it's name was 'default', that is, the checkout directory
+        # Auto-rename submodule if it's name was 'default', that is, the checkout directory.
         if previous_sm_path == self.name:
             self.rename(module_checkout_path)
         # end
@@ -946,7 +972,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         dry_run: bool = False,
     ) -> "Submodule":
         """Remove this submodule from the repository. This will remove our entry
-        from the .gitmodules file and the entry in the .git / config file.
+        from the .gitmodules file and the entry in the .git/config file.
 
         :param module: If True, the checked out module we point to will be deleted as
             well.If that module is currently on a commit outside any branch in the
@@ -959,22 +985,23 @@ class Submodule(IndexObject, TraversableIterableObj):
         :param force: Enforces the deletion of the module even though it contains
             modifications. This basically enforces a brute-force file system based
             deletion.
-        :param configuration: if True, the submodule is deleted from the configuration,
-            otherwise it isn't. Although this should be enabled most of the times,
+        :param configuration: If True, the submodule is deleted from the configuration,
+            otherwise it isn't. Although this should be enabled most of the time,
             this flag enables you to safely delete the repository of your submodule.
-        :param dry_run: if True, we will not actually do anything, but throw the errors
-            we would usually throw
+        :param dry_run: If True, we will not actually do anything, but throw the errors
+            we would usually throw.
         :return: self
-        :note: doesn't work in bare repositories
-        :note: doesn't work atomically, as failure to remove any part of the submodule will leave
-            an inconsistent state
-        :raise InvalidGitRepositoryError: thrown if the repository cannot be deleted
-        :raise OSError: if directories or files could not be removed"""
+        :note: Doesn't work in bare repositories.
+        :note: Doesn't work atomically, as failure to remove any part of the submodule
+            will leave an inconsistent state.
+        :raise InvalidGitRepositoryError: Thrown if the repository cannot be deleted.
+        :raise OSError: If directories or files could not be removed.
+        """
         if not (module or configuration):
             raise ValueError("Need to specify to delete at least the module, or the configuration")
         # END handle parameters
 
-        # Recursively remove children of this submodule
+        # Recursively remove children of this submodule.
         nc = 0
         for csm in self.children():
             nc += 1
@@ -982,8 +1009,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             del csm
         # end
         if configuration and not dry_run and nc > 0:
-            # Assure we don't leave the parent repository in a dirty state, and commit our changes
-            # It's important for recursive, unforced, deletions to work as expected
+            # Ensure we don't leave the parent repository in a dirty state, and commit our changes.
+            # It's important for recursive, unforced, deletions to work as expected.
             self.module().index.commit("Removed at least one of child-modules of '%s'" % self.name)
         # end handle recursion
 
@@ -993,9 +1020,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             mod = self.module()
             git_dir = mod.git_dir
             if force:
-                # take the fast lane and just delete everything in our module path
+                # Take the fast lane and just delete everything in our module path.
                 # TODO: If we run into permission problems, we have a highly inconsistent
-                # state. Delete the .git folders last, start with the submodules first
+                # state. Delete the .git folders last, start with the submodules first.
                 mp = self.abspath
                 method: Union[None, Callable[[PathLike], None]] = None
                 if osp.islink(mp):
@@ -1010,7 +1037,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     method(mp)
                 # END apply deletion method
             else:
-                # verify we may delete our module
+                # Verify we may delete our module.
                 if mod.is_dirty(index=True, working_tree=True, untracked_files=True):
                     raise InvalidGitRepositoryError(
                         "Cannot delete module at %s with any modifications, unless force is specified"
@@ -1018,25 +1045,27 @@ class Submodule(IndexObject, TraversableIterableObj):
                     )
                 # END check for dirt
 
-                # figure out whether we have new commits compared to the remotes
-                # NOTE: If the user pulled all the time, the remote heads might
-                # not have been updated, so commits coming from the remote look
-                # as if they come from us. But we stay strictly read-only and
-                # don't fetch beforehand.
+                # Figure out whether we have new commits compared to the remotes.
+                # NOTE: If the user pulled all the time, the remote heads might not have
+                # been updated, so commits coming from the remote look as if they come
+                # from us. But we stay strictly read-only and don't fetch beforehand.
                 for remote in mod.remotes:
                     num_branches_with_new_commits = 0
                     rrefs = remote.refs
                     for rref in rrefs:
                         num_branches_with_new_commits += len(mod.git.cherry(rref)) != 0
                     # END for each remote ref
-                    # not a single remote branch contained all our commits
+                    # Not a single remote branch contained all our commits.
                     if len(rrefs) and num_branches_with_new_commits == len(rrefs):
                         raise InvalidGitRepositoryError(
                             "Cannot delete module at %s as there are new commits" % mod.working_tree_dir
                         )
                     # END handle new commits
-                    # have to manually delete references as python's scoping is
-                    # not existing, they could keep handles open ( on windows this is a problem )
+                    # We have to manually delete some references to allow resources to
+                    # be cleaned up immediately when we are done with them, because
+                    # Python's scoping is no more granular than the whole function (loop
+                    # bodies are not scopes). When the objects stay alive longer, they
+                    # can keep handles open. On Windows, this is a problem.
                     if len(rrefs):
                         del rref  # skipcq: PYL-W0631
                     # END handle remotes
@@ -1044,11 +1073,11 @@ class Submodule(IndexObject, TraversableIterableObj):
                     del remote
                 # END for each remote
 
-                # finally delete our own submodule
+                # Finally delete our own submodule.
                 if not dry_run:
                     self._clear_cache()
                     wtd = mod.working_tree_dir
-                    del mod  # release file-handles (windows)
+                    del mod  # Release file-handles (Windows).
                     import gc
 
                     gc.collect()
@@ -1062,14 +1091,14 @@ class Submodule(IndexObject, TraversableIterableObj):
             # end handle separate bare repository
         # END handle module deletion
 
-        # void our data not to delay invalid access
+        # Void our data so as not to delay invalid access.
         if not dry_run:
             self._clear_cache()
 
         # DELETE CONFIGURATION
         ######################
         if configuration and not dry_run:
-            # first the index-entry
+            # First the index-entry.
             parent_index = self.repo.index
             try:
                 del parent_index.entries[parent_index.entry_key(self.path, 0)]
@@ -1078,8 +1107,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END delete entry
             parent_index.write()
 
-            # now git config - need the config intact, otherwise we can't query
-            # information anymore
+            # Now git config - we need the config intact, otherwise we can't query
+            # information anymore.
 
             with self.repo.config_writer() as gcp_writer:
                 gcp_writer.remove_section(sm_section(self.name))
@@ -1095,15 +1124,16 @@ class Submodule(IndexObject, TraversableIterableObj):
         contain the .gitmodules blob.
 
         :param commit:
-            Commit-ish reference pointing at the root_tree, or None to always point to the
-            most recent commit
+            Commit-ish reference pointing at the root_tree, or None to always point to
+            the most recent commit
         :param check:
-            if True, relatively expensive checks will be performed to verify
+            If True, relatively expensive checks will be performed to verify
             validity of the submodule.
-        :raise ValueError: if the commit's tree didn't contain the .gitmodules blob.
+        :raise ValueError: If the commit's tree didn't contain the .gitmodules blob.
         :raise ValueError:
-            if the parent commit didn't store this submodule under the current path
-        :return: self"""
+            If the parent commit didn't store this submodule under the current path.
+        :return: self
+        """
         if commit is None:
             self._parent_commit = None
             return self
@@ -1125,9 +1155,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END handle submodule did not exist
         # END handle checking mode
 
-        # update our sha, it could have changed
-        # If check is False, we might see a parent-commit that doesn't even contain the submodule anymore.
-        # in that case, mark our sha as being NULL
+        # Update our sha, it could have changed.
+        # If check is False, we might see a parent-commit that doesn't even contain the
+        # submodule anymore. in that case, mark our sha as being NULL.
         try:
             self.binsha = pctree[str(self.path)].binsha
         except KeyError:
@@ -1141,19 +1171,23 @@ class Submodule(IndexObject, TraversableIterableObj):
     def config_writer(
         self, index: Union["IndexFile", None] = None, write: bool = True
     ) -> SectionConstraint["SubmoduleConfigParser"]:
-        """:return: a config writer instance allowing you to read and write the data
+        """
+        :return: A config writer instance allowing you to read and write the data
             belonging to this submodule into the .gitmodules file.
 
-        :param index: if not None, an IndexFile instance which should be written.
-            defaults to the index of the Submodule's parent repository.
-        :param write: if True, the index will be written each time a configuration
+        :param index: If not None, an IndexFile instance which should be written.
+            Defaults to the index of the Submodule's parent repository.
+        :param write: If True, the index will be written each time a configuration
             value changes.
-        :note: the parameters allow for a more efficient writing of the index,
+
+        :note: The parameters allow for a more efficient writing of the index,
             as you can pass in a modified index on your own, prevent automatic writing,
-            and write yourself once the whole operation is complete
-        :raise ValueError: if trying to get a writer on a parent_commit which does not
-            match the current head commit
-        :raise IOError: If the .gitmodules file/blob could not be read"""
+            and write yourself once the whole operation is complete.
+
+        :raise ValueError: If trying to get a writer on a parent_commit which does not
+            match the current head commit.
+        :raise IOError: If the .gitmodules file/blob could not be read
+        """
         writer = self._config_parser_constrained(read_only=False)
         if index is not None:
             writer.config._index = index
@@ -1162,17 +1196,19 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @unbare_repo
     def rename(self, new_name: str) -> "Submodule":
-        """Rename this submodule
-        :note: This method takes care of renaming the submodule in various places, such as
+        """Rename this submodule.
+
+        :note:
+            This method takes care of renaming the submodule in various places, such as:
 
             * $parent_git_dir / config
             * $working_tree_dir / .gitmodules
             * (git >= v1.8.0: move submodule repository to new name)
 
-        As .gitmodules will be changed, you would need to make a commit afterwards. The changed .gitmodules file
-        will already be added to the index
+        As .gitmodules will be changed, you would need to make a commit afterwards. The
+        changed .gitmodules file will already be added to the index.
 
-        :return: this submodule instance
+        :return: This submodule instance
         """
         if self.name == new_name:
             return self
@@ -1195,7 +1231,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         if mod.has_separate_working_tree():
             destination_module_abspath = self._module_abspath(self.repo, self.path, new_name)
             source_dir = mod.git_dir
-            # Let's be sure the submodule name is not so obviously tied to a directory
+            # Let's be sure the submodule name is not so obviously tied to a directory.
             if str(destination_module_abspath).startswith(str(mod.git_dir)):
                 tmp_dir = self._module_abspath(self.repo, self.path, str(uuid.uuid4()))
                 os.renames(source_dir, tmp_dir)
@@ -1214,9 +1250,12 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @unbare_repo
     def module(self) -> "Repo":
-        """:return: Repo instance initialized from the repository at our submodule path
-        :raise InvalidGitRepositoryError: if a repository was not available. This could
-            also mean that it was not yet initialized"""
+        """
+        :return: Repo instance initialized from the repository at our submodule path
+
+        :raise InvalidGitRepositoryError: If a repository was not available. This could
+            also mean that it was not yet initialized.
+        """
         module_checkout_abspath = self.abspath
         try:
             repo = git.Repo(module_checkout_abspath)
@@ -1230,7 +1269,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         # END handle exceptions
 
     def module_exists(self) -> bool:
-        """:return: True if our module exists and is a valid git repository. See module() method"""
+        """:return: True if our module exists and is a valid git repository. See module() method."""
         try:
             self.module()
             return True
@@ -1241,10 +1280,11 @@ class Submodule(IndexObject, TraversableIterableObj):
     def exists(self) -> bool:
         """
         :return: True if the submodule exists, False otherwise. Please note that
-            a submodule may exist ( in the .gitmodules file) even though its module
-            doesn't exist on disk"""
-        # keep attributes for later, and restore them if we have no valid data
-        # this way we do not actually alter the state of the object
+            a submodule may exist (in the .gitmodules file) even though its module
+            doesn't exist on disk.
+        """
+        # Keep attributes for later, and restore them if we have no valid data.
+        # This way we do not actually alter the state of the object.
         loc = locals()
         for attr in self._cache_attrs:
             try:
@@ -1252,7 +1292,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     loc[attr] = getattr(self, attr)
                 # END if we have the attribute cache
             except (cp.NoSectionError, ValueError):
-                # on PY3, this can happen apparently ... don't know why this doesn't happen on PY2
+                # On PY3, this can happen apparently... don't know why this doesn't happen on PY2.
                 pass
         # END for each attr
         self._clear_cache()
@@ -1274,22 +1314,26 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @property
     def branch(self) -> "Head":
-        """:return: The branch instance that we are to checkout
-        :raise InvalidGitRepositoryError: if our module is not yet checked out"""
+        """
+        :return: The branch instance that we are to checkout
+
+        :raise InvalidGitRepositoryError: If our module is not yet checked out
+        """
         return mkhead(self.module(), self._branch_path)
 
     @property
     def branch_path(self) -> PathLike:
         """
-        :return: full(relative) path as string to the branch we would checkout
-            from the remote and track"""
+        :return: Full (relative) path as string to the branch we would checkout
+            from the remote and track
+        """
         return self._branch_path
 
     @property
     def branch_name(self) -> str:
-        """:return: the name of the branch, which is the shortest possible branch name"""
-        # use an instance method, for this we create a temporary Head instance
-        # which uses a repository that is available at least ( it makes no difference )
+        """:return: The name of the branch, which is the shortest possible branch name"""
+        # Use an instance method, for this we create a temporary Head instance
+        # which uses a repository that is available at least (it makes no difference).
         return git.Head(self.repo, self._branch_path).name
 
     @property
@@ -1299,37 +1343,46 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @property
     def parent_commit(self) -> "Commit_ish":
-        """:return: Commit instance with the tree containing the .gitmodules file
-        :note: will always point to the current head's commit if it was not set explicitly"""
+        """
+        :return: Commit instance with the tree containing the .gitmodules file
+
+        :note: Will always point to the current head's commit if it was not set explicitly.
+        """
         if self._parent_commit is None:
             return self.repo.commit()
         return self._parent_commit
 
     @property
     def name(self) -> str:
-        """:return: The name of this submodule. It is used to identify it within the
+        """
+        :return: The name of this submodule. It is used to identify it within the
             .gitmodules file.
-        :note: by default, the name is the path at which to find the submodule, but
-            in git - python it should be a unique identifier similar to the identifiers
-            used for remotes, which allows to change the path of the submodule
-            easily
+
+        :note: By default, this is the name is the path at which to find the submodule,
+            but in GitPython it should be a unique identifier similar to the identifiers
+            used for remotes, which allows to change the path of the submodule easily.
         """
         return self._name
 
     def config_reader(self) -> SectionConstraint[SubmoduleConfigParser]:
         """
-        :return: ConfigReader instance which allows you to qurey the configuration values
-            of this submodule, as provided by the .gitmodules file
-        :note: The config reader will actually read the data directly from the repository
-            and thus does not need nor care about your working tree.
-        :note: Should be cached by the caller and only kept as long as needed
-        :raise IOError: If the .gitmodules file/blob could not be read"""
+        :return: ConfigReader instance which allows you to query the configuration
+            values of this submodule, as provided by the .gitmodules file.
+
+        :note: The config reader will actually read the data directly from the
+            repository and thus does not need nor care about your working tree.
+
+        :note: Should be cached by the caller and only kept as long as needed.
+
+        :raise IOError: If the .gitmodules file/blob could not be read.
+        """
         return self._config_parser_constrained(read_only=True)
 
     def children(self) -> IterableList["Submodule"]:
         """
         :return: IterableList(Submodule, ...) an iterable list of submodules instances
-            which are children of this submodule or 0 if the submodule is not checked out"""
+            which are children of this submodule or 0 if the submodule is not checked out.
+        """
         return self._get_intermediate_items(self)
 
     # } END query interface
@@ -1344,9 +1397,9 @@ class Submodule(IndexObject, TraversableIterableObj):
         *Args: Any,
         **kwargs: Any,
     ) -> Iterator["Submodule"]:
-        """:return: iterator yielding Submodule instances available in the given repository"""
+        """:return: Iterator yielding Submodule instances available in the given repository"""
         try:
-            pc = repo.commit(parent_commit)  # parent commit instance
+            pc = repo.commit(parent_commit)  # Parent commit instance
             parser = cls._config_parser(repo, pc, read_only=True)
         except (IOError, BadName):
             return iter([])
@@ -1361,13 +1414,13 @@ class Submodule(IndexObject, TraversableIterableObj):
                 b = str(parser.get(sms, cls.k_head_option))
             # END handle optional information
 
-            # get the binsha
+            # Get the binsha.
             index = repo.index
             try:
-                rt = pc.tree  # root tree
+                rt = pc.tree  # Root tree
                 sm = rt[p]
             except KeyError:
-                # try the index, maybe it was just added
+                # Try the index, maybe it was just added.
                 try:
                     entry = index.entries[index.entry_key(p, 0)]
                     sm = Submodule(repo, entry.binsha, entry.mode, entry.path)
@@ -1378,15 +1431,15 @@ class Submodule(IndexObject, TraversableIterableObj):
                 # END handle keyerror
             # END handle critical error
 
-            # Make sure we are looking at a submodule object
+            # Make sure we are looking at a submodule object.
             if type(sm) is not git.objects.submodule.base.Submodule:
                 continue
 
-            # fill in remaining info - saves time as it doesn't have to be parsed again
+            # Fill in remaining info - saves time as it doesn't have to be parsed again.
             sm._name = n
             if pc != repo.commit():
                 sm._parent_commit = pc
-            # end set only if not most recent !
+            # end set only if not most recent!
             sm._branch_path = git.Head.to_full_path(b)
             sm._url = u
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1217,7 +1217,6 @@ class Submodule(IndexObject, TraversableIterableObj):
         """:return: Repo instance initialized from the repository at our submodule path
         :raise InvalidGitRepositoryError: if a repository was not available. This could
             also mean that it was not yet initialized"""
-        # late import to workaround circular dependencies
         module_checkout_abspath = self.abspath
         try:
             repo = git.Repo(module_checkout_abspath)

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -136,7 +136,7 @@ class Submodule(IndexObject, TraversableIterableObj):
     def _set_cache_(self, attr: str) -> None:
         if attr in ("path", "_url", "_branch_path"):
             reader: SectionConstraint = self.config_reader()
-            # default submodule values
+            # Default submodule values.
             try:
                 self.path = reader.get("path")
             except cp.NoSectionError as e:
@@ -147,7 +147,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     ) from e
 
             self._url = reader.get("url")
-            # git-python extension values - optional
+            # GitPython extension values - optional.
             self._branch_path = reader.get_value(self.k_head_option, git.Head.to_full_path(self.k_head_default))
         elif attr == "_name":
             raise AttributeError("Cannot retrieve the name of a submodule if it was not set initially")
@@ -484,7 +484,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END verify we have url
             url = urls[0]
         else:
-            # clone new repo
+            # Clone new repo.
             kwargs: Dict[str, Union[bool, int, str, Sequence[TBD]]] = {"n": no_checkout}
             if not branch_is_default:
                 kwargs["b"] = br.name
@@ -531,7 +531,7 @@ class Submodule(IndexObject, TraversableIterableObj):
 
             sm._url = url
             if not branch_is_default:
-                # store full path
+                # Store full path.
                 writer.set_value(cls.k_head_option, br.path)
                 sm._branch_path = br.path
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -145,7 +145,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                         "This submodule instance does not exist anymore in '%s' file"
                         % osp.join(self.repo.working_tree_dir, ".gitmodules")
                     ) from e
-            # end
+
             self._url = reader.get("url")
             # git-python extension values - optional
             self._branch_path = reader.get_value(self.k_head_option, git.Head.to_full_path(self.k_head_default))
@@ -213,7 +213,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             except ValueError:
                 # We are most likely in an empty repository, so the HEAD doesn't point to a valid ref.
                 pass
-        # end handle parent_commit
+        # END handle parent_commit
         fp_module: Union[str, BytesIO]
         if not repo.bare and parent_matches_head and repo.working_tree_dir:
             fp_module = osp.join(repo.working_tree_dir, cls.k_modules_file)
@@ -257,7 +257,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             pc: Union["Commit_ish", None] = self.parent_commit
         except ValueError:
             pc = None
-        # end handle empty parent repository
+        # END handle empty parent repository
         parser = self._config_parser(self.repo, pc, read_only)
         parser.set_submodule(self)
         return SectionConstraint(parser, sm_section(self.name))
@@ -269,7 +269,6 @@ class Submodule(IndexObject, TraversableIterableObj):
         if parent_repo.working_tree_dir:
             return osp.join(parent_repo.working_tree_dir, path)
         raise NotADirectoryError()
-        # end
 
     @classmethod
     def _clone_repo(
@@ -300,7 +299,6 @@ class Submodule(IndexObject, TraversableIterableObj):
             if not osp.isdir(module_abspath_dir):
                 os.makedirs(module_abspath_dir)
             module_checkout_path = osp.join(str(repo.working_tree_dir), path)
-        # end
 
         clone = git.Repo.clone_from(
             url,
@@ -311,7 +309,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         )
         if cls._need_gitfile_submodules(repo.git):
             cls._write_git_file_and_module_config(module_checkout_path, module_abspath)
-        # end
+
         return clone
 
     @classmethod
@@ -333,8 +331,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             path = path[len(working_tree_linux.rstrip("/")) + 1 :]
             if not path:
                 raise ValueError("Absolute submodule path '%s' didn't yield a valid relative path" % path)
-            # end verify converted relative path makes sense
-        # end convert to a relative path
+            # END verify converted relative path makes sense
+        # END convert to a relative path
 
         return path
 
@@ -792,15 +790,15 @@ class Submodule(IndexObject, TraversableIterableObj):
                             )
                             log.info(msg)
                             may_reset = False
-                        # end handle force
-                    # end handle if we are in the future
+                        # END handle force
+                    # END handle if we are in the future
 
                     if may_reset and not force and mrepo.is_dirty(index=True, working_tree=True, untracked_files=True):
                         raise RepositoryDirtyError(mrepo, "Cannot reset a dirty repository")
-                    # end handle force and dirty state
-                # end handle empty repo
+                    # END handle force and dirty state
+                # END handle empty repo
 
-                # end verify future/past
+                # END verify future/past
                 progress.update(
                     BEGIN | UPDWKTREE,
                     0,
@@ -831,7 +829,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             if not keep_going:
                 raise
             log.error(str(err))
-        # end handle keep_going
+        # END handle keep_going
 
         # HANDLE RECURSION
         ##################
@@ -926,7 +924,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             if osp.isfile(osp.join(module_checkout_abspath, ".git")):
                 module_abspath = self._module_abspath(self.repo, self.path, self.name)
                 self._write_git_file_and_module_config(module_checkout_abspath, module_abspath)
-            # end handle git file rewrite
+            # END handle git file rewrite
         # END move physical module
 
         # Rename the index entry - we have to manipulate the index directly as
@@ -959,7 +957,6 @@ class Submodule(IndexObject, TraversableIterableObj):
         # Auto-rename submodule if it's name was 'default', that is, the checkout directory.
         if previous_sm_path == self.name:
             self.rename(module_checkout_path)
-        # end
 
         return self
 
@@ -1007,12 +1004,12 @@ class Submodule(IndexObject, TraversableIterableObj):
             nc += 1
             csm.remove(module, force, configuration, dry_run)
             del csm
-        # end
+
         if configuration and not dry_run and nc > 0:
             # Ensure we don't leave the parent repository in a dirty state, and commit our changes.
             # It's important for recursive, unforced, deletions to work as expected.
             self.module().index.commit("Removed at least one of child-modules of '%s'" % self.name)
-        # end handle recursion
+        # END handle recursion
 
         # DELETE REPOSITORY WORKING TREE
         ################################
@@ -1088,7 +1085,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             if not dry_run and osp.isdir(git_dir):
                 self._clear_cache()
                 rmtree(git_dir)
-            # end handle separate bare repository
+            # END handle separate bare repository
         # END handle module deletion
 
         # Void our data so as not to delay invalid access.
@@ -1137,7 +1134,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         if commit is None:
             self._parent_commit = None
             return self
-        # end handle None
+        # END handle None
         pcommit = self.repo.commit(commit)
         pctree = pcommit.tree
         if self.k_modules_file not in pctree:
@@ -1162,7 +1159,6 @@ class Submodule(IndexObject, TraversableIterableObj):
             self.binsha = pctree[str(self.path)].binsha
         except KeyError:
             self.binsha = self.NULL_BIN_SHA
-        # end
 
         self._clear_cache()
         return self
@@ -1236,11 +1232,11 @@ class Submodule(IndexObject, TraversableIterableObj):
                 tmp_dir = self._module_abspath(self.repo, self.path, str(uuid.uuid4()))
                 os.renames(source_dir, tmp_dir)
                 source_dir = tmp_dir
-            # end handle self-containment
+            # END handle self-containment
             os.renames(source_dir, destination_module_abspath)
             if mod.working_tree_dir:
                 self._write_git_file_and_module_config(mod.working_tree_dir, destination_module_abspath)
-        # end move separate git repository
+        # END move separate git repository
 
         return self
 
@@ -1439,7 +1435,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             sm._name = n
             if pc != repo.commit():
                 sm._parent_commit = pc
-            # end set only if not most recent!
+            # END set only if not most recent!
             sm._branch_path = git.Head.to_full_path(b)
             sm._url = u
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1095,7 +1095,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         contain the .gitmodules blob.
 
         :param commit:
-            Commit'ish reference pointing at the root_tree, or None to always point to the
+            Commit-ish reference pointing at the root_tree, or None to always point to the
             most recent commit
         :param check:
             if True, relatively expensive checks will be performed to verify

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -755,7 +755,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                     if len(base_commit) == 0 or (base_commit[0] is not None and base_commit[0].hexsha == hexsha):
                         if force:
                             msg = "Will force checkout or reset on local branch that is possibly in the future of"
-                            msg += "the commit it will be checked out to, effectively 'forgetting' new commits"
+                            msg += " the commit it will be checked out to, effectively 'forgetting' new commits"
                             log.debug(msg)
                         else:
                             msg = "Skipping %s on branch '%s' of submodule repo '%s' as it contains un-pushed commits"

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -113,14 +113,16 @@ class Submodule(IndexObject, TraversableIterableObj):
     ) -> None:
         """Initialize this instance with its attributes.
 
-        We only document the parameters that differ
-        from :class:`IndexObject <git.objects.base.IndexObject>`.
+        We only document the parameters that differ from
+        :class:`~git.objects.base.IndexObject`.
 
-        :param repo: Our parent repository
-        :param binsha: binary sha referring to a commit in the remote repository, see url parameter
-        :param parent_commit: see set_parent_commit()
-        :param url: The url to the remote repository which is the submodule
-        :param branch_path: full (relative) path to ref to checkout when cloning the remote repository
+        :param repo: Our parent repository.
+        :param binsha: Binary sha referring to a commit in the remote repository. See
+            the ``url`` parameter.
+        :param parent_commit: See :meth:`set_parent_commit`.
+        :param url: The URL to the remote repository which is the submodule.
+        :param branch_path: Full (relative) path to ref to checkout when cloning the
+            remote repository.
         """
         super(Submodule, self).__init__(repo, binsha, mode, path)
         self.size = 0

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -43,9 +43,11 @@ PATHCHANGE = RootUpdateProgress.PATHCHANGE
 
 
 class RootModule(Submodule):
+    """A (virtual) root of all submodules in the given repository.
 
-    """A (virtual) Root of all submodules in the given repository. It can be used
-    to more easily traverse all submodules of the master repository"""
+    This can be used to more easily traverse all submodules of the
+    superproject (master repository).
+    """
 
     __slots__ = ()
 

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -356,7 +356,7 @@ class RootModule(Submodule):
                             # to be sure...
                             for remote in smmr:
                                 remote.fetch(progress=progress)
-                            # end for each remote
+                            # END for each remote
 
                             try:
                                 tbr = git.Head.create(
@@ -391,7 +391,7 @@ class RootModule(Submodule):
             if not keep_going:
                 raise
             log.error(str(err))
-        # end handle keep_going
+        # END handle keep_going
 
         # FINALLY UPDATE ALL ACTUAL SUBMODULES
         ######################################

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -91,7 +91,7 @@ class RootModule(Submodule):
         Additionally it will detect addition and removal of submodules, which will be handled
         gracefully.
 
-        :param previous_commit: If set to a commit'ish, the commit we should use
+        :param previous_commit: If set to a commit-ish, the commit we should use
             as the previous commit the HEAD pointed to before it was set to the commit it points to now.
             If None, it defaults to HEAD@{1} otherwise
         :param recursive: if True, the children of submodules will be updated as well

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -133,7 +133,7 @@ class RootModule(Submodule):
 
         if progress is None:
             progress = RootUpdateProgress()
-        # END assure progress is set
+        # END ensure progress is set
 
         prefix = ""
         if dry_run:
@@ -300,7 +300,7 @@ class RootModule(Submodule):
                                 smr.rename(orig_name)
 
                                 # Early on, we verified that the our current tracking branch
-                                # exists in the remote. Now we have to assure that the
+                                # exists in the remote. Now we have to ensure that the
                                 # sha we point to is still contained in the new remote
                                 # tracking branch.
                                 smsha = sm.binsha
@@ -367,7 +367,7 @@ class RootModule(Submodule):
                             except OSError:
                                 # ...or reuse the existing one.
                                 tbr = git.Head(smm, sm.branch_path)
-                            # END assure tracking branch exists
+                            # END ensure tracking branch exists
 
                             tbr.set_tracking_branch(find_first_remote_branch(smmr, sm.branch_name))
                             # NOTE: All head-resetting is done in the base implementation of update

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -24,7 +24,7 @@ log.addHandler(logging.NullHandler())
 
 
 class RootUpdateProgress(UpdateProgress):
-    """Utility class which adds more opcodes to the UpdateProgress"""
+    """Utility class which adds more opcodes to the UpdateProgress."""
 
     REMOVE, PATHCHANGE, BRANCHCHANGE, URLCHANGE = [
         1 << x for x in range(UpdateProgress._num_op_codes, UpdateProgress._num_op_codes + 4)
@@ -67,7 +67,7 @@ class RootModule(Submodule):
         )
 
     def _clear_cache(self) -> None:
-        """May not do anything"""
+        """May not do anything."""
         pass
 
     # { Interface
@@ -85,37 +85,48 @@ class RootModule(Submodule):
         keep_going: bool = False,
     ) -> "RootModule":
         """Update the submodules of this repository to the current HEAD commit.
+
         This method behaves smartly by determining changes of the path of a submodules
         repository, next to changes to the to-be-checked-out commit or the branch to be
         checked out. This works if the submodules ID does not change.
-        Additionally it will detect addition and removal of submodules, which will be handled
-        gracefully.
+        Additionally it will detect addition and removal of submodules, which will be
+        handled gracefully.
 
-        :param previous_commit: If set to a commit-ish, the commit we should use
-            as the previous commit the HEAD pointed to before it was set to the commit it points to now.
-            If None, it defaults to HEAD@{1} otherwise
+        :param previous_commit: If set to a commit-ish, the commit we should use as the
+            previous commit the HEAD pointed to before it was set to the commit it
+            points to now.
+            If None, it defaults to ``HEAD@{1}`` otherwise
         :param recursive: if True, the children of submodules will be updated as well
-            using the same technique
-        :param force_remove: If submodules have been deleted, they will be forcibly removed.
-            Otherwise the update may fail if a submodule's repository cannot be deleted as
-            changes have been made to it (see Submodule.update() for more information)
-        :param init: If we encounter a new module which would need to be initialized, then do it.
-        :param to_latest_revision: If True, instead of checking out the revision pointed to
-            by this submodule's sha, the checked out tracking branch will be merged with the
-            latest remote branch fetched from the repository's origin.
-            Unless force_reset is specified, a local tracking branch will never be reset into its past, therefore
-            the remote branch must be in the future for this to have an effect.
-        :param force_reset: if True, submodules may checkout or reset their branch even if the repository has
-            pending changes that would be overwritten, or if the local tracking branch is in the future of the
-            remote tracking branch and would be reset into its past.
-        :param progress: RootUpdateProgress instance or None if no progress should be sent
-        :param dry_run: if True, operations will not actually be performed. Progress messages
-            will change accordingly to indicate the WOULD DO state of the operation.
-        :param keep_going: if True, we will ignore but log all errors, and keep going recursively.
-            Unless dry_run is set as well, keep_going could cause subsequent/inherited errors you wouldn't see
-            otherwise.
-            In conjunction with dry_run, it can be useful to anticipate all errors when updating submodules
-        :return: self"""
+            using the same technique.
+        :param force_remove: If submodules have been deleted, they will be forcibly
+            removed. Otherwise the update may fail if a submodule's repository cannot be
+            deleted as changes have been made to it.
+            (See :meth:`Submodule.update <git.objects.submodule.base.Submodule.update>`
+            for more information.)
+        :param init: If we encounter a new module which would need to be initialized,
+            then do it.
+        :param to_latest_revision: If True, instead of checking out the revision pointed
+            to by this submodule's sha, the checked out tracking branch will be merged
+            with the latest remote branch fetched from the repository's origin.
+            Unless `force_reset` is specified, a local tracking branch will never be
+            reset into its past, therefore the remote branch must be in the future for
+            this to have an effect.
+        :param force_reset: If True, submodules may checkout or reset their branch even
+            if the repository has pending changes that would be overwritten, or if the
+            local tracking branch is in the future of the remote tracking branch and
+            would be reset into its past.
+        :param progress: :class:`RootUpdateProgress` instance or None if no progress
+            should be sent.
+        :param dry_run: If True, operations will not actually be performed. Progress
+            messages will change accordingly to indicate the WOULD DO state of the
+            operation.
+        :param keep_going: If True, we will ignore but log all errors, and keep going
+            recursively. Unless `dry_run` is set as well, `keep_going` could cause
+            subsequent/inherited errors you wouldn't see otherwise.
+            In conjunction with `dry_run`, this can be useful to anticipate all errors
+            when updating submodules.
+        :return: self
+        """
         if self.repo.bare:
             raise InvalidGitRepositoryError("Cannot update submodules in bare repositories")
         # END handle bare
@@ -141,11 +152,11 @@ class RootModule(Submodule):
                         raise IndexError
                     # END handle initial commit
                 except IndexError:
-                    # in new repositories, there is no previous commit
+                    # In new repositories, there is no previous commit.
                     previous_commit = cur_commit
                 # END exception handling
             else:
-                previous_commit = repo.commit(previous_commit)  # obtain commit object
+                previous_commit = repo.commit(previous_commit)  # Obtain commit object.
             # END handle previous commit
 
             psms: "IterableList[Submodule]" = self.list_items(repo, parent_commit=previous_commit)
@@ -164,8 +175,8 @@ class RootModule(Submodule):
                     op |= BEGIN
                 # END handle begin
 
-                # fake it into thinking its at the current commit to allow deletion
-                # of previous module. Trigger the cache to be updated before that
+                # Fake it into thinking its at the current commit to allow deletion
+                # of previous module. Trigger the cache to be updated before that.
                 progress.update(
                     op,
                     i,
@@ -188,7 +199,7 @@ class RootModule(Submodule):
 
             # HANDLE PATH RENAMES
             #####################
-            # url changes + branch changes
+            # URL changes + branch changes.
             csms = spsms & ssms
             len_csms = len(csms)
             for i, csm in enumerate(csms):
@@ -204,7 +215,7 @@ class RootModule(Submodule):
                         len_csms,
                         prefix + "Moving repository of submodule %r from %s to %s" % (sm.name, psm.abspath, sm.abspath),
                     )
-                    # move the module to the new path
+                    # Move the module to the new path.
                     if not dry_run:
                         psm.move(sm.path, module=True, configuration=False)
                     # END handle dry_run
@@ -220,14 +231,14 @@ class RootModule(Submodule):
                     # HANDLE URL CHANGE
                     ###################
                     if sm.url != psm.url:
-                        # Add the new remote, remove the old one
+                        # Add the new remote, remove the old one.
                         # This way, if the url just changes, the commits will not
-                        # have to be re-retrieved
+                        # have to be re-retrieved.
                         nn = "__new_origin__"
                         smm = sm.module()
                         rmts = smm.remotes
 
-                        # don't do anything if we already have the url we search in place
+                        # Don't do anything if we already have the url we search in place.
                         if len([r for r in rmts if r.url == sm.url]) == 0:
                             progress.update(
                                 BEGIN | URLCHANGE,
@@ -250,7 +261,7 @@ class RootModule(Submodule):
                                     )
                                 # END head is not detached
 
-                                # now delete the changed one
+                                # Now delete the changed one.
                                 rmt_for_deletion = None
                                 for remote in rmts:
                                     if remote.url == psm.url:
@@ -259,17 +270,17 @@ class RootModule(Submodule):
                                     # END if urls match
                                 # END for each remote
 
-                                # if we didn't find a matching remote, but have exactly one,
-                                # we can safely use this one
+                                # If we didn't find a matching remote, but have exactly one,
+                                # we can safely use this one.
                                 if rmt_for_deletion is None:
                                     if len(rmts) == 1:
                                         rmt_for_deletion = rmts[0]
                                     else:
-                                        # if we have not found any remote with the original url
+                                        # If we have not found any remote with the original URL
                                         # we may not have a name. This is a special case,
-                                        # and its okay to fail here
-                                        # Alternatively we could just generate a unique name and leave all
-                                        # existing ones in place
+                                        # and its okay to fail here.
+                                        # Alternatively we could just generate a unique name and
+                                        # leave all existing ones in place.
                                         raise InvalidGitRepositoryError(
                                             "Couldn't find original remote-repo at url %r" % psm.url
                                         )
@@ -280,15 +291,15 @@ class RootModule(Submodule):
                                 smm.delete_remote(rmt_for_deletion)
                                 # NOTE: Currently we leave tags from the deleted remotes
                                 # as well as separate tracking branches in the possibly totally
-                                # changed repository ( someone could have changed the url to
-                                # another project ). At some point, one might want to clean
+                                # changed repository (someone could have changed the url to
+                                # another project). At some point, one might want to clean
                                 # it up, but the danger is high to remove stuff the user
-                                # has added explicitly
+                                # has added explicitly.
 
-                                # rename the new remote back to what it was
+                                # Rename the new remote back to what it was.
                                 smr.rename(orig_name)
 
-                                # early on, we verified that the our current tracking branch
+                                # Early on, we verified that the our current tracking branch
                                 # exists in the remote. Now we have to assure that the
                                 # sha we point to is still contained in the new remote
                                 # tracking branch.
@@ -303,10 +314,10 @@ class RootModule(Submodule):
                                 # END for each commit
 
                                 if not found:
-                                    # adjust our internal binsha to use the one of the remote
-                                    # this way, it will be checked out in the next step
+                                    # Adjust our internal binsha to use the one of the remote
+                                    # this way, it will be checked out in the next step.
                                     # This will change the submodule relative to us, so
-                                    # the user will be able to commit the change easily
+                                    # the user will be able to commit the change easily.
                                     log.warning(
                                         "Current sha %s was not contained in the tracking\
              branch at the new remote, setting it the the remote's tracking branch",
@@ -315,7 +326,7 @@ class RootModule(Submodule):
                                     sm.binsha = rref.commit.binsha
                                 # END reset binsha
 
-                                # NOTE: All checkout is performed by the base implementation of update
+                                # NOTE: All checkout is performed by the base implementation of update.
                             # END handle dry_run
                             progress.update(
                                 END | URLCHANGE,
@@ -329,8 +340,7 @@ class RootModule(Submodule):
                     # HANDLE PATH CHANGES
                     #####################
                     if sm.branch_path != psm.branch_path:
-                        # finally, create a new tracking branch which tracks the
-                        # new remote branch
+                        # Finally, create a new tracking branch which tracks the new remote branch.
                         progress.update(
                             BEGIN | BRANCHCHANGE,
                             i,
@@ -342,7 +352,8 @@ class RootModule(Submodule):
                         if not dry_run:
                             smm = sm.module()
                             smmr = smm.remotes
-                            # As the branch might not exist yet, we will have to fetch all remotes to be sure ... .
+                            # As the branch might not exist yet, we will have to fetch all remotes
+                            # to be sure...
                             for remote in smmr:
                                 remote.fetch(progress=progress)
                             # end for each remote
@@ -354,15 +365,16 @@ class RootModule(Submodule):
                                     logmsg="branch: Created from HEAD",
                                 )
                             except OSError:
-                                # ... or reuse the existing one
+                                # ...or reuse the existing one.
                                 tbr = git.Head(smm, sm.branch_path)
                             # END assure tracking branch exists
 
                             tbr.set_tracking_branch(find_first_remote_branch(smmr, sm.branch_name))
                             # NOTE: All head-resetting is done in the base implementation of update
-                            # but we will have to checkout the new branch here. As it still points to the currently
-                            # checkout out commit, we don't do any harm.
-                            # As we don't want to update working-tree or index, changing the ref is all there is to do
+                            # but we will have to checkout the new branch here. As it still points
+                            # to the currently checked out commit, we don't do any harm.
+                            # As we don't want to update working-tree or index, changing the ref is
+                            # all there is to do.
                             smm.head.reference = tbr
                         # END handle dry_run
 
@@ -384,7 +396,7 @@ class RootModule(Submodule):
         # FINALLY UPDATE ALL ACTUAL SUBMODULES
         ######################################
         for sm in sms:
-            # update the submodule using the default method
+            # Update the submodule using the default method.
             sm.update(
                 recursive=False,
                 init=init,
@@ -395,12 +407,12 @@ class RootModule(Submodule):
                 keep_going=keep_going,
             )
 
-            # update recursively depth first - question is which inconsistent
+            # Update recursively depth first - question is which inconsistent
             # state will be better in case it fails somewhere. Defective branch
             # or defective depth. The RootSubmodule type will never process itself,
-            # which was done in the previous expression
+            # which was done in the previous expression.
             if recursive:
-                # the module would exist by now if we are not in dry_run mode
+                # The module would exist by now if we are not in dry_run mode.
                 if sm.module_exists():
                     type(self)(sm.module()).update(
                         recursive=True,
@@ -419,7 +431,7 @@ class RootModule(Submodule):
         return self
 
     def module(self) -> "Repo":
-        """:return: the actual repository containing the submodules"""
+        """:return: The actual repository containing the submodules"""
         return self.repo
 
     # } END interface

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -32,12 +32,12 @@ __all__ = (
 
 
 def sm_section(name: str) -> str:
-    """:return: section title used in .gitmodules configuration file"""
+    """:return: Section title used in .gitmodules configuration file"""
     return f'submodule "{name}"'
 
 
 def sm_name(section: str) -> str:
-    """:return: name of the submodule as parsed from the section name"""
+    """:return: Name of the submodule as parsed from the section name"""
     section = section.strip()
     return section[11:-1]
 
@@ -48,7 +48,7 @@ def mkhead(repo: "Repo", path: PathLike) -> "Head":
 
 
 def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "RemoteReference":
-    """Find the remote branch matching the name of the given branch or raise InvalidGitRepositoryError"""
+    """Find the remote branch matching the name of the given branch or raise InvalidGitRepositoryError."""
     for remote in remotes:
         try:
             return remote.refs[branch_name]
@@ -66,14 +66,13 @@ def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "
 
 
 class SubmoduleConfigParser(GitConfigParser):
+    """Catches calls to _write, and updates the .gitmodules blob in the index
+    with the new data, if we have written into a stream.
 
-    """
-    Catches calls to _write, and updates the .gitmodules blob in the index
-    with the new data, if we have written into a stream. Otherwise it will
-    add the local file to the index to make it correspond with the working tree.
-    Additionally, the cache must be cleared
+    Otherwise it would add the local file to the index to make it correspond
+    with the working tree. Additionally, the cache must be cleared.
 
-    Please note that no mutating method will work in bare mode
+    Please note that no mutating method will work in bare mode.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -85,13 +84,13 @@ class SubmoduleConfigParser(GitConfigParser):
     # { Interface
     def set_submodule(self, submodule: "Submodule") -> None:
         """Set this instance's submodule. It must be called before
-        the first write operation begins"""
+        the first write operation begins."""
         self._smref = weakref.ref(submodule)
 
     def flush_to_index(self) -> None:
-        """Flush changes in our configuration file to the index"""
+        """Flush changes in our configuration file to the index."""
         assert self._smref is not None
-        # should always have a file here
+        # Should always have a file here.
         assert not isinstance(self._file_or_files, BytesIO)
 
         sm = self._smref()

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -3,7 +3,9 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
-""" Module containing all object based types. """
+
+"""Module containing all Object-based types."""
+
 from . import base
 from .util import get_object_type_by_name, parse_actor_and_date
 from ..util import hex_to_bin
@@ -24,10 +26,10 @@ __all__ = ("TagObject",)
 
 
 class TagObject(base.Object):
-
-    """Non-Lightweight tag carrying additional information about an object we are pointing to."""
+    """Non-lightweight tag carrying additional information about an object we are pointing to."""
 
     type: Literal["tag"] = "tag"
+
     __slots__ = (
         "object",
         "tag",
@@ -48,18 +50,20 @@ class TagObject(base.Object):
         tagger_tz_offset: Union[int, None] = None,
         message: Union[str, None] = None,
     ) -> None:  # @ReservedAssignment
-        """Initialize a tag object with additional data
+        """Initialize a tag object with additional data.
 
-        :param repo: repository this object is located in
+        :param repo: Repository this object is located in
         :param binsha: 20 byte SHA1
         :param object: Object instance of object we are pointing to
-        :param tag: name of this tag
+        :param tag: Name of this tag
         :param tagger: Actor identifying the tagger
         :param tagged_date: int_seconds_since_epoch
-            is the DateTime of the tag creation - use time.gmtime to convert
-            it into a different format
-        :param tagged_tz_offset: int_seconds_west_of_utc is the timezone that the
-            authored_date is in, in a format similar to time.altzone"""
+            The :class:`DateTime` of the tag creation.
+            Use :func:`time.gmtime` to convert it into a different format.
+        :param tagged_tz_offset: int_seconds_west_of_utc
+            The timezone that the authored_date is in, in a format similar
+            to :attr:`time.altzone`.
+        """
         super(TagObject, self).__init__(repo, binsha)
         if object is not None:
             self.object: Union["Commit", "Blob", "Tree", "TagObject"] = object
@@ -75,7 +79,7 @@ class TagObject(base.Object):
             self.message = message
 
     def _set_cache_(self, attr: str) -> None:
-        """Cache all our attributes at once"""
+        """Cache all our attributes at once."""
         if attr in TagObject.__slots__:
             ostream = self.repo.odb.stream(self.binsha)
             lines: List[str] = ostream.read().decode(defenc, "replace").splitlines()
@@ -95,9 +99,9 @@ class TagObject(base.Object):
                     self.tagger_tz_offset,
                 ) = parse_actor_and_date(tagger_info)
 
-            # line 4 empty - it could mark the beginning of the next header
-            # in case there really is no message, it would not exist. Otherwise
-            # a newline separates header from message
+            # Line 4 empty - it could mark the beginning of the next header.
+            # In case there really is no message, it would not exist.
+            # Otherwise a newline separates header from message.
             if len(lines) > 5:
                 self.message = "\n".join(lines[5:])
             else:

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -1,4 +1,4 @@
-# objects.py
+# tag.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -180,8 +180,8 @@ class TreeModifier:
         return self
 
     def add_unchecked(self, binsha: bytes, mode: int, name: str) -> None:
-        """Add the given item to the tree. Its correctness is assumed, which
-        puts the caller into responsibility to assure the input is correct.
+        """Add the given item to the tree. Its correctness is assumed, so it is the
+        caller's responsibility to ensure that the input is correct.
 
         For more information on the parameters, see :meth:`add`.
 

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -109,7 +109,7 @@ class TreeModifier:
     the cache of a tree, will be sorted. This ensures it will be in a serializable state.
     """
 
-    __slots__ = "_cache"
+    __slots__ = ("_cache",)
 
     def __init__(self, cache: List[TreeCacheTup]) -> None:
         self._cache = cache
@@ -214,7 +214,8 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     """
 
     type: Literal["tree"] = "tree"
-    __slots__ = "_cache"
+
+    __slots__ = ("_cache",)
 
     # Actual integer IDs for comparison.
     commit_id = 0o16  # Equals stat.S_IFDIR | stat.S_IFLNK - a directory link.

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -102,7 +102,7 @@ def merge_sort(a: List[TreeCacheTup], cmp: Callable[[TreeCacheTup, TreeCacheTup]
         k = k + 1
 
 
-class TreeModifier(object):
+class TreeModifier:
     """A utility class providing methods to alter the underlying cache in a list-like fashion.
 
     Once all adjustments are complete, the _cache, which really is a reference to

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -337,7 +337,7 @@ def parse_actor_and_date(line: str) -> Tuple[Actor, int, int]:
 # { Classes
 
 
-class ProcessStreamAdapter(object):
+class ProcessStreamAdapter:
     """Class wiring all calls to the contained Process instance.
 
     Use this type to hide the underlying process to provide access only to a specified

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -3,7 +3,9 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
-"""Module for general utility functions"""
+
+"""Module for general utility functions."""
+
 # flake8: noqa F401
 
 
@@ -62,10 +64,10 @@ class TraverseNT(NamedTuple):
     src: Union["Traversable", None]
 
 
-T_TIobj = TypeVar("T_TIobj", bound="TraversableIterableObj")  # for TraversableIterableObj.traverse()
+T_TIobj = TypeVar("T_TIobj", bound="TraversableIterableObj")  # For TraversableIterableObj.traverse()
 
 TraversedTup = Union[
-    Tuple[Union["Traversable", None], "Traversable"],  # for commit, submodule
+    Tuple[Union["Traversable", None], "Traversable"],  # For commit, submodule
     "TraversedTreeTup",
 ]  # for tree.traverse()
 
@@ -92,12 +94,14 @@ ZERO = timedelta(0)
 
 def mode_str_to_int(modestr: Union[bytes, str]) -> int:
     """
-    :param modestr: string like 755 or 644 or 100644 - only the last 6 chars will be used
+    :param modestr:
+        String like 755 or 644 or 100644 - only the last 6 chars will be used.
+
     :return:
         String identifying a mode compatible to the mode methods ids of the
         stat module regarding the rwx permissions for user, group and other,
-        special flags and file system flags, i.e. whether it is a symlink
-        for example."""
+        special flags and file system flags, such as whether it is a symlink.
+    """
     mode = 0
     for iteration, char in enumerate(reversed(modestr[-6:])):
         char = cast(Union[str, int], char)
@@ -110,12 +114,13 @@ def get_object_type_by_name(
     object_type_name: bytes,
 ) -> Union[Type["Commit"], Type["TagObject"], Type["Tree"], Type["Blob"]]:
     """
-    :return: type suitable to handle the given object type name.
+    :return: A type suitable to handle the given object type name.
         Use the type to create new instances.
 
     :param object_type_name: Member of TYPES
 
-    :raise ValueError: In case object_type_name is unknown"""
+    :raise ValueError: If object_type_name is unknown
+    """
     if object_type_name == b"commit":
         from . import commit
 
@@ -138,9 +143,9 @@ def get_object_type_by_name(
 
 def utctz_to_altz(utctz: str) -> int:
     """Convert a git timezone offset into a timezone offset west of
-    UTC in seconds (compatible with time.altzone).
+    UTC in seconds (compatible with :attr:`time.altzone`).
 
-    :param utctz: git utc timezone string, i.e. +0200
+    :param utctz: git utc timezone string, e.g. +0200
     """
     int_utctz = int(utctz)
     seconds = (abs(int_utctz) // 100) * 3600 + (abs(int_utctz) % 100) * 60
@@ -148,9 +153,9 @@ def utctz_to_altz(utctz: str) -> int:
 
 
 def altz_to_utctz_str(altz: float) -> str:
-    """Convert a timezone offset west of UTC in seconds into a git timezone offset string
+    """Convert a timezone offset west of UTC in seconds into a Git timezone offset string.
 
-    :param altz: timezone offset in seconds west of UTC
+    :param altz: Timezone offset in seconds west of UTC
     """
     hours = abs(altz) // 3600
     minutes = (abs(altz) % 3600) // 60
@@ -159,8 +164,11 @@ def altz_to_utctz_str(altz: float) -> str:
 
 
 def verify_utctz(offset: str) -> str:
-    """:raise ValueError: if offset is incorrect
-    :return: offset"""
+    """
+    :raise ValueError: If offset is incorrect
+
+    :return: offset
+    """
     fmt_exc = ValueError("Invalid timezone offset format: %s" % offset)
     if len(offset) != 5:
         raise fmt_exc
@@ -194,7 +202,7 @@ utc = tzoffset(0, "UTC")
 
 
 def from_timestamp(timestamp: float, tz_offset: float) -> datetime:
-    """Converts a timestamp + tz_offset into an aware datetime instance."""
+    """Convert a timestamp + tz_offset into an aware datetime instance."""
     utc_dt = datetime.fromtimestamp(timestamp, utc)
     try:
         local_dt = utc_dt.astimezone(tzoffset(tz_offset))
@@ -205,16 +213,18 @@ def from_timestamp(timestamp: float, tz_offset: float) -> datetime:
 
 def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
     """
-    Parse the given date as one of the following
+    Parse the given date as one of the following:
 
-        * aware datetime instance
+        * Aware datetime instance
         * Git internal format: timestamp offset
         * RFC 2822: Thu, 07 Apr 2005 22:13:13 +0200.
         * ISO 8601 2005-04-07T22:13:13
-            The T can be a space as well
+            The T can be a space as well.
 
     :return: Tuple(int(timestamp_UTC), int(offset)), both in seconds since epoch
+
     :raise ValueError: If the format could not be understood
+
     :note: Date can also be YYYY.MM.DD, MM/DD/YYYY and DD.MM.YYYY.
     """
     if isinstance(string_date, datetime):
@@ -225,7 +235,7 @@ def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
         else:
             raise ValueError(f"string_date datetime object without tzinfo, {string_date}")
 
-    # git time
+    # Git time
     try:
         if string_date.count(" ") == 1 and string_date.rfind(":") == -1:
             timestamp, offset_str = string_date.split()
@@ -234,21 +244,21 @@ def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
             timestamp_int = int(timestamp)
             return timestamp_int, utctz_to_altz(verify_utctz(offset_str))
         else:
-            offset_str = "+0000"  # local time by default
+            offset_str = "+0000"  # Local time by default.
             if string_date[-5] in "-+":
                 offset_str = verify_utctz(string_date[-5:])
                 string_date = string_date[:-6]  # skip space as well
             # END split timezone info
             offset = utctz_to_altz(offset_str)
 
-            # now figure out the date and time portion - split time
+            # Now figure out the date and time portion - split time.
             date_formats = []
             splitter = -1
             if "," in string_date:
                 date_formats.append("%a, %d %b %Y")
                 splitter = string_date.rfind(" ")
             else:
-                # iso plus additional
+                # ISO plus additional
                 date_formats.append("%Y-%m-%d")
                 date_formats.append("%Y.%m.%d")
                 date_formats.append("%m/%d/%Y")
@@ -258,15 +268,15 @@ def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
                 if splitter == -1:
                     splitter = string_date.rfind(" ")
                 # END handle 'T' and ' '
-            # END handle rfc or iso
+            # END handle RFC or ISO
 
             assert splitter > -1
 
-            # split date and time
-            time_part = string_date[splitter + 1 :]  # skip space
+            # Split date and time.
+            time_part = string_date[splitter + 1 :]  # Skip space.
             date_part = string_date[:splitter]
 
-            # parse time
+            # Parse time.
             tstruct = time.strptime(time_part, "%H:%M:%S")
 
             for fmt in date_formats:
@@ -291,7 +301,7 @@ def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
                 # END exception handling
             # END for each fmt
 
-            # still here ? fail
+            # Still here ? fail.
             raise ValueError("no format matched")
         # END handle format
     except Exception as e:
@@ -299,7 +309,7 @@ def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
     # END handle exceptions
 
 
-# precompiled regex
+# Precompiled regexes
 _re_actor_epoch = re.compile(r"^.+? (.*) (\d+) ([+-]\d+).*$")
 _re_only_actor = re.compile(r"^.+? (.*)$")
 
@@ -309,7 +319,8 @@ def parse_actor_and_date(line: str) -> Tuple[Actor, int, int]:
 
         author Tom Preston-Werner <tom@mojombo.com> 1191999972 -0700
 
-    :return: [Actor, int_seconds_since_epoch, int_timezone_offset]"""
+    :return: [Actor, int_seconds_since_epoch, int_timezone_offset]
+    """
     actor, epoch, offset = "", "0", "0"
     m = _re_actor_epoch.search(line)
     if m:
@@ -327,12 +338,12 @@ def parse_actor_and_date(line: str) -> Tuple[Actor, int, int]:
 
 
 class ProcessStreamAdapter(object):
-
-    """Class wireing all calls to the contained Process instance.
+    """Class wiring all calls to the contained Process instance.
 
     Use this type to hide the underlying process to provide access only to a specified
     stream. The process is usually wrapped into an AutoInterrupt class to kill
-    it if the instance goes out of scope."""
+    it if the instance goes out of scope.
+    """
 
     __slots__ = ("_proc", "_stream")
 
@@ -346,11 +357,12 @@ class ProcessStreamAdapter(object):
 
 @runtime_checkable
 class Traversable(Protocol):
-
     """Simple interface to perform depth-first or breadth-first traversals
-    into one direction.
+    in one direction.
+
     Subclasses only need to implement one function.
-    Instances of the Subclass must be hashable
+
+    Instances of the Subclass must be hashable.
 
     Defined subclasses = [Commit, Tree, SubModule]
     """
@@ -363,7 +375,7 @@ class Traversable(Protocol):
         """
         Returns:
             Tuple of items connected to the given item.
-            Must be implemented in subclass
+            Must be implemented in subclass.
 
         class Commit::     (cls, Commit) -> Tuple[Commit, ...]
         class Submodule::  (cls, Submodule) -> Iterablelist[Submodule]
@@ -393,22 +405,22 @@ class Traversable(Protocol):
             Submodule ->  IterableList['Submodule']
             Tree -> IterableList[Union['Submodule', 'Tree', 'Blob']]
         """
-        # Commit and Submodule have id.__attribute__ as IterableObj
-        # Tree has id.__attribute__ inherited from IndexObject
+        # Commit and Submodule have id.__attribute__ as IterableObj.
+        # Tree has id.__attribute__ inherited from IndexObject.
         if isinstance(self, Has_id_attribute):
             id = self._id_attribute_
         else:
-            id = ""  # shouldn't reach here, unless Traversable subclass created with no _id_attribute_
-            # could add _id_attribute_ to Traversable, or make all Traversable also Iterable?
+            id = ""  # Shouldn't reach here, unless Traversable subclass created with no _id_attribute_.
+            # Could add _id_attribute_ to Traversable, or make all Traversable also Iterable?
 
         if not as_edge:
             out: IterableList[Union["Commit", "Submodule", "Tree", "Blob"]] = IterableList(id)
             out.extend(self.traverse(as_edge=as_edge, *args, **kwargs))
             return out
-            # overloads in subclasses (mypy doesn't allow typing self: subclass)
+            # Overloads in subclasses (mypy doesn't allow typing self: subclass).
             # Union[IterableList['Commit'], IterableList['Submodule'], IterableList[Union['Submodule', 'Tree', 'Blob']]]
         else:
-            # Raise deprecationwarning, doesn't make sense to use this
+            # Raise DeprecationWarning, it doesn't make sense to use this.
             out_list: IterableList = IterableList(self.traverse(*args, **kwargs))
             return out_list
 
@@ -434,35 +446,37 @@ class Traversable(Protocol):
         ignore_self: int = 1,
         as_edge: bool = False,
     ) -> Union[Iterator[Union["Traversable", "Blob"]], Iterator[TraversedTup]]:
-        """:return: iterator yielding of items found when traversing self
-        :param predicate: f(i,d) returns False if item i at depth d should not be included in the result
+        """:return: Iterator yielding items found when traversing self
+
+        :param predicate: f(i,d) returns False if item i at depth d should not be
+            included in the result.
 
         :param prune:
-            f(i,d) return True if the search should stop at item i at depth d.
-            Item i will not be returned.
+            f(i,d) return True if the search should stop at item i at depth d. Item i
+            will not be returned.
 
         :param depth:
-            define at which level the iteration should not go deeper
-            if -1, there is no limit
-            if 0, you would effectively only get self, the root of the iteration
+            Defines at which level the iteration should not go deeper if -1, there is no
+            limit if 0, you would effectively only get self, the root of the iteration
             i.e. if 1, you would only get the first level of predecessors/successors
 
         :param branch_first:
             if True, items will be returned branch first, otherwise depth first
 
         :param visit_once:
-            if True, items will only be returned once, although they might be encountered
-            several times. Loops are prevented that way.
+            if True, items will only be returned once, although they might be
+            encountered several times. Loops are prevented that way.
 
         :param ignore_self:
-            if True, self will be ignored and automatically pruned from
-            the result. Otherwise it will be the first item to be returned.
-            If as_edge is True, the source of the first edge is None
+            if True, self will be ignored and automatically pruned from the result.
+            Otherwise it will be the first item to be returned. If as_edge is True, the
+            source of the first edge is None
 
         :param as_edge:
             if True, return a pair of items, first being the source, second the
-            destination, i.e. tuple(src, dest) with the edge spanning from
-            source to destination"""
+            destination, i.e. tuple(src, dest) with the edge spanning from source to
+            destination
+        """
 
         """
             Commit -> Iterator[Union[Commit, Tuple[Commit, Commit]]
@@ -473,11 +487,12 @@ class Traversable(Protocol):
            ignore_self=True is_edge=True -> Iterator[item]
            ignore_self=True is_edge=False --> Iterator[item]
            ignore_self=False is_edge=True -> Iterator[item] | Iterator[Tuple[src, item]]
-           ignore_self=False is_edge=False -> Iterator[Tuple[src, item]]"""
+           ignore_self=False is_edge=False -> Iterator[Tuple[src, item]]
+        """
 
         visited = set()
         stack: Deque[TraverseNT] = deque()
-        stack.append(TraverseNT(0, self, None))  # self is always depth level 0
+        stack.append(TraverseNT(0, self, None))  # self is always depth level 0.
 
         def addToStack(
             stack: Deque[TraverseNT],
@@ -497,7 +512,7 @@ class Traversable(Protocol):
         # END addToStack local method
 
         while stack:
-            d, item, src = stack.pop()  # depth of item, item, item_source
+            d, item, src = stack.pop()  # Depth of item, item, item_source
 
             if visit_once and item in visited:
                 continue
@@ -506,7 +521,7 @@ class Traversable(Protocol):
                 visited.add(item)
 
             rval: Union[TraversedTup, "Traversable", "Blob"]
-            if as_edge:  # if as_edge return (src, item) unless rrc is None (e.g. for first item)
+            if as_edge:  # If as_edge return (src, item) unless rrc is None (e.g. for first item).
                 rval = (src, item)
             else:
                 rval = item
@@ -518,7 +533,7 @@ class Traversable(Protocol):
             if not skipStartItem and predicate(rval, d):
                 yield rval
 
-            # only continue to next level if this is appropriate !
+            # Only continue to next level if this is appropriate!
             nd = d + 1
             if depth > -1 and nd > depth:
                 continue
@@ -529,24 +544,30 @@ class Traversable(Protocol):
 
 @runtime_checkable
 class Serializable(Protocol):
-
-    """Defines methods to serialize and deserialize objects from and into a data stream"""
+    """Defines methods to serialize and deserialize objects from and into a data stream."""
 
     __slots__ = ()
 
     # @abstractmethod
     def _serialize(self, stream: "BytesIO") -> "Serializable":
-        """Serialize the data of this object into the given data stream
-        :note: a serialized object would ``_deserialize`` into the same object
+        """Serialize the data of this object into the given data stream.
+
+        :note: A serialized object would ``_deserialize`` into the same object.
+
         :param stream: a file-like object
-        :return: self"""
+
+        :return: self
+        """
         raise NotImplementedError("To be implemented in subclass")
 
     # @abstractmethod
     def _deserialize(self, stream: "BytesIO") -> "Serializable":
-        """Deserialize all information regarding this object from the stream
+        """Deserialize all information regarding this object from the stream.
+
         :param stream: a file-like object
-        :return: self"""
+
+        :return: self
+        """
         raise NotImplementedError("To be implemented in subclass")
 
 

--- a/git/refs/__init__.py
+++ b/git/refs/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# import all modules in order, fix the names they require
+# Import all modules in order, fix the names they require.
 from .symbolic import *
 from .reference import *
 from .head import *

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -231,8 +231,8 @@ class Head(Reference):
 
         :param force:
             If True, changes to the index and the working tree will be discarded.
-            If False, :class:`GitCommandError <git.exc.GitCommandError>` will be
-            raised in that situation.
+            If False, :class:`~git.exc.GitCommandError` will be raised in that
+            situation.
 
         :param kwargs:
             Additional keyword arguments to be passed to git checkout, e.g.

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -5,7 +5,7 @@ from git.exc import GitCommandError
 from .symbolic import SymbolicReference
 from .reference import Reference
 
-# typinng ---------------------------------------------------
+# typing ---------------------------------------------------
 
 from typing import Any, Sequence, Union, TYPE_CHECKING
 
@@ -28,12 +28,12 @@ def strip_quotes(string: str) -> str:
 
 
 class HEAD(SymbolicReference):
-
-    """Special case of a Symbolic Reference as it represents the repository's
+    """Special case of a SymbolicReference representing the repository's
     HEAD reference."""
 
     _HEAD_NAME = "HEAD"
     _ORIG_HEAD_NAME = "ORIG_HEAD"
+
     __slots__ = ()
 
     def __init__(self, repo: "Repo", path: PathLike = _HEAD_NAME):
@@ -45,7 +45,8 @@ class HEAD(SymbolicReference):
     def orig_head(self) -> SymbolicReference:
         """
         :return: SymbolicReference pointing at the ORIG_HEAD, which is maintained
-            to contain the previous value of HEAD"""
+            to contain the previous value of HEAD.
+        """
         return SymbolicReference(self.repo, self._ORIG_HEAD_NAME)
 
     def reset(
@@ -71,7 +72,7 @@ class HEAD(SymbolicReference):
         :param working_tree:
             If True, the working tree will be forcefully adjusted to match the given
             commit, possibly overwriting uncommitted changes without warning.
-            If working_tree is True, index must be true as well
+            If `working_tree` is True, `index` must be True as well.
 
         :param paths:
             Single path or list of paths relative to the git root directory
@@ -80,14 +81,15 @@ class HEAD(SymbolicReference):
         :param kwargs:
             Additional arguments passed to git-reset.
 
-        :return: self"""
+        :return: self
+        """
         mode: Union[str, None]
         mode = "--soft"
         if index:
             mode = "--mixed"
 
-            # it appears, some git-versions declare mixed and paths deprecated
-            # see http://github.com/Byron/GitPython/issues#issue/2
+            # Tt appears some git versions declare mixed and paths deprecated.
+            # See http://github.com/Byron/GitPython/issues#issue/2.
             if paths:
                 mode = None
             # END special case
@@ -104,7 +106,7 @@ class HEAD(SymbolicReference):
             self.repo.git.reset(mode, commit, "--", paths, **kwargs)
         except GitCommandError as e:
             # git nowadays may use 1 as status to indicate there are still unstaged
-            # modifications after the reset
+            # modifications after the reset.
             if e.status != 1:
                 raise
         # END handle exception
@@ -113,7 +115,6 @@ class HEAD(SymbolicReference):
 
 
 class Head(Reference):
-
     """A Head is a named reference to a Commit. Every Head instance contains a name
     and a Commit object.
 
@@ -129,33 +130,35 @@ class Head(Reference):
         <git.Commit "1c09f116cbc2cb4100fb6935bb162daa4723f455">
 
         >>> head.commit.hexsha
-        '1c09f116cbc2cb4100fb6935bb162daa4723f455'"""
+        '1c09f116cbc2cb4100fb6935bb162daa4723f455'
+    """
 
     _common_path_default = "refs/heads"
     k_config_remote = "remote"
-    k_config_remote_ref = "merge"  # branch to merge from remote
+    k_config_remote_ref = "merge"  # Branch to merge from remote.
 
     @classmethod
     def delete(cls, repo: "Repo", *heads: "Union[Head, str]", force: bool = False, **kwargs: Any) -> None:
-        """Delete the given heads
+        """Delete the given heads.
 
         :param force:
             If True, the heads will be deleted even if they are not yet merged into
             the main development stream.
-            Default False"""
+            Default False
+        """
         flag = "-d"
         if force:
             flag = "-D"
         repo.git.branch(flag, *heads)
 
     def set_tracking_branch(self, remote_reference: Union["RemoteReference", None]) -> "Head":
-        """
-        Configure this branch to track the given remote reference. This will alter
-            this branch's configuration accordingly.
+        """Configure this branch to track the given remote reference. This will
+        alter this branch's configuration accordingly.
 
         :param remote_reference: The remote reference to track or None to untrack
-            any references
-        :return: self"""
+            any references.
+        :return: self
+        """
         from .remote import RemoteReference
 
         if remote_reference is not None and not isinstance(remote_reference, RemoteReference):
@@ -180,7 +183,7 @@ class Head(Reference):
     def tracking_branch(self) -> Union["RemoteReference", None]:
         """
         :return: The remote_reference we are tracking, or None if we are
-            not a tracking branch"""
+            not a tracking branch."""
         from .remote import RemoteReference
 
         reader = self.config_reader()
@@ -193,22 +196,24 @@ class Head(Reference):
             return RemoteReference(self.repo, remote_refpath)
         # END handle have tracking branch
 
-        # we are not a tracking branch
+        # We are not a tracking branch.
         return None
 
     def rename(self, new_path: PathLike, force: bool = False) -> "Head":
-        """Rename self to a new path
+        """Rename self to a new path.
 
         :param new_path:
             Either a simple name or a path, i.e. new_name or features/new_name.
-            The prefix refs/heads is implied
+            The prefix refs/heads is implied.
 
         :param force:
             If True, the rename will succeed even if a head with the target name
             already exists.
 
         :return: self
-        :note: respects the ref log as git commands are used"""
+
+        :note: Respects the ref log as git commands are used.
+        """
         flag = "-m"
         if force:
             flag = "-M"
@@ -218,19 +223,20 @@ class Head(Reference):
         return self
 
     def checkout(self, force: bool = False, **kwargs: Any) -> Union["HEAD", "Head"]:
-        """Checkout this head by setting the HEAD to this reference, by updating the index
-        to reflect the tree we point to and by updating the working tree to reflect
-        the latest index.
+        """Check out this head by setting the HEAD to this reference, by updating the
+        index to reflect the tree we point to and by updating the working tree to
+        reflect the latest index.
 
         The command will fail if changed working tree files would be overwritten.
 
         :param force:
             If True, changes to the index and the working tree will be discarded.
-            If False, GitCommandError will be raised in that situation.
+            If False, :class:`GitCommandError <git.exc.GitCommandError>` will be
+            raised in that situation.
 
         :param kwargs:
-            Additional keyword arguments to be passed to git checkout, i.e.
-            b='new_branch' to create a new branch at the given spot.
+            Additional keyword arguments to be passed to git checkout, e.g.
+            ``b="new_branch"`` to create a new branch at the given spot.
 
         :return:
             The active branch after the checkout operation, usually self unless
@@ -241,7 +247,8 @@ class Head(Reference):
         :note:
             By default it is only allowed to checkout heads - everything else
             will leave the HEAD detached which is allowed and possible, but remains
-            a special state that some tools might not be able to handle."""
+            a special state that some tools might not be able to handle.
+        """
         kwargs["f"] = force
         if kwargs["f"] is False:
             kwargs.pop("f")
@@ -265,13 +272,15 @@ class Head(Reference):
     def config_reader(self) -> SectionConstraint[GitConfigParser]:
         """
         :return: A configuration parser instance constrained to only read
-            this instance's values"""
+            this instance's values.
+        """
         return self._config_parser(read_only=True)
 
     def config_writer(self) -> SectionConstraint[GitConfigParser]:
         """
         :return: A configuration writer instance with read-and write access
-            to options of this head"""
+            to options of this head.
+        """
         return self._config_parser(read_only=False)
 
     # } END configuration

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -38,18 +38,17 @@ __all__ = ["RefLog", "RefLogEntry"]
 
 
 class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
-
-    """Named tuple allowing easy access to the revlog data fields"""
+    """Named tuple allowing easy access to the revlog data fields."""
 
     _re_hexsha_only = re.compile(r"^[0-9A-Fa-f]{40}$")
     __slots__ = ()
 
     def __repr__(self) -> str:
-        """Representation of ourselves in git reflog format"""
+        """Representation of ourselves in git reflog format."""
         return self.format()
 
     def format(self) -> str:
-        """:return: a string suitable to be placed in a reflog file"""
+        """:return: A string suitable to be placed in a reflog file."""
         act = self.actor
         time = self.time
         return "{} {} {} <{}> {!s} {}\t{}\n".format(
@@ -64,30 +63,31 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
 
     @property
     def oldhexsha(self) -> str:
-        """The hexsha to the commit the ref pointed to before the change"""
+        """The hexsha to the commit the ref pointed to before the change."""
         return self[0]
 
     @property
     def newhexsha(self) -> str:
-        """The hexsha to the commit the ref now points to, after the change"""
+        """The hexsha to the commit the ref now points to, after the change."""
         return self[1]
 
     @property
     def actor(self) -> Actor:
-        """Actor instance, providing access"""
+        """Actor instance, providing access."""
         return self[2]
 
     @property
     def time(self) -> Tuple[int, int]:
         """time as tuple:
 
-        * [0] = int(time)
-        * [1] = int(timezone_offset) in time.altzone format"""
+        * [0] = ``int(time)``
+        * [1] = ``int(timezone_offset)`` in :attr:`time.altzone` format
+        """
         return self[3]
 
     @property
     def message(self) -> str:
-        """Message describing the operation that acted on the reference"""
+        """Message describing the operation that acted on the reference."""
         return self[4]
 
     @classmethod
@@ -109,8 +109,11 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
     @classmethod
     def from_line(cls, line: bytes) -> "RefLogEntry":
         """:return: New RefLogEntry instance from the given revlog line.
-        :param line: line bytes without trailing newline
-        :raise ValueError: If line could not be parsed"""
+
+        :param line: Line bytes without trailing newline
+
+        :raise ValueError: If `line` could not be parsed
+        """
         line_str = line.decode(defenc)
         fields = line_str.split("\t", 1)
         if len(fields) == 1:
@@ -141,13 +144,13 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
 
 
 class RefLog(List[RefLogEntry], Serializable):
-
     """A reflog contains RefLogEntrys, each of which defines a certain state
     of the head in question. Custom query methods allow to retrieve log entries
     by date or by other criteria.
 
-    Reflog entries are ordered, the first added entry is first in the list, the last
-    entry, i.e. the last change of the head or reference, is last in the list."""
+    Reflog entries are ordered. The first added entry is first in the list. The last
+    entry, i.e. the last change of the head or reference, is last in the list.
+    """
 
     __slots__ = ("_path",)
 
@@ -158,7 +161,7 @@ class RefLog(List[RefLogEntry], Serializable):
     def __init__(self, filepath: Union[PathLike, None] = None):
         """Initialize this instance with an optional filepath, from which we will
         initialize our data. The path is also used to write changes back using
-        the write() method"""
+        the write() method."""
         self._path = filepath
         if filepath is not None:
             self._read_from_file()
@@ -168,7 +171,7 @@ class RefLog(List[RefLogEntry], Serializable):
         try:
             fmap = file_contents_ro_filepath(self._path, stream=True, allow_mmap=True)
         except OSError:
-            # it is possible and allowed that the file doesn't exist !
+            # It is possible and allowed that the file doesn't exist!
             return
         # END handle invalid log
 
@@ -183,31 +186,35 @@ class RefLog(List[RefLogEntry], Serializable):
     @classmethod
     def from_file(cls, filepath: PathLike) -> "RefLog":
         """
-        :return: a new RefLog instance containing all entries from the reflog
+        :return: A new RefLog instance containing all entries from the reflog
             at the given filepath
-        :param filepath: path to reflog
-        :raise ValueError: If the file could not be read or was corrupted in some way"""
+        :param filepath: Path to reflog
+        :raise ValueError: If the file could not be read or was corrupted in some way
+        """
         return cls(filepath)
 
     @classmethod
     def path(cls, ref: "SymbolicReference") -> str:
         """
-        :return: string to absolute path at which the reflog of the given ref
+        :return: String to absolute path at which the reflog of the given ref
             instance would be found. The path is not guaranteed to point to a valid
             file though.
-        :param ref: SymbolicReference instance"""
+        :param ref: SymbolicReference instance
+        """
         return osp.join(ref.repo.git_dir, "logs", to_native_path(ref.path))
 
     @classmethod
     def iter_entries(cls, stream: Union[str, "BytesIO", mmap]) -> Iterator[RefLogEntry]:
         """
         :return: Iterator yielding RefLogEntry instances, one for each line read
-            sfrom the given stream.
-        :param stream: file-like object containing the revlog in its native format
-            or string instance pointing to a file to read"""
+            from the given stream.
+
+        :param stream: File-like object containing the revlog in its native format
+            or string instance pointing to a file to read.
+        """
         new_entry = RefLogEntry.from_line
         if isinstance(stream, str):
-            # default args return mmap on py>3
+            # Default args return mmap since Python 3.
             _stream = file_contents_ro_filepath(stream)
             assert isinstance(_stream, mmap)
         else:
@@ -223,23 +230,23 @@ class RefLog(List[RefLogEntry], Serializable):
     @classmethod
     def entry_at(cls, filepath: PathLike, index: int) -> "RefLogEntry":
         """
-        :return: RefLogEntry at the given index
+        :return: RefLogEntry at the given index.
 
-        :param filepath: full path to the index file from which to read the entry
+        :param filepath: Full path to the index file from which to read the entry.
 
-        :param index: python list compatible index, i.e. it may be negative to
-            specify an entry counted from the end of the list
+        :param index: Python list compatible index, i.e. it may be negative to
+            specify an entry counted from the end of the list.
 
-        :raise IndexError: If the entry didn't exist
+        :raise IndexError: If the entry didn't exist.
 
         .. note:: This method is faster as it only parses the entry at index, skipping
             all other lines. Nonetheless, the whole file has to be read if
-            the index is negative
+            the index is negative.
         """
         with open(filepath, "rb") as fp:
             if index < 0:
                 return RefLogEntry.from_line(fp.readlines()[index].strip())
-            # read until index is reached
+            # Read until index is reached.
 
             for i in range(index + 1):
                 line = fp.readline()
@@ -254,7 +261,8 @@ class RefLog(List[RefLogEntry], Serializable):
     def to_file(self, filepath: PathLike) -> None:
         """Write the contents of the reflog instance to a file at the given filepath.
 
-        :param filepath: path to file, parent directories are assumed to exist"""
+        :param filepath: Path to file, parent directories are assumed to exist.
+        """
         lfd = LockedFD(filepath)
         assure_directory_exists(filepath, is_file=True)
 
@@ -279,19 +287,21 @@ class RefLog(List[RefLogEntry], Serializable):
     ) -> "RefLogEntry":
         """Append a new log entry to the revlog at filepath.
 
-        :param config_reader: configuration reader of the repository - used to obtain
-            user information. May also be an Actor instance identifying the committer directly or None.
-        :param filepath: full path to the log file
-        :param oldbinsha: binary sha of the previous commit
-        :param newbinsha: binary sha of the current commit
-        :param message: message describing the change to the reference
-        :param write: If True, the changes will be written right away. Otherwise
-            the change will not be written
+        :param config_reader: Configuration reader of the repository - used to obtain
+            user information. May also be an Actor instance identifying the committer
+            directly or None.
+        :param filepath: Full path to the log file.
+        :param oldbinsha: Binary sha of the previous commit.
+        :param newbinsha: Binary sha of the current commit.
+        :param message: Message describing the change to the reference.
+        :param write: If True, the changes will be written right away. Otherwise the
+            change will not be written.
 
-        :return: RefLogEntry objects which was appended to the log
+        :return: RefLogEntry objects which was appended to the log.
 
-        :note: As we are append-only, concurrent access is not a problem as we
-            do not interfere with readers."""
+        :note: As we are append-only, concurrent access is not a problem as we do not
+            interfere with readers.
+        """
 
         if len(oldbinsha) != 20 or len(newbinsha) != 20:
             raise ValueError("Shas need to be given in binary format")
@@ -325,9 +335,10 @@ class RefLog(List[RefLogEntry], Serializable):
         return entry
 
     def write(self) -> "RefLog":
-        """Write this instance's data to the file we are originating from
+        """Write this instance's data to the file we are originating from.
 
-        :return: self"""
+        :return: self
+        """
         if self._path is None:
             raise ValueError("Instance was not initialized with a path, use to_file(...) instead")
         # END assert path
@@ -337,10 +348,11 @@ class RefLog(List[RefLogEntry], Serializable):
     # } END interface
 
     # { Serializable Interface
+
     def _serialize(self, stream: "BytesIO") -> "RefLog":
         write = stream.write
 
-        # write all entries
+        # Write all entries.
         for e in self:
             write(e.format().encode(defenc))
         # END for each entry
@@ -348,5 +360,6 @@ class RefLog(List[RefLogEntry], Serializable):
 
     def _deserialize(self, stream: "BytesIO") -> "RefLog":
         self.extend(self.iter_entries(stream))
-        # } END serializable interface
         return self
+
+    # } END serializable interface

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -41,7 +41,7 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
 
     """Named tuple allowing easy access to the revlog data fields"""
 
-    _re_hexsha_only = re.compile("^[0-9A-Fa-f]{40}$")
+    _re_hexsha_only = re.compile(r"^[0-9A-Fa-f]{40}$")
     __slots__ = ()
 
     def __repr__(self) -> str:

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -86,18 +86,19 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
         super(Reference, self).set_object(object, logmsg)
 
         if oldbinsha is not None:
-            # /* from refs.c in git-source
-            # * Special hack: If a branch is updated directly and HEAD
-            # * points to it (may happen on the remote side of a push
-            # * for example) then logically the HEAD reflog should be
-            # * updated too.
-            # * A generic solution implies reverse symref information,
-            # * but finding all symrefs pointing to the given branch
-            # * would be rather costly for this rare event (the direct
-            # * update of a branch) to be worth it.  So let's cheat and
-            # * check with HEAD only which should cover 99% of all usage
-            # * scenarios (even 100% of the default ones).
-            # */
+            # From refs/files-backend.c in git-source:
+            # /*
+            #  * Special hack: If a branch is updated directly and HEAD
+            #  * points to it (may happen on the remote side of a push
+            #  * for example) then logically the HEAD reflog should be
+            #  * updated too.
+            #  * A generic solution implies reverse symref information,
+            #  * but finding all symrefs pointing to the given branch
+            #  * would be rather costly for this rare event (the direct
+            #  * update of a branch) to be worth it.  So let's cheat and
+            #  * check with HEAD only which should cover 99% of all usage
+            #  * scenarios (even 100% of the default ones).
+            #  */
             self.repo.head.log_append(oldbinsha, logmsg)
         # END check if the head
 

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -40,8 +40,8 @@ def require_remote_ref_path(func: Callable[..., _T]) -> Callable[..., _T]:
 class Reference(SymbolicReference, LazyMixin, IterableObj):
     """A named reference to any object.
 
-    Subclasses may apply restrictions though, e.g., a :class:`Head <git.refs.head.Head>`
-    can only point to commits.
+    Subclasses may apply restrictions though, e.g., a :class:`~git.refs.head.Head` can
+    only point to commits.
     """
 
     __slots__ = ()

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -22,7 +22,7 @@ __all__ = ["Reference"]
 
 
 def require_remote_ref_path(func: Callable[..., _T]) -> Callable[..., _T]:
-    """A decorator raising a TypeError if we are not a valid remote, based on the path"""
+    """A decorator raising a TypeError if we are not a valid remote, based on the path."""
 
     def wrapper(self: T_References, *args: Any) -> _T:
         if not self.is_remote():
@@ -38,27 +38,30 @@ def require_remote_ref_path(func: Callable[..., _T]) -> Callable[..., _T]:
 
 
 class Reference(SymbolicReference, LazyMixin, IterableObj):
+    """A named reference to any object.
 
-    """Represents a named reference to any object. Subclasses may apply restrictions though,
-    i.e. Heads can only point to commits."""
+    Subclasses may apply restrictions though, e.g., a :class:`Head <git.refs.head.Head>`
+    can only point to commits.
+    """
 
     __slots__ = ()
+
     _points_to_commits_only = False
     _resolve_ref_on_create = True
     _common_path_default = "refs"
 
     def __init__(self, repo: "Repo", path: PathLike, check_path: bool = True) -> None:
-        """Initialize this instance
+        """Initialize this instance.
 
-        :param repo: Our parent repository
-        :param path:
-            Path relative to the .git/ directory pointing to the ref in question, i.e.
-            refs/heads/master
-        :param check_path: if False, you can provide any path. Otherwise the path must start with the
-            default path prefix of this type."""
+        :param repo: Our parent repository.
+        :param path: Path relative to the .git/ directory pointing to the ref in
+            question, e.g. ``refs/heads/master``.
+        :param check_path: If False, you can provide any path. Otherwise the path must
+            start with the default path prefix of this type.
+        """
         if check_path and not str(path).startswith(self._common_path_default + "/"):
             raise ValueError(f"Cannot instantiate {self.__class__.__name__!r} from path {path}")
-        self.path: str  # SymbolicReference converts to string atm
+        self.path: str  # SymbolicReference converts to string at the moment.
         super(Reference, self).__init__(repo, path)
 
     def __str__(self) -> str:
@@ -72,9 +75,10 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
         object: Union[Commit_ish, "SymbolicReference", str],
         logmsg: Union[str, None] = None,
     ) -> "Reference":
-        """Special version which checks if the head-log needs an update as well
+        """Special version which checks if the head-log needs an update as well.
 
-        :return: self"""
+        :return: self
+        """
         oldbinsha = None
         if logmsg is not None:
             head = self.repo.head
@@ -104,13 +108,13 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
 
         return self
 
-    # NOTE: Don't have to overwrite properties as the will only work without a the log
+    # NOTE: No need to overwrite properties, as the will only work without a the log.
 
     @property
     def name(self) -> str:
         """:return: (shortest) Name of this reference - it may contain path components"""
-        # first two path tokens are can be removed as they are
-        # refs/heads or refs/tags or refs/remotes
+        # The first two path tokens can be removed as they are
+        # refs/heads or refs/tags or refs/remotes.
         tokens = self.path.split("/")
         if len(tokens) < 3:
             return self.path  # could be refs/HEAD
@@ -132,23 +136,27 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
 
     # { Remote Interface
 
-    @property  # type: ignore ## mypy cannot deal with properties with an extra decorator (2021-04-21)
+    @property  # type: ignore  # mypy cannot deal with properties with an extra decorator (2021-04-21).
     @require_remote_ref_path
     def remote_name(self) -> str:
         """
         :return:
             Name of the remote we are a reference of, such as 'origin' for a reference
-            named 'origin/master'"""
+            named 'origin/master'.
+        """
         tokens = self.path.split("/")
         # /refs/remotes/<remote name>/<branch_name>
         return tokens[2]
 
-    @property  # type: ignore ## mypy cannot deal with properties with an extra decorator (2021-04-21)
+    @property  # type: ignore  # mypy cannot deal with properties with an extra decorator (2021-04-21).
     @require_remote_ref_path
     def remote_head(self) -> str:
-        """:return: Name of the remote head itself, i.e. master.
+        """
+        :return: Name of the remote head itself, e.g. master.
+
         :note: The returned name is usually not qualified enough to uniquely identify
-            a branch"""
+            a branch.
+        """
         tokens = self.path.split("/")
         return "/".join(tokens[3:])
 

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -21,8 +21,7 @@ if TYPE_CHECKING:
 
 
 class RemoteReference(Head):
-
-    """Represents a reference pointing to a remote head."""
+    """A reference pointing to a remote head."""
 
     _common_path_default = Head._remote_common_path_default
 
@@ -35,7 +34,7 @@ class RemoteReference(Head):
         *args: Any,
         **kwargs: Any,
     ) -> Iterator["RemoteReference"]:
-        """Iterate remote references, and if given, constrain them to the given remote"""
+        """Iterate remote references, and if given, constrain them to the given remote."""
         common_path = common_path or cls._common_path_default
         if remote is not None:
             common_path = join_path(common_path, str(remote))
@@ -49,15 +48,16 @@ class RemoteReference(Head):
     # "type: ignore".  (See https://github.com/python/typing/issues/241)
     @classmethod
     def delete(cls, repo: "Repo", *refs: "RemoteReference", **kwargs: Any) -> None:  # type: ignore
-        """Delete the given remote references
+        """Delete the given remote references.
 
         :note:
             kwargs are given for comparability with the base class method as we
-            should not narrow the signature."""
+            should not narrow the signature.
+        """
         repo.git.branch("-d", "-r", *refs)
-        # the official deletion method will ignore remote symbolic refs - these
+        # The official deletion method will ignore remote symbolic refs - these
         # are generally ignored in the refs/ folder. We don't though
-        # and delete remainders manually
+        # and delete remainders manually.
         for ref in refs:
             try:
                 os.remove(os.path.join(repo.common_dir, ref.path))
@@ -71,5 +71,5 @@ class RemoteReference(Head):
 
     @classmethod
     def create(cls, *args: Any, **kwargs: Any) -> NoReturn:
-        """Used to disable this method"""
+        """Raises TypeError. Defined so the create method is disabled."""
         raise TypeError("Cannot explicitly create remote references")

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -641,7 +641,7 @@ class SymbolicReference(object):
 
         :param reference:
             The reference to which the new symbolic reference should point to.
-            If it is a commit'ish, the symbolic ref will be detached.
+            If it is a commit-ish, the symbolic ref will be detached.
 
         :param force:
             if True, force creation even if a symbolic reference with that name already exists.

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -798,7 +798,7 @@ class SymbolicReference(object):
                 instance: T_References
                 instance = ref_type(repo, path)
                 if instance.__class__ == SymbolicReference and instance.is_detached:
-                    raise ValueError("SymbolRef was detached, we drop it")
+                    raise ValueError("SymbolicRef was detached, we drop it")
                 else:
                     return instance
 

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -523,7 +523,7 @@ class SymbolicReference:
             committer_or_reader: Union["Actor", "GitConfigParser"] = self.commit.committer
         except ValueError:
             committer_or_reader = self.repo.config_reader()
-        # end handle newly cloned repositories
+        # END handle newly cloned repositories
         if newbinsha is None:
             newbinsha = self.commit.binsha
 

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -55,7 +55,7 @@ def _git_dir(repo: "Repo", path: Union[PathLike, None]) -> PathLike:
     return repo.common_dir
 
 
-class SymbolicReference(object):
+class SymbolicReference:
     """Special case of a reference that is symbolic.
 
     This does not point to a specific commit, but to another

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -769,7 +769,7 @@ class SymbolicReference(object):
 
             List is lexicographically sorted
             The returned objects represent actual subclasses, such as Head or TagReference"""
-        return (r for r in cls._iter_items(repo, common_path) if r.__class__ == SymbolicReference or not r.is_detached)
+        return (r for r in cls._iter_items(repo, common_path) if r.__class__ is SymbolicReference or not r.is_detached)
 
     @classmethod
     def from_path(cls: Type[T_References], repo: "Repo", path: PathLike) -> T_References:
@@ -797,7 +797,7 @@ class SymbolicReference(object):
             try:
                 instance: T_References
                 instance = ref_type(repo, path)
-                if instance.__class__ == SymbolicReference and instance.is_detached:
+                if instance.__class__ is SymbolicReference and instance.is_detached:
                     raise ValueError("SymbolicRef was detached, we drop it")
                 else:
                     return instance

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -59,7 +59,7 @@ class SymbolicReference:
     """Special case of a reference that is symbolic.
 
     This does not point to a specific commit, but to another
-    :class:`Head <git.refs.head.Head>`, which itself specifies a commit.
+    :class:`~git.refs.head.Head`, which itself specifies a commit.
 
     A typical example for a symbolic reference is ``HEAD``.
     """
@@ -345,7 +345,7 @@ class SymbolicReference:
         If the reference does not exist, it will be created.
 
         :param object: A refspec, a :class:`SymbolicReference` or an
-            :class:`Object <git.objects.base.Object>` instance.
+            :class:`~git.objects.base.Object` instance.
             :class:`SymbolicReference` instances will be dereferenced beforehand to
             obtain the object they point to.
         :param logmsg: If not None, the message will be used in the reflog entry to be
@@ -396,10 +396,10 @@ class SymbolicReference:
         symbolic one.
 
         :param ref:
-            A :class:`SymbolicReference` instance,
-            an :class:`Object <git.objects.base.Object>` instance, or a refspec string.
-            Only if the ref is a :class:`SymbolicReference` instance, we will point to
-            it. Everything else is dereferenced to obtain the actual object.
+            A :class:`SymbolicReference` instance, an :class:`~git.objects.base.Object`
+            instance, or a refspec string. Only if the ref is a
+            :class:`SymbolicReference` instance, we will point to it. Everything else is
+            dereferenced to obtain the actual object.
 
         :param logmsg: If set to a string, the message will be used in the reflog.
             Otherwise, a reflog entry is not written for the changed reference.
@@ -514,7 +514,7 @@ class SymbolicReference:
         :param message: A message describing the change.
         :param newbinsha: The sha the ref points to now. If None, our current commit sha
             will be used.
-        :return: The added :class:`RefLogEntry <git.refs.log.RefLogEntry>` instance.
+        :return: The added :class:`~git.refs.log.RefLogEntry` instance.
         """
         # NOTE: We use the committer of the currently active commit - this should be
         # correct to allow overriding the committer on a per-commit level.
@@ -540,7 +540,7 @@ class SymbolicReference:
 
         .. note:: This method must read part of the reflog during execution, hence
             it should be used sparingly, or only if you need just one index.
-            In that case, it will be faster than the ``log()`` method.
+            In that case, it will be faster than the :meth:`log` method.
         """
         return RefLog.entry_at(RefLog.path(self), index)
 
@@ -816,8 +816,8 @@ class SymbolicReference:
             which is not detached and pointing to a valid ref.
 
             The list is lexicographically sorted. The returned objects are instances of
-            concrete subclasses, such as :class:`Head <git.refs.head.Head>` or
-            :class:`TagReference <git.refs.tag.TagReference>`.
+            concrete subclasses, such as :class:`~git.refs.head.Head` or
+            :class:`~git.refs.tag.TagReference`.
         """
         return (r for r in cls._iter_items(repo, common_path) if r.__class__ is SymbolicReference or not r.is_detached)
 
@@ -826,14 +826,16 @@ class SymbolicReference:
         """
         Make a symbolic reference from a path.
 
-        :param path: Full ``.git``-directory-relative path name to the Reference to instantiate.
+        :param path: Full ``.git``-directory-relative path name to the Reference to
+            instantiate.
 
-        :note: Use :meth:`to_full_path` if you only have a partial path of a known Reference type.
+        :note: Use :meth:`to_full_path` if you only have a partial path of a known
+            Reference type.
 
         :return:
-            Instance of type :class:`Reference <git.refs.reference.Reference>`,
-            :class:`Head <git.refs.head.Head>`, or :class:`Tag <git.refs.tag.Tag>`,
-            depending on the given path.
+            Instance of type :class:`~git.refs.reference.Reference`,
+            :class:`~git.refs.head.Head`, or :class:`~git.refs.tag.Tag`, depending on
+            the given path.
         """
         if not path:
             raise ValueError("Cannot create Reference from %r" % path)

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -89,8 +89,8 @@ class TagReference(Reference):
             The prefix ``refs/tags`` is implied.
 
         :param ref:
-            A reference to the :class:`Object <git.objects.base.Object>` you want to
-            tag. The Object can be a commit, tree or blob.
+            A reference to the :class:`~git.objects.base.Object` you want to tag.
+            The Object can be a commit, tree or blob.
 
         :param logmsg:
             If not None, the message will be used in your tag object. This will also

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -18,10 +18,9 @@ if TYPE_CHECKING:
 
 
 class TagReference(Reference):
-
-    """Class representing a lightweight tag reference which either points to a commit
-    ,a tag object or any other object. In the latter case additional information,
-    like the signature or the tag-creator, is available.
+    """A lightweight tag reference which either points to a commit, a tag object or any
+    other object. In the latter case additional information, like the signature or the
+    tag-creator, is available.
 
     This tag object will always point to a commit object, but may carry additional
     information in a tag object::
@@ -29,9 +28,11 @@ class TagReference(Reference):
      tagref = TagReference.list_items(repo)[0]
      print(tagref.commit.message)
      if tagref.tag is not None:
-        print(tagref.tag.message)"""
+        print(tagref.tag.message)
+    """
 
     __slots__ = ()
+
     _common_default = "tags"
     _common_path_default = Reference._common_path_default + "/" + _common_default
 
@@ -39,11 +40,12 @@ class TagReference(Reference):
     def commit(self) -> "Commit":  # type: ignore[override]  # LazyMixin has unrelated commit method
         """:return: Commit object the tag ref points to
 
-        :raise ValueError: if the tag points to a tree or blob"""
+        :raise ValueError: If the tag points to a tree or blob
+        """
         obj = self.object
         while obj.type != "commit":
             if obj.type == "tag":
-                # it is a tag object which carries the commit as an object - we can point to anything
+                # It is a tag object which carries the commit as an object - we can point to anything.
                 obj = obj.object
             else:
                 raise ValueError(
@@ -59,16 +61,13 @@ class TagReference(Reference):
     def tag(self) -> Union["TagObject", None]:
         """
         :return: Tag object this tag ref points to or None in case
-            we are a light weight tag"""
+            we are a lightweight tag"""
         obj = self.object
         if obj.type == "tag":
             return obj
         return None
 
-    # make object read-only
-    # It should be reasonably hard to adjust an existing tag
-
-    # object = property(Reference._get_object)
+    # Make object read-only. It should be reasonably hard to adjust an existing tag.
     @property
     def object(self) -> Commit_ish:  # type: ignore[override]
         return Reference._get_object(self)
@@ -86,30 +85,31 @@ class TagReference(Reference):
         """Create a new tag reference.
 
         :param path:
-            The name of the tag, i.e. 1.0 or releases/1.0.
-            The prefix refs/tags is implied
+            The name of the tag, e.g. ``1.0`` or ``releases/1.0``.
+            The prefix ``refs/tags`` is implied.
 
         :param ref:
-            A reference to the Object you want to tag. The Object can be a commit, tree or
-            blob.
+            A reference to the :class:`Object <git.objects.base.Object>` you want to
+            tag. The Object can be a commit, tree or blob.
 
         :param logmsg:
             If not None, the message will be used in your tag object. This will also
-            create an additional tag object that allows to obtain that information, i.e.::
+            create an additional tag object that allows to obtain that information, e.g.::
 
                 tagref.tag.message
 
         :param message:
-            Synonym for :param logmsg:
-            Included for backwards compatibility. :param logmsg is used in preference if both given.
+            Synonym for the `logmsg` parameter.
+            Included for backwards compatibility. `logmsg` takes precedence if both are passed.
 
         :param force:
-            If True, to force creation of a tag even though that tag already exists.
+            If True, force creation of a tag even though that tag already exists.
 
         :param kwargs:
-            Additional keyword arguments to be passed to git-tag
+            Additional keyword arguments to be passed to git-tag.
 
-        :return: A new TagReference"""
+        :return: A new TagReference.
+        """
         if "ref" in kwargs and kwargs["ref"]:
             reference = kwargs["ref"]
 
@@ -130,9 +130,9 @@ class TagReference(Reference):
 
     @classmethod
     def delete(cls, repo: "Repo", *tags: "TagReference") -> None:  # type: ignore[override]
-        """Delete the given existing tag or tags"""
+        """Delete the given existing tag or tags."""
         repo.git.tag("-d", *tags)
 
 
-# provide an alias
+# Provide an alias.
 Tag = TagReference

--- a/git/remote.py
+++ b/git/remote.py
@@ -622,7 +622,6 @@ class Remote(LazyMixin, IterableObj):
             return True
         except cp.NoSectionError:
             return False
-        # end
 
     @classmethod
     def iter_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> Iterator["Remote"]:
@@ -757,7 +756,7 @@ class Remote(LazyMixin, IterableObj):
             else:
                 fqhn = "%s/%s" % (RemoteReference._common_path_default, ref_name)
                 out_refs.append(RemoteReference(self.repo, fqhn))
-            # end special case handling
+            # END special case handling
         # END for each line
         return out_refs
 
@@ -887,8 +886,8 @@ class Remote(LazyMixin, IterableObj):
                 fetch_head_info = fetch_head_info[:l_fil]
             else:
                 fetch_info_lines = fetch_info_lines[:l_fhi]
-            # end truncate correct list
-        # end sanity check + sanitization
+            # END truncate correct list
+        # END sanity check + sanitization
 
         for err_line, fetch_line in zip(fetch_info_lines, fetch_head_info):
             try:

--- a/git/remote.py
+++ b/git/remote.py
@@ -210,9 +210,9 @@ class PushInfo(IterableObj, object):
     def remote_ref(self) -> Union[RemoteReference, TagReference]:
         """
         :return:
-            Remote :class:`Reference <git.refs.reference.Reference>` or
-            :class:`TagReference <git.refs.tag.TagReference>` in the local repository
-            corresponding to the :attr:`remote_ref_string` kept in this instance.
+            Remote :class:`~git.refs.reference.Reference` or
+            :class:`~git.refs.tag.TagReference` in the local repository corresponding to
+            the :attr:`remote_ref_string` kept in this instance.
         """
         # Translate heads to a local remote. Tags stay as they are.
         if self.remote_ref_string.startswith("refs/tags"):
@@ -1093,7 +1093,7 @@ class Remote(LazyMixin, IterableObj):
               `Click here <http://goo.gl/NPa7st>`__ for a description of all arguments
               given to the function.
             * An instance of a class derived from :class:`git.RemoteProgress` that
-              overrides the :meth:`update <git.RemoteProgress.update>` method.
+              overrides the :meth:`~git.RemoteProgress.update` method.
 
         :note: No further progress information is returned after push returns.
 
@@ -1109,14 +1109,14 @@ class Remote(LazyMixin, IterableObj):
         :param kwargs: Additional arguments to be passed to git-push.
 
         :return:
-            A :class:`PushInfoList` object, where each list member
-            represents an individual head which had been updated on the remote side.
+            A :class:`PushInfoList` object, where each list member represents an
+            individual head which had been updated on the remote side.
             If the push contains rejected heads, these will have the
             :attr:`PushInfo.ERROR` bit set in their flags.
-            If the operation fails completely, the length of the returned PushInfoList will
-            be 0.
-            Call :meth:`raise_if_error <PushInfoList.raise_if_error>` on the returned
-            object to raise on any failure.
+            If the operation fails completely, the length of the returned PushInfoList
+            will be 0.
+            Call :meth:`~PushInfoList.raise_if_error` on the returned object to raise on
+            any failure.
         """
         kwargs = add_progress(kwargs, self.repo.git, progress)
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -4,7 +4,8 @@
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 
-# Module implementing a remote object allowing easy access to git remotes
+"""Module implementing a remote object allowing easy access to git remotes."""
+
 import logging
 import re
 
@@ -80,9 +81,13 @@ def add_progress(
     progress: Union[RemoteProgress, "UpdateProgress", Callable[..., RemoteProgress], None],
 ) -> Any:
     """Add the --progress flag to the given kwargs dict if supported by the
-    git command. If the actual progress in the given progress instance is not
-    given, we do not request any progress
-    :return: possibly altered kwargs"""
+    git command.
+
+    :note: If the actual progress in the given progress instance is not
+        given, we do not request any progress.
+
+    :return: possibly altered kwargs
+    """
     if progress is not None:
         v = git.version_info[:2]
         if v >= (1, 7):
@@ -113,18 +118,16 @@ def to_progress_instance(progress: RemoteProgress) -> RemoteProgress:
 def to_progress_instance(
     progress: Union[Callable[..., Any], RemoteProgress, None]
 ) -> Union[RemoteProgress, CallableRemoteProgress]:
-    """Given the 'progress' return a suitable object derived from
-    RemoteProgress().
-    """
-    # new API only needs progress as a function
+    """Given the 'progress' return a suitable object derived from RemoteProgress."""
+    # New API only needs progress as a function.
     if callable(progress):
         return CallableRemoteProgress(progress)
 
-    # where None is passed create a parser that eats the progress
+    # Where None is passed create a parser that eats the progress.
     elif progress is None:
         return RemoteProgress()
 
-    # assume its the old API with an instance of RemoteProgress.
+    # Assume its the old API with an instance of RemoteProgress.
     return progress
 
 
@@ -152,6 +155,7 @@ class PushInfo(IterableObj, object):
         "_remote",
         "summary",
     )
+
     _id_attribute_ = "pushinfo"
 
     (
@@ -187,8 +191,10 @@ class PushInfo(IterableObj, object):
         old_commit: Optional[str] = None,
         summary: str = "",
     ) -> None:
-        """Initialize a new instance
-        local_ref: HEAD | Head | RemoteReference | TagReference | Reference | SymbolicReference | None"""
+        """Initialize a new instance.
+
+        local_ref: HEAD | Head | RemoteReference | TagReference | Reference | SymbolicReference | None
+        """
         self.flags = flags
         self.local_ref = local_ref
         self.remote_ref_string = remote_ref_string
@@ -204,9 +210,11 @@ class PushInfo(IterableObj, object):
     def remote_ref(self) -> Union[RemoteReference, TagReference]:
         """
         :return:
-            Remote Reference or TagReference in the local repository corresponding
-            to the remote_ref_string kept in this instance."""
-        # translate heads to a local remote, tags stay as they are
+            Remote :class:`Reference <git.refs.reference.Reference>` or
+            :class:`TagReference <git.refs.tag.TagReference>` in the local repository
+            corresponding to the :attr:`remote_ref_string` kept in this instance.
+        """
+        # Translate heads to a local remote. Tags stay as they are.
         if self.remote_ref_string.startswith("refs/tags"):
             return TagReference(self._remote.repo, self.remote_ref_string)
         elif self.remote_ref_string.startswith("refs/heads"):
@@ -222,11 +230,11 @@ class PushInfo(IterableObj, object):
     @classmethod
     def _from_line(cls, remote: "Remote", line: str) -> "PushInfo":
         """Create a new PushInfo instance as parsed from line which is expected to be like
-        refs/heads/master:refs/heads/master 05d2687..1d0568e as bytes"""
+        refs/heads/master:refs/heads/master 05d2687..1d0568e as bytes."""
         control_character, from_to, summary = line.split("\t", 3)
         flags = 0
 
-        # control character handling
+        # Control character handling
         try:
             flags |= cls._flag_map[control_character]
         except KeyError as e:
@@ -243,7 +251,7 @@ class PushInfo(IterableObj, object):
             else:
                 from_ref = Reference.from_path(remote.repo, from_ref_string)
 
-        # commit handling, could be message or commit info
+        # Commit handling, could be message or commit info
         old_commit: Optional[str] = None
         if summary.startswith("["):
             if "[rejected]" in summary:
@@ -260,13 +268,13 @@ class PushInfo(IterableObj, object):
                 flags |= cls.NEW_HEAD
             # uptodate encoded in control character
         else:
-            # fast-forward or forced update - was encoded in control character,
-            # but we parse the old and new commit
+            # Fast-forward or forced update - was encoded in control character,
+            # but we parse the old and new commit.
             split_token = "..."
             if control_character == " ":
                 split_token = ".."
             old_sha, _new_sha = summary.split(" ")[0].split(split_token)
-            # have to use constructor here as the sha usually is abbreviated
+            # Have to use constructor here as the sha usually is abbreviated.
             old_commit = old_sha
         # END message handling
 
@@ -278,9 +286,7 @@ class PushInfo(IterableObj, object):
 
 
 class PushInfoList(IterableList[PushInfo]):
-    """
-    IterableList of PushInfo objects.
-    """
+    """IterableList of PushInfo objects."""
 
     def __new__(cls) -> "PushInfoList":
         return cast(PushInfoList, IterableList.__new__(cls, "push_infos"))
@@ -290,15 +296,12 @@ class PushInfoList(IterableList[PushInfo]):
         self.error: Optional[Exception] = None
 
     def raise_if_error(self) -> None:
-        """
-        Raise an exception if any ref failed to push.
-        """
+        """Raise an exception if any ref failed to push."""
         if self.error:
             raise self.error
 
 
 class FetchInfo(IterableObj, object):
-
     """
     Carries information about the results of a fetch operation of a single head::
 
@@ -315,6 +318,7 @@ class FetchInfo(IterableObj, object):
     """
 
     __slots__ = ("ref", "old_commit", "flags", "note", "remote_ref_path")
+
     _id_attribute_ = "fetchinfo"
 
     (
@@ -341,9 +345,7 @@ class FetchInfo(IterableObj, object):
 
     @classmethod
     def refresh(cls) -> Literal[True]:
-        """This gets called by the refresh function (see the top level
-        __init__).
-        """
+        """This gets called by the refresh function (see the top level __init__)."""
         # clear the old values in _flag_map
         try:
             del cls._flag_map["t"]
@@ -371,9 +373,7 @@ class FetchInfo(IterableObj, object):
         old_commit: Union[Commit_ish, None] = None,
         remote_ref_path: Optional[PathLike] = None,
     ) -> None:
-        """
-        Initialize a new instance
-        """
+        """Initialize a new instance."""
         self.ref = ref
         self.flags = flags
         self.note = note
@@ -410,12 +410,13 @@ class FetchInfo(IterableObj, object):
         ' ' means a fast-forward
 
         fetch line is the corresponding line from FETCH_HEAD, like
-        acb0fa8b94ef421ad60c8507b634759a472cd56c    not-for-merge   branch '0.1.7RC' of /tmp/tmpya0vairemote_repo"""
+        acb0fa8b94ef421ad60c8507b634759a472cd56c    not-for-merge   branch '0.1.7RC' of /tmp/tmpya0vairemote_repo
+        """
         match = cls._re_fetch_result.match(line)
         if match is None:
             raise ValueError("Failed to parse line: %r" % line)
 
-        # parse lines
+        # Parse lines.
         remote_local_ref_str: str
         (
             control_character,
@@ -432,7 +433,7 @@ class FetchInfo(IterableObj, object):
         except ValueError as e:  # unpack error
             raise ValueError("Failed to parse FETCH_HEAD line: %r" % fetch_line) from e
 
-        # parse flags from control_character
+        # Parse flags from control_character.
         flags = 0
         try:
             flags |= cls._flag_map[control_character]
@@ -440,7 +441,8 @@ class FetchInfo(IterableObj, object):
             raise ValueError("Control character %r unknown as parsed from line %r" % (control_character, line)) from e
         # END control char exception handling
 
-        # parse operation string for more info - makes no sense for symbolic refs, but we parse it anyway
+        # Parse operation string for more info.
+        # This makes no sense for symbolic refs, but we parse it anyway.
         old_commit: Union[Commit_ish, None] = None
         is_tag_operation = False
         if "rejected" in operation:
@@ -460,45 +462,45 @@ class FetchInfo(IterableObj, object):
             old_commit = repo.rev_parse(operation.split(split_token)[0])
         # END handle refspec
 
-        # handle FETCH_HEAD and figure out ref type
+        # Handle FETCH_HEAD and figure out ref type.
         # If we do not specify a target branch like master:refs/remotes/origin/master,
         # the fetch result is stored in FETCH_HEAD which destroys the rule we usually
-        # have. In that case we use a symbolic reference which is detached
+        # have. In that case we use a symbolic reference which is detached.
         ref_type: Optional[Type[SymbolicReference]] = None
         if remote_local_ref_str == "FETCH_HEAD":
             ref_type = SymbolicReference
         elif ref_type_name == "tag" or is_tag_operation:
-            # the ref_type_name can be branch, whereas we are still seeing a tag operation. It happens during
-            # testing, which is based on actual git operations
+            # The ref_type_name can be branch, whereas we are still seeing a tag operation.
+            # It happens during testing, which is based on actual git operations.
             ref_type = TagReference
         elif ref_type_name in ("remote-tracking", "branch"):
-            # note: remote-tracking is just the first part of the 'remote-tracking branch' token.
-            # We don't parse it correctly, but its enough to know what to do, and its new in git 1.7something
+            # Note: remote-tracking is just the first part of the 'remote-tracking branch' token.
+            # We don't parse it correctly, but its enough to know what to do, and it's new in git 1.7something.
             ref_type = RemoteReference
         elif "/" in ref_type_name:
-            # If the fetch spec look something like this '+refs/pull/*:refs/heads/pull/*', and is thus pretty
-            # much anything the user wants, we will have trouble to determine what's going on
-            # For now, we assume the local ref is a Head
+            # If the fetch spec look something like this '+refs/pull/*:refs/heads/pull/*',
+            # and is thus pretty much anything the user wants, we will have trouble
+            # determining what's going on. For now, we assume the local ref is a Head.
             ref_type = Head
         else:
             raise TypeError("Cannot handle reference type: %r" % ref_type_name)
         # END handle ref type
 
-        # create ref instance
+        # Create ref instance.
         if ref_type is SymbolicReference:
             remote_local_ref = ref_type(repo, "FETCH_HEAD")
         else:
-            # determine prefix. Tags are usually pulled into refs/tags, they may have subdirectories.
-            # It is not clear sometimes where exactly the item is, unless we have an absolute path as indicated
-            # by the 'ref/' prefix. Otherwise even a tag could be in refs/remotes, which is when it will have the
-            # 'tags/' subdirectory in its path.
+            # Determine prefix. Tags are usually pulled into refs/tags, they may have subdirectories.
+            # It is not clear sometimes where exactly the item is, unless we have an absolute path as
+            # indicated by the 'ref/' prefix. Otherwise even a tag could be in refs/remotes, which is
+            # when it will have the 'tags/' subdirectory in its path.
             # We don't want to test for actual existence, but try to figure everything out analytically.
             ref_path: Optional[PathLike] = None
             remote_local_ref_str = remote_local_ref_str.strip()
 
             if remote_local_ref_str.startswith(Reference._common_path_default + "/"):
-                # always use actual type if we get absolute paths
-                # Will always be the case if something is fetched outside of refs/remotes (if its not a tag)
+                # Always use actual type if we get absolute paths.
+                # Will always be the case if something is fetched outside of refs/remotes (if its not a tag).
                 ref_path = remote_local_ref_str
                 if ref_type is not TagReference and not remote_local_ref_str.startswith(
                     RemoteReference._common_path_default + "/"
@@ -506,14 +508,14 @@ class FetchInfo(IterableObj, object):
                     ref_type = Reference
                 # END downgrade remote reference
             elif ref_type is TagReference and "tags/" in remote_local_ref_str:
-                # even though its a tag, it is located in refs/remotes
+                # Even though it's a tag, it is located in refs/remotes.
                 ref_path = join_path(RemoteReference._common_path_default, remote_local_ref_str)
             else:
                 ref_path = join_path(ref_type._common_path_default, remote_local_ref_str)
             # END obtain refpath
 
-            # even though the path could be within the git conventions, we make
-            # sure we respect whatever the user wanted, and disabled path checking
+            # Even though the path could be within the git conventions, we make
+            # sure we respect whatever the user wanted, and disabled path checking.
             remote_local_ref = ref_type(repo, ref_path, check_path=False)
         # END create ref instance
 
@@ -527,16 +529,17 @@ class FetchInfo(IterableObj, object):
 
 
 class Remote(LazyMixin, IterableObj):
-
     """Provides easy read and write access to a git remote.
 
     Everything not part of this interface is considered an option for the current
     remote, allowing constructs like remote.pushurl to query the pushurl.
 
-    NOTE: When querying configuration, the configuration accessor will be cached
-    to speed up subsequent accesses."""
+    :note: When querying configuration, the configuration accessor will be cached
+        to speed up subsequent accesses.
+    """
 
     __slots__ = ("repo", "name", "_config_reader")
+
     _id_attribute_ = "name"
 
     unsafe_git_fetch_options = [
@@ -557,22 +560,23 @@ class Remote(LazyMixin, IterableObj):
     ]
 
     def __init__(self, repo: "Repo", name: str) -> None:
-        """Initialize a remote instance
+        """Initialize a remote instance.
 
         :param repo: The repository we are a remote of
-        :param name: the name of the remote, i.e. 'origin'"""
+        :param name: The name of the remote, e.g. 'origin'
+        """
         self.repo = repo
         self.name = name
         self.url: str
 
     def __getattr__(self, attr: str) -> Any:
         """Allows to call this instance like
-        remote.special( \\*args, \\*\\*kwargs) to call git-remote special self.name"""
+        remote.special( \\*args, \\*\\*kwargs) to call git-remote special self.name."""
         if attr == "_config_reader":
             return super(Remote, self).__getattr__(attr)
 
-        # sometimes, probably due to a bug in python itself, we are being called
-        # even though a slot of the same name exists
+        # Sometimes, probably due to a bug in Python itself, we are being called
+        # even though a slot of the same name exists.
         try:
             return self._config_reader.get(attr)
         except cp.NoOptionError:
@@ -584,8 +588,8 @@ class Remote(LazyMixin, IterableObj):
 
     def _set_cache_(self, attr: str) -> None:
         if attr == "_config_reader":
-            # NOTE: This is cached as __getattr__ is overridden to return remote config values implicitly, such as
-            # in print(r.pushurl)
+            # NOTE: This is cached as __getattr__ is overridden to return remote config
+            # values implicitly, such as in print(r.pushurl).
             self._config_reader = SectionConstraint(self.repo.config_reader("repository"), self._config_section_name())
         else:
             super(Remote, self)._set_cache_(attr)
@@ -608,12 +612,13 @@ class Remote(LazyMixin, IterableObj):
     def exists(self) -> bool:
         """
         :return: True if this is a valid, existing remote.
-            Valid remotes have an entry in the repository's configuration"""
+            Valid remotes have an entry in the repository's configuration.
+        """
         try:
             self.config_reader.get("url")
             return True
         except cp.NoOptionError:
-            # we have the section at least ...
+            # We have the section at least...
             return True
         except cp.NoSectionError:
             return False
@@ -635,12 +640,12 @@ class Remote(LazyMixin, IterableObj):
     def set_url(
         self, new_url: str, old_url: Optional[str] = None, allow_unsafe_protocols: bool = False, **kwargs: Any
     ) -> "Remote":
-        """Configure URLs on current remote (cf command git remote set_url)
+        """Configure URLs on current remote (cf command git remote set_url).
 
         This command manages URLs on the remote.
 
-        :param new_url: string being the URL to add as an extra remote URL
-        :param old_url: when set, replaces this URL with new_url for the remote
+        :param new_url: String being the URL to add as an extra remote URL
+        :param old_url: When set, replaces this URL with new_url for the remote
         :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
         :return: self
         """
@@ -655,12 +660,12 @@ class Remote(LazyMixin, IterableObj):
         return self
 
     def add_url(self, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
-        """Adds a new url on current remote (special case of git remote set_url)
+        """Adds a new url on current remote (special case of git remote set_url).
 
         This command adds new URLs to a given remote, making it possible to have
         multiple URLs for a single remote.
 
-        :param url: string being the URL to add as an extra remote URL
+        :param url: String being the URL to add as an extra remote URL
         :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
         :return: self
         """
@@ -672,7 +677,7 @@ class Remote(LazyMixin, IterableObj):
         This command deletes new URLs to a given remote, making it possible to have
         multiple URLs for a single remote.
 
-        :param url: string being the URL to delete from the remote
+        :param url: String being the URL to delete from the remote
         :return: self
         """
         return self.set_url(url, delete=True)
@@ -700,7 +705,7 @@ class Remote(LazyMixin, IterableObj):
                             yield line.split(": ")[-1]
                 except GitCommandError as _ex:
                     if any(msg in str(_ex) for msg in ["correct access rights", "cannot run ssh"]):
-                        # If ssh is not setup to access this repository, see issue 694
+                        # If ssh is not setup to access this repository, see issue 694.
                         remote_details = self.repo.git.config("--get-all", "remote.%s.url" % self.name)
                         assert isinstance(remote_details, str)
                         for line in remote_details.split("\n"):
@@ -715,8 +720,9 @@ class Remote(LazyMixin, IterableObj):
         """
         :return:
             IterableList of RemoteReference objects. It is prefixed, allowing
-            you to omit the remote path portion, i.e.::
-            remote.refs.master # yields RemoteReference('/refs/remotes/origin/master')"""
+            you to omit the remote path portion, e.g.::
+            remote.refs.master # yields RemoteReference('/refs/remotes/origin/master')
+        """
         out_refs: IterableList[RemoteReference] = IterableList(RemoteReference._id_attribute_, "%s/" % self.name)
         out_refs.extend(RemoteReference.list_items(self.repo, remote=self.name))
         return out_refs
@@ -745,7 +751,7 @@ class Remote(LazyMixin, IterableObj):
             if not line.startswith(token):
                 continue
             ref_name = line.replace(token, "")
-            # sometimes, paths start with a full ref name, like refs/tags/foo, see #260
+            # Sometimes, paths start with a full ref name, like refs/tags/foo. See #260.
             if ref_name.startswith(Reference._common_path_default + "/"):
                 out_refs.append(Reference.from_path(self.repo, ref_name))
             else:
@@ -757,7 +763,7 @@ class Remote(LazyMixin, IterableObj):
 
     @classmethod
     def create(cls, repo: "Repo", name: str, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
-        """Create a new remote to the given repository
+        """Create a new remote to the given repository.
 
         :param repo: Repository instance that is to receive the new remote
         :param name: Desired name of the remote
@@ -765,7 +771,8 @@ class Remote(LazyMixin, IterableObj):
         :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
         :param kwargs: Additional arguments to be passed to the git-remote add command
         :return: New Remote instance
-        :raise GitCommandError: in case an origin with that name already exists"""
+        :raise GitCommandError: in case an origin with that name already exists
+        """
         scmd = "add"
         kwargs["insert_kwargs_after"] = scmd
         url = Git.polish_url(url)
@@ -774,29 +781,30 @@ class Remote(LazyMixin, IterableObj):
         repo.git.remote(scmd, "--", name, url, **kwargs)
         return cls(repo, name)
 
-    # add is an alias
+    # `add` is an alias.
     @classmethod
     def add(cls, repo: "Repo", name: str, url: str, **kwargs: Any) -> "Remote":
         return cls.create(repo, name, url, **kwargs)
 
     @classmethod
     def remove(cls, repo: "Repo", name: str) -> str:
-        """Remove the remote with the given name
+        """Remove the remote with the given name.
 
-        :return: the passed remote name to remove
+        :return: The passed remote name to remove
         """
         repo.git.remote("rm", name)
         if isinstance(name, cls):
             name._clear_cache()
         return name
 
-    # alias
+    # `rm` is an alias.
     rm = remove
 
     def rename(self, new_name: str) -> "Remote":
-        """Rename self to the given new_name
+        """Rename self to the given new_name.
 
-        :return: self"""
+        :return: self
+        """
         if self.name == new_name:
             return self
 
@@ -808,13 +816,12 @@ class Remote(LazyMixin, IterableObj):
 
     def update(self, **kwargs: Any) -> "Remote":
         """Fetch all changes for this remote, including new branches which will
-        be forced in ( in case your local remote branch is not part the new remote branches
-        ancestry anymore ).
+        be forced in (in case your local remote branch is not part the new remote
+        branch's ancestry anymore).
 
-        :param kwargs:
-            Additional arguments passed to git-remote update
-
-        :return: self"""
+        :param kwargs: Additional arguments passed to git-remote update
+        :return: self
+        """
         scmd = "update"
         kwargs["insert_kwargs_after"] = scmd
         self.repo.git.remote(scmd, self.name, **kwargs)
@@ -828,15 +835,15 @@ class Remote(LazyMixin, IterableObj):
     ) -> IterableList["FetchInfo"]:
         progress = to_progress_instance(progress)
 
-        # skip first line as it is some remote info we are not interested in
+        # Skip first line as it is some remote info we are not interested in.
         output: IterableList["FetchInfo"] = IterableList("name")
 
-        # lines which are no progress are fetch info lines
-        # this also waits for the command to finish
-        # Skip some progress lines that don't provide relevant information
+        # Lines which are no progress are fetch info lines.
+        # This also waits for the command to finish.
+        # Skip some progress lines that don't provide relevant information.
         fetch_info_lines = []
-        # Basically we want all fetch info lines which appear to be in regular form, and thus have a
-        # command character. Everything else we ignore,
+        # Basically we want all fetch info lines which appear to be in regular form, and
+        # thus have a command character. Everything else we ignore.
         cmds = set(FetchInfo._flag_map.keys())
 
         progress_handler = progress.new_message_handler()
@@ -861,7 +868,7 @@ class Remote(LazyMixin, IterableObj):
                     fetch_info_lines.append(line)
                     continue
 
-        # read head information
+        # Read head information.
         fetch_head = SymbolicReference(self.repo, "FETCH_HEAD")
         with open(fetch_head.abspath, "rb") as fp:
             fetch_head_info = [line.decode(defenc) for line in fp.readlines()]
@@ -899,10 +906,10 @@ class Remote(LazyMixin, IterableObj):
     ) -> PushInfoList:
         progress = to_progress_instance(progress)
 
-        # read progress information from stderr
-        # we hope stdout can hold all the data, it should ...
-        # read the lines manually as it will use carriage returns between the messages
-        # to override the previous one. This is why we read the bytes manually
+        # Read progress information from stderr.
+        # We hope stdout can hold all the data, it should...
+        # Read the lines manually as it will use carriage returns between the messages
+        # to override the previous one. This is why we read the bytes manually.
         progress_handler = progress.new_message_handler()
         output: PushInfoList = PushInfoList()
 
@@ -925,8 +932,8 @@ class Remote(LazyMixin, IterableObj):
         try:
             proc.wait(stderr=stderr_text)
         except Exception as e:
-            # This is different than fetch (which fails if there is any std_err
-            # even if there is an output)
+            # This is different than fetch (which fails if there is any stderr
+            # even if there is an output).
             if not output:
                 raise
             elif stderr_text:
@@ -936,7 +943,7 @@ class Remote(LazyMixin, IterableObj):
         return output
 
     def _assert_refspec(self) -> None:
-        """Turns out we can't deal with remotes if the refspec is missing"""
+        """Turns out we can't deal with remotes if the refspec is missing."""
         config = self.config_reader
         unset = "placeholder"
         try:
@@ -958,38 +965,46 @@ class Remote(LazyMixin, IterableObj):
         allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> IterableList[FetchInfo]:
-        """Fetch the latest changes for this remote
+        """Fetch the latest changes for this remote.
 
         :param refspec:
             A "refspec" is used by fetch and push to describe the mapping
             between remote ref and local ref. They are combined with a colon in
-            the format <src>:<dst>, preceded by an optional plus sign, +.
-            For example: git fetch $URL refs/heads/master:refs/heads/origin means
+            the format ``<src>:<dst>``, preceded by an optional plus sign, ``+``.
+            For example: ``git fetch $URL refs/heads/master:refs/heads/origin`` means
             "grab the master branch head from the $URL and store it as my origin
-            branch head". And git push $URL refs/heads/master:refs/heads/to-upstream
+            branch head". And ``git push $URL refs/heads/master:refs/heads/to-upstream``
             means "publish my master branch head as to-upstream branch at $URL".
             See also git-push(1).
 
-            Taken from the git manual
+            Taken from the git manual, gitglossary(7).
 
             Fetch supports multiple refspecs (as the
             underlying git-fetch does) - supplying a list rather than a string
             for 'refspec' will make use of this facility.
-        :param progress: See 'push' method
-        :param verbose: Boolean for verbose output
+
+        :param progress: See :meth:`push` method.
+
+        :param verbose: Boolean for verbose output.
+
         :param kill_after_timeout:
             To specify a timeout in seconds for the git command, after which the process
             should be killed. It is set to None by default.
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :param kwargs: Additional arguments to be passed to git-fetch
+
+        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+
+        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
+
+        :param kwargs: Additional arguments to be passed to git-fetch.
+
         :return:
             IterableList(FetchInfo, ...) list of FetchInfo instances providing detailed
             information about the fetch results
 
         :note:
             As fetch does not provide progress information to non-ttys, we cannot make
-            it available here unfortunately as in the 'push' method."""
+            it available here unfortunately as in the :meth:`push` method.
+        """
         if refspec is None:
             # No argument refspec, then ensure the repo's config has a fetch refspec.
             self._assert_refspec()
@@ -1028,13 +1043,14 @@ class Remote(LazyMixin, IterableObj):
         """Pull changes from the given branch, being the same as a fetch followed
         by a merge of branch with your local branch.
 
-        :param refspec: see :meth:`fetch` method
-        :param progress: see :meth:`push` method
-        :param kill_after_timeout: see :meth:`fetch` method
+        :param refspec: See :meth:`fetch` method
+        :param progress: See :meth:`push` method
+        :param kill_after_timeout: See :meth:`fetch` method
         :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
         :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
         :param kwargs: Additional arguments to be passed to git-pull
-        :return: Please see :meth:`fetch` method"""
+        :return: Please see :meth:`fetch` method
+        """
         if refspec is None:
             # No argument refspec, then ensure the repo's config has a fetch refspec.
             self._assert_refspec()
@@ -1067,33 +1083,42 @@ class Remote(LazyMixin, IterableObj):
     ) -> PushInfoList:
         """Push changes from source branch in refspec to target branch in refspec.
 
-        :param refspec: see 'fetch' method
+        :param refspec: See :meth:`fetch` method.
+
         :param progress:
             Can take one of many value types:
 
-            * None to discard progress information
+            * None to discard progress information.
             * A function (callable) that is called with the progress information.
               Signature: ``progress(op_code, cur_count, max_count=None, message='')``.
               `Click here <http://goo.gl/NPa7st>`__ for a description of all arguments
               given to the function.
-            * An instance of a class derived from ``git.RemoteProgress`` that
-              overrides the ``update()`` function.
+            * An instance of a class derived from :class:`git.RemoteProgress` that
+              overrides the :meth:`update <git.RemoteProgress.update>` method.
 
         :note: No further progress information is returned after push returns.
+
         :param kill_after_timeout:
             To specify a timeout in seconds for the git command, after which the process
             should be killed. It is set to None by default.
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --receive-pack
-        :param kwargs: Additional arguments to be passed to git-push
+
+        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like --receive-pack.
+
+        :param kwargs: Additional arguments to be passed to git-push.
+
         :return:
-            A ``PushInfoList`` object, where each list member
+            A :class:`PushInfoList` object, where each list member
             represents an individual head which had been updated on the remote side.
-            If the push contains rejected heads, these will have the PushInfo.ERROR bit set
-            in their flags.
+            If the push contains rejected heads, these will have the
+            :attr:`PushInfo.ERROR` bit set in their flags.
             If the operation fails completely, the length of the returned PushInfoList will
             be 0.
-            Call ``.raise_if_error()`` on the returned object to raise on any failure."""
+            Call :meth:`raise_if_error <PushInfoList.raise_if_error>` on the returned
+            object to raise on any failure.
+        """
         kwargs = add_progress(kwargs, self.repo.git, progress)
 
         refspec = Git._unpack_args(refspec or [])
@@ -1121,7 +1146,8 @@ class Remote(LazyMixin, IterableObj):
         """
         :return:
             GitConfigParser compatible object able to read options for only our remote.
-            Hence you may simple type config.get("pushurl") to obtain the information"""
+            Hence you may simple type config.get("pushurl") to obtain the information.
+        """
         return self._config_reader
 
     def _clear_cache(self) -> None:
@@ -1135,15 +1161,17 @@ class Remote(LazyMixin, IterableObj):
     def config_writer(self) -> SectionConstraint:
         """
         :return: GitConfigParser compatible object able to write options for this remote.
+
         :note:
             You can only own one writer at a time - delete it to release the
             configuration file and make it usable by others.
 
             To assure consistent results, you should only query options through the
             writer. Once you are done writing, you are free to use the config reader
-            once again."""
+            once again.
+        """
         writer = self.repo.config_writer()
 
-        # clear our cache to assure we re-read the possibly changed configuration
+        # Clear our cache to ensure we re-read the possibly changed configuration.
         self._clear_cache()
         return SectionConstraint(writer, self._config_section_name())

--- a/git/repo/__init__.py
+++ b/git/repo/__init__.py
@@ -1,3 +1,5 @@
-"""Initialize the Repo package"""
+"""Initialize the Repo package."""
+
 # flake8: noqa
+
 from .base import Repo as Repo

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -728,7 +728,7 @@ class Repo:
         """
         if len(rev) < 2:
             raise ValueError("Please specify at least two revs, got only %i" % len(rev))
-        # end handle input
+        # END handle input
 
         res: List[Union[Commit_ish, None]] = []
         try:
@@ -736,15 +736,15 @@ class Repo:
         except GitCommandError as err:
             if err.status == 128:
                 raise
-            # end handle invalid rev
+            # END handle invalid rev
             # Status code 1 is returned if there is no merge-base
             # (see https://github.com/git/git/blob/master/builtin/merge-base.c#L16)
             return res
-        # end exception handling
+        # END exception handling
 
         for line in lines:
             res.append(self.commit(line))
-        # end for each merge-base
+        # END for each merge-base
 
         return res
 
@@ -1098,7 +1098,7 @@ class Repo:
                 parts = self.re_whitespace.split(line_str, 1)
                 firstpart = parts[0]
                 is_binary = False
-            # end handle decode of line
+            # END handle decode of line
 
             if self.re_hexsha_only.search(firstpart):
                 # handles
@@ -1448,7 +1448,7 @@ class Repo:
         path = cast(Union[PathLike, List[PathLike], Tuple[PathLike, ...]], path)
         if not isinstance(path, (tuple, list)):
             path = [path]
-        # end ensure paths is list (or tuple)
+        # END ensure paths is list (or tuple)
         self.git.archive("--", treeish, *path, **kwargs)
         return self
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -108,7 +108,7 @@ class BlameEntry(NamedTuple):
     orig_linenos: range
 
 
-class Repo(object):
+class Repo:
     """Represents a git repository and allows you to query references,
     gather commit information, generate diffs, create and clone repositories query
     the log.

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1448,7 +1448,7 @@ class Repo:
         path = cast(Union[PathLike, List[PathLike], Tuple[PathLike, ...]], path)
         if not isinstance(path, (tuple, list)):
             path = [path]
-        # end assure paths is list
+        # end ensure paths is list (or tuple)
         self.git.archive("--", treeish, *path, **kwargs)
         return self
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1,4 +1,4 @@
-# repo.py
+# base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -3,7 +3,9 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 from __future__ import annotations
+
 import logging
 import os
 import re
@@ -164,10 +166,10 @@ class Repo(object):
         search_parent_directories: bool = False,
         expand_vars: bool = True,
     ) -> None:
-        """Create a new Repo instance
+        """Create a new Repo instance.
 
         :param path:
-            the path to either the root git directory or the bare git repo::
+            The path to either the root git directory or the bare git repo::
 
                 repo = Repo("/Users/mtrier/Development/git-python")
                 repo = Repo("/Users/mtrier/Development/git-python.git")
@@ -175,21 +177,26 @@ class Repo(object):
                 repo = Repo("$REPOSITORIES/Development/git-python.git")
                 repo = Repo("C:\\Users\\mtrier\\Development\\git-python\\.git")
 
-            - In *Cygwin*, path may be a `'cygdrive/...'` prefixed path.
-            - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also evals to false,
-              the current-directory is used.
+            - In *Cygwin*, path may be a ``cygdrive/...`` prefixed path.
+            - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also
+              evals to false, the current-directory is used.
+
         :param odbt:
             Object DataBase type - a type which is constructed by providing
             the directory containing the database objects, i.e. .git/objects. It will
             be used to access all object data
-        :param search_parent_directories:
-            if True, all parent directories will be searched for a valid repo as well.
 
-            Please note that this was the default behaviour in older versions of GitPython,
-            which is considered a bug though.
+        :param search_parent_directories:
+            If True, all parent directories will be searched for a valid repo as well.
+
+            Please note that this was the default behaviour in older versions of
+            GitPython, which is considered a bug though.
+
         :raise InvalidGitRepositoryError:
         :raise NoSuchPathError:
-        :return: git.Repo"""
+
+        :return: git.Repo
+        """
 
         epath = path or os.getenv("GIT_DIR")
         if not epath:
@@ -271,7 +278,7 @@ class Repo(object):
         try:
             self._bare = self.config_reader("repository").getboolean("core", "bare")
         except Exception:
-            # lets not assume the option exists, although it should
+            # Let's not assume the option exists, although it should.
             pass
 
         try:
@@ -280,8 +287,8 @@ class Repo(object):
         except OSError:
             self._common_dir = ""
 
-        # adjust the wd in case we are actually bare - we didn't know that
-        # in the first place
+        # Adjust the working directory in case we are actually bare - we didn't know
+        # that in the first place.
         if self._bare:
             self._working_tree_dir = None
         # END working dir handling
@@ -289,7 +296,7 @@ class Repo(object):
         self.working_dir: PathLike = self._working_tree_dir or self.common_dir
         self.git = self.GitCommandWrapperType(self.working_dir)
 
-        # special handling, in special times
+        # Special handling, in special times.
         rootpath = osp.join(self.common_dir, "objects")
         if issubclass(odbt, GitCmdObjectDB):
             self.odb = odbt(rootpath, self.git)
@@ -311,12 +318,10 @@ class Repo(object):
     def close(self) -> None:
         if self.git:
             self.git.clear_cache()
-            # Tempfiles objects on Windows are holding references to
-            # open files until they are collected by the garbage
-            # collector, thus preventing deletion.
-            # TODO: Find these references and ensure they are closed
-            # and deleted synchronously rather than forcing a gc
-            # collection.
+            # Tempfiles objects on Windows are holding references to open files until
+            # they are collected by the garbage collector, thus preventing deletion.
+            # TODO: Find these references and ensure they are closed and deleted
+            # synchronously rather than forcing a gc collection.
             if is_win:
                 gc.collect()
             gitdb.util.mman.collect()
@@ -351,14 +356,18 @@ class Repo(object):
 
     @property
     def working_tree_dir(self) -> Optional[PathLike]:
-        """:return: The working tree directory of our git repository. If this is a bare repository, None is returned."""
+        """
+        :return: The working tree directory of our git repository.
+            If this is a bare repository, None is returned.
+        """
         return self._working_tree_dir
 
     @property
     def common_dir(self) -> PathLike:
         """
         :return: The git dir that holds everything except possibly HEAD,
-            FETCH_HEAD, ORIG_HEAD, COMMIT_EDITMSG, index, and logs/."""
+            FETCH_HEAD, ORIG_HEAD, COMMIT_EDITMSG, index, and logs/.
+        """
         return self._common_dir or self.git_dir
 
     @property
@@ -368,30 +377,36 @@ class Repo(object):
 
     @property
     def heads(self) -> "IterableList[Head]":
-        """A list of ``Head`` objects representing the branch heads in
-        this repo
+        """A list of ``Head`` objects representing the branch heads in this repo.
 
-        :return: ``git.IterableList(Head, ...)``"""
+        :return: ``git.IterableList(Head, ...)``
+        """
         return Head.list_items(self)
 
     @property
     def references(self) -> "IterableList[Reference]":
         """A list of Reference objects representing tags, heads and remote references.
 
-        :return: IterableList(Reference, ...)"""
+        :return: IterableList(Reference, ...)
+        """
         return Reference.list_items(self)
 
-    # alias for references
+    # Alias for references.
     refs = references
 
-    # alias for heads
+    # Alias for heads.
     branches = heads
 
     @property
     def index(self) -> "IndexFile":
-        """:return: IndexFile representing this repository's index.
-        :note: This property can be expensive, as the returned ``IndexFile`` will be
-         reinitialized. It's recommended to re-use the object."""
+        """
+        :return: :class:`IndexFile <git.index.base.IndexFile>` representing this
+            repository's index.
+
+        :note: This property can be expensive, as the returned
+            :class:`IndexFile <git.index.base.IndexFile>` will be reinitialized.
+            It is recommended to reuse the object.
+        """
         return IndexFile(self)
 
     @property
@@ -401,14 +416,17 @@ class Repo(object):
 
     @property
     def remotes(self) -> "IterableList[Remote]":
-        """A list of Remote objects allowing to access and manipulate remotes
+        """A list of Remote objects allowing to access and manipulate remotes.
 
-        :return: ``git.IterableList(Remote, ...)``"""
+        :return: ``git.IterableList(Remote, ...)``
+        """
         return Remote.list_items(self)
 
     def remote(self, name: str = "origin") -> "Remote":
         """:return: Remote with the specified name
-        :raise ValueError:  if no remote with such a name exists"""
+
+        :raise ValueError: If no remote with such a name exists
+        """
         r = Remote(self, name)
         if not r.exists():
             raise ValueError("Remote named '%s' didn't exist" % name)
@@ -420,12 +438,15 @@ class Repo(object):
     def submodules(self) -> "IterableList[Submodule]":
         """
         :return: git.IterableList(Submodule, ...) of direct submodules
-            available from the current head"""
+            available from the current head
+        """
         return Submodule.list_items(self)
 
     def submodule(self, name: str) -> "Submodule":
         """:return: Submodule with the given name
-        :raise ValueError: If no such submodule exists"""
+
+        :raise ValueError: If no such submodule exists
+        """
         try:
             return self.submodules[name]
         except IndexError as e:
@@ -433,38 +454,47 @@ class Repo(object):
         # END exception handling
 
     def create_submodule(self, *args: Any, **kwargs: Any) -> Submodule:
-        """Create a new submodule
+        """Create a new submodule.
 
         :note: See the documentation of Submodule.add for a description of the
-            applicable parameters
-        :return: created submodules"""
+            applicable parameters.
+
+        :return: The created submodules.
+        """
         return Submodule.add(self, *args, **kwargs)
 
     def iter_submodules(self, *args: Any, **kwargs: Any) -> Iterator[Submodule]:
         """An iterator yielding Submodule instances, see Traversable interface
-        for a description of args and kwargs
+        for a description of args and kwargs.
 
-        :return: Iterator"""
+        :return: Iterator
+        """
         return RootModule(self).traverse(*args, **kwargs)
 
     def submodule_update(self, *args: Any, **kwargs: Any) -> Iterator[Submodule]:
         """Update the submodules, keeping the repository consistent as it will
-        take the previous state into consideration. For more information, please
-        see the documentation of RootModule.update"""
+        take the previous state into consideration.
+
+        :note: For more information, please see the documentation of
+            :meth:`RootModule.update <git.objects.submodule.root.RootModule.update>`.
+        """
         return RootModule(self).update(*args, **kwargs)
 
     # }END submodules
 
     @property
     def tags(self) -> "IterableList[TagReference]":
-        """A list of ``Tag`` objects that are available in this repo
+        """A list of ``Tag`` objects that are available in this repo.
 
-        :return: ``git.IterableList(TagReference, ...)``"""
+        :return: ``git.IterableList(TagReference, ...)``
+        """
         return TagReference.list_items(self)
 
     def tag(self, path: PathLike) -> TagReference:
         """:return: TagReference Object, reference pointing to a Commit or Tag
-        :param path: path to the tag reference, i.e. 0.1.5 or tags/0.1.5"""
+
+        :param path: path to the tag reference, i.e. 0.1.5 or tags/0.1.5
+        """
         full_path = self._to_full_tag_path(path)
         return TagReference(self, full_path)
 
@@ -486,15 +516,19 @@ class Repo(object):
         logmsg: Optional[str] = None,
     ) -> "Head":
         """Create a new head within the repository.
-        For more documentation, please see the Head.create method.
 
-        :return: newly created Head Reference"""
+        :note: For more documentation, please see the
+            :meth:`Head.create <git.refs.head.Head.create>` method.
+
+        :return: Newly created :class:`Head <git.refs.head.Head>` Reference
+        """
         return Head.create(self, path, commit, logmsg, force)
 
     def delete_head(self, *heads: "Union[str, Head]", **kwargs: Any) -> None:
-        """Delete the given heads
+        """Delete the given heads.
 
-        :param kwargs: Additional keyword arguments to be passed to git-branch"""
+        :param kwargs: Additional keyword arguments to be passed to git-branch
+        """
         return Head.delete(self, *heads, **kwargs)
 
     def create_tag(
@@ -506,9 +540,12 @@ class Repo(object):
         **kwargs: Any,
     ) -> TagReference:
         """Create a new tag reference.
-        For more documentation, please see the TagReference.create method.
 
-        :return: TagReference object"""
+        :note: For more documentation, please see the
+            :meth:`TagReference.create <git.refs.tag.TagReference.create>` method.
+
+        :return: :class:`TagReference <git.refs.tag.TagReference>` object
+        """
         return TagReference.create(self, path, ref, message, force, **kwargs)
 
     def delete_tag(self, *tags: TagReference) -> None:
@@ -518,10 +555,11 @@ class Repo(object):
     def create_remote(self, name: str, url: str, **kwargs: Any) -> Remote:
         """Create a new remote.
 
-        For more information, please see the documentation of the Remote.create
-        methods
+        For more information, please see the documentation of the
+        :meth:`Remote.create <git.remote.Remote.create>` method.
 
-        :return: Remote reference"""
+        :return: :class:`Remote <git.remote.Remote>` reference
+        """
         return Remote.create(self, name, url, **kwargs)
 
     def delete_remote(self, remote: "Remote") -> str:
@@ -531,8 +569,8 @@ class Repo(object):
     def _get_config_path(self, config_level: Lit_config_levels, git_dir: Optional[PathLike] = None) -> str:
         if git_dir is None:
             git_dir = self.git_dir
-        # we do not support an absolute path of the gitconfig on windows ,
-        # use the global config instead
+        # We do not support an absolute path of the gitconfig on Windows.
+        # Use the global config instead.
         if is_win and config_level == "system":
             config_level = "global"
 
@@ -561,17 +599,20 @@ class Repo(object):
     ) -> GitConfigParser:
         """
         :return:
-            GitConfigParser allowing to read the full git configuration, but not to write it
+            :class:`GitConfigParser <git.config.GitConfigParser>` allowing to read the
+            full git configuration, but not to write it.
 
             The configuration will include values from the system, user and repository
             configuration files.
 
         :param config_level:
-            For possible values, see config_writer method
-            If None, all applicable levels will be used. Specify a level in case
-            you know which file you wish to read to prevent reading multiple files.
-        :note: On windows, system configuration cannot currently be read as the path is
-            unknown, instead the global path will be used."""
+            For possible values, see the :meth:`config_writer` method. If None, all
+            applicable levels will be used. Specify a level in case you know which file
+            you wish to read to prevent reading multiple files.
+
+        :note: On Windows, system configuration cannot currently be read as the path is
+            unknown, instead the global path will be used.
+        """
         return self._config_reader(config_level=config_level)
 
     def _config_reader(
@@ -592,23 +633,26 @@ class Repo(object):
     def config_writer(self, config_level: Lit_config_levels = "repository") -> GitConfigParser:
         """
         :return:
-            GitConfigParser allowing to write values of the specified configuration file level.
-            Config writers should be retrieved, used to change the configuration, and written
-            right away as they will lock the configuration file in question and prevent other's
-            to write it.
+            A :class:`GitConfigParser <git.config.GitConfigParser>` allowing to write
+            values of the specified configuration file level. Config writers should be
+            retrieved, used to change the configuration, and written right away as they
+            will lock the configuration file in question and prevent other's to write
+            it.
 
         :param config_level:
-            One of the following values
-            system = system wide configuration file
-            global = user level configuration file
-            repository = configuration file for this repository only"""
+            One of the following values:
+
+            * ``"system"`` = system wide configuration file
+            * ``"global"`` = user level configuration file
+            * ``"`repository"`` = configuration file for this repository only
+        """
         return GitConfigParser(self._get_config_path(config_level), read_only=False, repo=self, merge_includes=False)
 
     def commit(self, rev: Union[str, Commit_ish, None] = None) -> Commit:
-        """The Commit object for the specified revision
+        """The Commit object for the specified revision.
 
         :param rev: revision specifier, see git-rev-parse for viable options.
-        :return: ``git.Commit``
+        :return: :class:`git.Commit <git.objects.commit.Commit>`
         """
         if rev is None:
             return self.head.commit
@@ -616,22 +660,27 @@ class Repo(object):
 
     def iter_trees(self, *args: Any, **kwargs: Any) -> Iterator["Tree"]:
         """:return: Iterator yielding Tree objects
-        :note: Takes all arguments known to iter_commits method"""
+
+        :note: Accepts all arguments known to the :meth:`iter_commits` method.
+        """
         return (c.tree for c in self.iter_commits(*args, **kwargs))
 
     def tree(self, rev: Union[Tree_ish, str, None] = None) -> "Tree":
-        """The Tree object for the given treeish revision
+        """The Tree object for the given tree-ish revision.
+
         Examples::
 
               repo.tree(repo.heads[0])
 
-        :param rev: is a revision pointing to a Treeish ( being a commit or tree )
+        :param rev: is a revision pointing to a Treeish (being a commit or tree)
+
         :return: ``git.Tree``
 
         :note:
             If you need a non-root level tree, find it by iterating the root tree. Otherwise
             it cannot know about its path relative to the repository root and subsequent
-            operations might have unexpected results."""
+            operations might have unexpected results.
+        """
         if rev is None:
             return self.head.commit.tree
         return self.rev_parse(str(rev) + "^{tree}")
@@ -642,37 +691,40 @@ class Repo(object):
         paths: Union[PathLike, Sequence[PathLike]] = "",
         **kwargs: Any,
     ) -> Iterator[Commit]:
-        """A list of Commit objects representing the history of a given ref/commit
+        """A list of Commit objects representing the history of a given ref/commit.
 
         :param rev:
-            revision specifier, see git-rev-parse for viable options.
+            Revision specifier, see git-rev-parse for viable options.
             If None, the active branch will be used.
 
         :param paths:
-            is an optional path or a list of paths; if set only commits that include the path
-            or paths will be returned
+            An optional path or a list of paths; if set only commits that include the
+            path or paths will be returned
 
         :param kwargs:
-            Arguments to be passed to git-rev-list - common ones are
-            max_count and skip
+            Arguments to be passed to git-rev-list - common ones are max_count and skip.
 
-        :note: to receive only commits between two named revisions, use the
-            "revA...revB" revision specifier
+        :note: To receive only commits between two named revisions, use the
+            ``"revA...revB"`` revision specifier.
 
-        :return: ``git.Commit[]``"""
+        :return: ``git.Commit[]``
+        """
         if rev is None:
             rev = self.head.commit
 
         return Commit.iter_items(self, rev, paths, **kwargs)
 
     def merge_base(self, *rev: TBD, **kwargs: Any) -> List[Union[Commit_ish, None]]:
-        """Find the closest common ancestor for the given revision (e.g. Commits, Tags, References, etc)
+        """Find the closest common ancestor for the given revision (Commits, Tags, References, etc.).
 
         :param rev: At least two revs to find the common ancestor for.
-        :param kwargs: Additional arguments to be passed to the repo.git.merge_base() command which does all the work.
-        :return: A list of Commit objects. If --all was not specified as kwarg, the list will have at max one Commit,
-            or is empty if no common merge base exists.
-        :raises ValueError: If not at least two revs are provided
+        :param kwargs: Additional arguments to be passed to the
+            ``repo.git.merge_base()`` command which does all the work.
+        :return: A list of :class:`Commit <git.objects.commit.Commit>` objects. If
+            ``--all`` was not passed as a keyword argument, the list will have at max
+            one :class:`Commit <git.objects.commit.Commit>`, or is empty if no common
+            merge base exists.
+        :raises ValueError: If not at least two revs are provided.
         """
         if len(rev) < 2:
             raise ValueError("Please specify at least two revs, got only %i" % len(rev))
@@ -697,7 +749,7 @@ class Repo(object):
         return res
 
     def is_ancestor(self, ancestor_rev: "Commit", rev: "Commit") -> bool:
-        """Check if a commit is an ancestor of another
+        """Check if a commit is an ancestor of another.
 
         :param ancestor_rev: Rev which should be an ancestor
         :param rev: Rev to test against ancestor_rev
@@ -754,9 +806,10 @@ class Repo(object):
     del _set_daemon_export
 
     def _get_alternates(self) -> List[str]:
-        """The list of alternates for this repo from which objects can be retrieved
+        """The list of alternates for this repo from which objects can be retrieved.
 
-        :return: list of strings being pathnames of alternates"""
+        :return: List of strings being pathnames of alternates
+        """
         if self.git_dir:
             alternates_path = osp.join(self.git_dir, "objects", "info", "alternates")
 
@@ -767,16 +820,18 @@ class Repo(object):
         return []
 
     def _set_alternates(self, alts: List[str]) -> None:
-        """Sets the alternates
+        """Sets the alternates.
 
         :param alts:
             is the array of string paths representing the alternates at which
             git should look for objects, i.e. /home/user/repo/.git/objects
 
         :raise NoSuchPathError:
+
         :note:
             The method does not check for the existence of the paths in alts
-            as the caller is responsible."""
+            as the caller is responsible.
+        """
         alternates_path = osp.join(self.common_dir, "objects", "info", "alternates")
         if not alts:
             if osp.isfile(alternates_path):
@@ -801,27 +856,28 @@ class Repo(object):
     ) -> bool:
         """
         :return:
-            ``True``, the repository is considered dirty. By default it will react
+            ``True`` if the repository is considered dirty. By default it will react
             like a git-status without untracked files, hence it is dirty if the
-            index or the working copy have changes."""
+            index or the working copy have changes.
+        """
         if self._bare:
             # Bare repositories with no associated working directory are
             # always considered to be clean.
             return False
 
-        # start from the one which is fastest to evaluate
+        # Start from the one which is fastest to evaluate.
         default_args = ["--abbrev=40", "--full-index", "--raw"]
         if not submodules:
             default_args.append("--ignore-submodules")
         if path:
             default_args.extend(["--", str(path)])
         if index:
-            # diff index against HEAD
+            # diff index against HEAD.
             if osp.isfile(self.index.path) and len(self.git.diff("--cached", *default_args)):
                 return True
         # END index handling
         if working_tree:
-            # diff index against working tree
+            # diff index against working tree.
             if len(self.git.diff(*default_args)):
                 return True
         # END working tree handling
@@ -841,14 +897,15 @@ class Repo(object):
             are relative to the current working directory of the git command.
 
         :note:
-            ignored files will not appear here, i.e. files mentioned in .gitignore
+            Ignored files will not appear here, i.e. files mentioned in ``.gitignore``.
         :note:
-            This property is expensive, as no cache is involved. To process the result, please
-            consider caching it yourself."""
+            This property is expensive, as no cache is involved. To process the result,
+            please consider caching it yourself.
+        """
         return self._get_untracked_files()
 
     def _get_untracked_files(self, *args: Any, **kwargs: Any) -> List[str]:
-        # make sure we get all files, not only untracked directories
+        # Make sure we get all files, not only untracked directories.
         proc = self.git.status(*args, porcelain=True, untracked_files=True, as_process=True, **kwargs)
         # Untracked files prefix in porcelain mode
         prefix = "?? "
@@ -868,11 +925,13 @@ class Repo(object):
         return untracked_files
 
     def ignored(self, *paths: PathLike) -> List[str]:
-        """Checks if paths are ignored via .gitignore
-        Doing so using the "git check-ignore" method.
+        """Checks if paths are ignored via .gitignore.
+
+        This does so using the ``git check-ignore`` method.
 
         :param paths: List of paths to check whether they are ignored or not
-        :return: subset of those paths which are ignored
+
+        :return: Subset of those paths which are ignored
         """
         try:
             proc: str = self.git.check_ignore(*paths)
@@ -892,23 +951,25 @@ class Repo(object):
         """The name of the currently active branch.
 
         :raises	TypeError: If HEAD is detached
-        :return: Head to the active branch"""
+        :return: Head to the active branch
+        """
         # reveal_type(self.head.reference)  # => Reference
         return self.head.reference
 
     def blame_incremental(self, rev: str | HEAD, file: str, **kwargs: Any) -> Iterator["BlameEntry"]:
         """Iterator for blame information for the given file at the given revision.
 
-        Unlike .blame(), this does not return the actual file's contents, only
-        a stream of BlameEntry tuples.
+        Unlike :meth:`blame`, this does not return the actual file's contents, only a
+        stream of :class:`BlameEntry` tuples.
 
-        :param rev: revision specifier, see git-rev-parse for viable options.
-        :return: lazy iterator of BlameEntry tuples, where the commit
-                 indicates the commit to blame for the line, and range
-                 indicates a span of line numbers in the resulting file.
+        :param rev: Revision specifier, see git-rev-parse for viable options.
 
-        If you combine all line number ranges outputted by this command, you
-        should get a continuous range spanning all line numbers in the file.
+        :return: Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates
+            the commit to blame for the line, and range indicates a span of line numbers
+            in the resulting file.
+
+        If you combine all line number ranges outputted by this command, you should get
+        a continuous range spanning all line numbers in the file.
         """
 
         data: bytes = self.git.blame(rev, "--", file, p=True, incremental=True, stdout_as_string=False, **kwargs)
@@ -917,7 +978,7 @@ class Repo(object):
         stream = (line for line in data.split(b"\n") if line)
         while True:
             try:
-                line = next(stream)  # when exhausted, causes a StopIteration, terminating this function
+                line = next(stream)  # When exhausted, causes a StopIteration, terminating this function.
             except StopIteration:
                 return
             split_line = line.split()
@@ -927,7 +988,7 @@ class Repo(object):
             orig_lineno = int(orig_lineno_b)
             if hexsha not in commits:
                 # Now read the next few lines and build up a dict of properties
-                # for this commit
+                # for this commit.
                 props: Dict[bytes, bytes] = {}
                 while True:
                     try:
@@ -936,13 +997,13 @@ class Repo(object):
                         return
                     if line == b"boundary":
                         # "boundary" indicates a root commit and occurs
-                        # instead of the "previous" tag
+                        # instead of the "previous" tag.
                         continue
 
                     tag, value = line.split(b" ", 1)
                     props[tag] = value
                     if tag == b"filename":
-                        # "filename" formally terminates the entry for --incremental
+                        # "filename" formally terminates the entry for --incremental.
                         orig_filename = value
                         break
 
@@ -963,10 +1024,10 @@ class Repo(object):
                 commits[hexsha] = c
             else:
                 # Discard all lines until we find "filename" which is
-                # guaranteed to be the last line
+                # guaranteed to be the last line.
                 while True:
                     try:
-                        line = next(stream)  # will fail if we reach the EOF unexpectedly
+                        line = next(stream)  # Will fail if we reach the EOF unexpectedly.
                     except StopIteration:
                         return
                     tag, value = line.split(b" ", 1)
@@ -991,12 +1052,15 @@ class Repo(object):
     ) -> List[List[Commit | List[str | bytes] | None]] | Iterator[BlameEntry] | None:
         """The blame information for the given file at the given revision.
 
-        :param rev: revision specifier, see git-rev-parse for viable options.
+        :param rev: Revision specifier, see git-rev-parse for viable options.
+
         :return:
             list: [git.Commit, list: [<line>]]
+
             A list of lists associating a Commit object with a list of lines that
             changed within the given commit. The Commit objects will be given in order
-            of appearance."""
+            of appearance.
+        """
         if incremental:
             return self.blame_incremental(rev, file, **kwargs)
         rev_opts = rev_opts or []
@@ -1028,9 +1092,9 @@ class Repo(object):
                 is_binary = True
             else:
                 # As we don't have an idea when the binary data ends, as it could contain multiple newlines
-                # in the process. So we rely on being able to decode to tell us what is is.
+                # in the process. So we rely on being able to decode to tell us what it is.
                 # This can absolutely fail even on text files, but even if it does, we should be fine treating it
-                # as binary instead
+                # as binary instead.
                 parts = self.re_whitespace.split(line_str, 1)
                 firstpart = parts[0]
                 is_binary = False
@@ -1133,32 +1197,32 @@ class Repo(object):
         expand_vars: bool = True,
         **kwargs: Any,
     ) -> "Repo":
-        """Initialize a git repository at the given path if specified
+        """Initialize a git repository at the given path if specified.
 
         :param path:
-            is the full path to the repo (traditionally ends with /<name>.git)
-            or None in which case the repository will be created in the current
-            working directory
+            The full path to the repo (traditionally ends with /<name>.git) or None in
+            which case the repository will be created in the current working directory
 
         :param mkdir:
-            if specified will create the repository directory if it doesn't
-            already exists. Creates the directory with a mode=0755.
-            Only effective if a path is explicitly given
+            If specified, will create the repository directory if it doesn't
+            already exist. Creates the directory with a mode=0755.
+            Only effective if a path is explicitly given.
 
         :param odbt:
             Object DataBase type - a type which is constructed by providing
             the directory containing the database objects, i.e. .git/objects.
-            It will be used to access all object data
+            It will be used to access all object data.
 
         :param expand_vars:
-            if specified, environment variables will not be escaped. This
+            If specified, environment variables will not be escaped. This
             can lead to information disclosure, allowing attackers to
-            access the contents of environment variables
+            access the contents of environment variables.
 
         :param kwargs:
-            keyword arguments serving as additional options to the git-init command
+            Keyword arguments serving as additional options to the git-init command.
 
-        :return: ``git.Repo`` (the newly created repo)"""
+        :return: ``git.Repo`` (the newly created repo)
+        """
         if path:
             path = expand_path(path, expand_vars)
         if mkdir and path and not osp.exists(path):
@@ -1184,7 +1248,7 @@ class Repo(object):
     ) -> "Repo":
         odbt = kwargs.pop("odbt", odb_default_type)
 
-        # when pathlib.Path or other classbased path is passed
+        # When pathlib.Path or other classbased path is passed
         if not isinstance(path, str):
             path = str(path)
 
@@ -1236,21 +1300,21 @@ class Repo(object):
             log.debug("Cmd(%s)'s unused stdout: %s", cmdline, stdout)
             finalize_process(proc, stderr=stderr)
 
-        # our git command could have a different working dir than our actual
-        # environment, hence we prepend its working dir if required
+        # Our git command could have a different working dir than our actual
+        # environment, hence we prepend its working dir if required.
         if not osp.isabs(path):
             path = osp.join(git._working_dir, path) if git._working_dir is not None else path
 
         repo = cls(path, odbt=odbt)
 
-        # retain env values that were passed to _clone()
+        # Retain env values that were passed to _clone().
         repo.git.update_environment(**git.environment())
 
-        # adjust remotes - there may be operating systems which use backslashes,
+        # Adjust remotes - there may be operating systems which use backslashes,
         # These might be given as initial paths, but when handling the config file
         # that contains the remote from which we were clones, git stops liking it
         # as it will escape the backslashes. Hence we undo the escaping just to be
-        # sure
+        # sure.
         if repo.remotes:
             with repo.remotes[0].config_writer as writer:
                 writer.set_value("url", Git.polish_url(repo.remotes[0].url))
@@ -1268,20 +1332,22 @@ class Repo(object):
     ) -> "Repo":
         """Create a clone from this repository.
 
-        :param path: is the full path of the new repo (traditionally ends with ./<name>.git).
-        :param progress: See 'git.remote.Remote.push'.
-        :param multi_options: A list of Clone options that can be provided multiple times.  One
-            option per list item which is passed exactly as specified to clone.
-            For example ['--config core.filemode=false', '--config core.ignorecase',
+        :param path: The full path of the new repo (traditionally ends with
+            ``./<name>.git``).
+        :param progress: See :meth:`git.remote.Remote.push`.
+        :param multi_options: A list of Clone options that can be provided multiple times.
+            One option per list item which is passed exactly as specified to clone.
+            For example: ['--config core.filemode=false', '--config core.ignorecase',
             '--recurse-submodule=repo1_path', '--recurse-submodule=repo2_path']
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
+        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
         :param kwargs:
             * odbt = ObjectDatabase Type, allowing to determine the object database
-              implementation used by the returned Repo instance
-            * All remaining keyword arguments are given to the git-clone command
+              implementation used by the returned Repo instance.
+            * All remaining keyword arguments are given to the git-clone command.
 
-        :return: ``git.Repo`` (the newly cloned repo)"""
+        :return: :class:`Repo` (the newly cloned repo)
+        """
         return self._clone(
             self.git,
             self.common_dir,
@@ -1306,22 +1372,32 @@ class Repo(object):
         allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> "Repo":
-        """Create a clone from the given URL
+        """Create a clone from the given URL.
 
-        :param url: valid git url, see http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
-        :param to_path: Path to which the repository should be cloned to
-        :param progress: See 'git.remote.Remote.push'.
+        :param url: Valid git url, see http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
+
+        :param to_path: Path to which the repository should be cloned to.
+
+        :param progress: See :meth:`git.remote.Remote.push`.
+
         :param env: Optional dictionary containing the desired environment variables.
+
             Note: Provided variables will be used to update the execution
             environment for `git`. If some variable is not specified in `env`
             and is defined in `os.environ`, value from `os.environ` will be used.
             If you want to unset some variable, consider providing empty string
             as its value.
-        :param multi_options: See ``clone`` method
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :param kwargs: see the ``clone`` method
-        :return: Repo instance pointing to the cloned directory"""
+
+        :param multi_options: See :meth:`clone` method.
+
+        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+
+        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
+
+        :param kwargs: See the :meth:`clone` method.
+
+        :return: :class:`Repo` instance pointing to the cloned directory.
+        """
         git = cls.GitCommandWrapperType(os.getcwd())
         if env is not None:
             git.update_environment(**env)
@@ -1346,18 +1422,23 @@ class Repo(object):
     ) -> Repo:
         """Archive the tree at the given revision.
 
-        :param ostream: file compatible stream object to which the archive will be written as bytes
-        :param treeish: is the treeish name/id, defaults to active branch
-        :param prefix: is the optional prefix to prepend to each filename in the archive
-        :param kwargs: Additional arguments passed to git-archive
+        :param ostream: file compatible stream object to which the archive will be written as bytes.
+
+        :param treeish: is the treeish name/id, defaults to active branch.
+
+        :param prefix: is the optional prefix to prepend to each filename in the archive.
+
+        :param kwargs: Additional arguments passed to git-archive:
 
             * Use the 'format' argument to define the kind of format. Use
               specialized ostreams to write any format supported by python.
             * You may specify the special **path** keyword, which may either be a repository-relative
               path to a directory or file to place into the archive, or a list or tuple of multiple paths.
 
-        :raise GitCommandError: in case something went wrong
-        :return: self"""
+        :raise GitCommandError: If something went wrong.
+
+        :return: self
+        """
         if treeish is None:
             treeish = self.head.commit
         if prefix and "prefix" not in kwargs:
@@ -1374,7 +1455,8 @@ class Repo(object):
     def has_separate_working_tree(self) -> bool:
         """
         :return: True if our git_dir is not at the root of our working_tree_dir, but a .git file with a
-            platform agnositic symbolic link. Our git_dir will be wherever the .git file points to
+            platform agnositic symbolic link. Our git_dir will be wherever the .git file points to.
+
         :note: bare repositories will always return False here
         """
         if self.bare:
@@ -1382,7 +1464,7 @@ class Repo(object):
         if self.working_tree_dir:
             return osp.isfile(osp.join(self.working_tree_dir, ".git"))
         else:
-            return False  # or raise Error?
+            return False  # Or raise Error?
 
     rev_parse = rev_parse
 
@@ -1394,7 +1476,7 @@ class Repo(object):
         """
         :return: The commit which is currently being replayed while rebasing.
 
-        None if we are not currently rebasing.
+            None if we are not currently rebasing.
         """
         if self.git_dir:
             rebase_head_file = osp.join(self.git_dir, "REBASE_HEAD")

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -387,7 +387,7 @@ class Repo:
     def references(self) -> "IterableList[Reference]":
         """A list of Reference objects representing tags, heads and remote references.
 
-        :return: IterableList(Reference, ...)
+        :return: ``git.IterableList(Reference, ...)``
         """
         return Reference.list_items(self)
 
@@ -400,11 +400,11 @@ class Repo:
     @property
     def index(self) -> "IndexFile":
         """
-        :return: :class:`IndexFile <git.index.base.IndexFile>` representing this
-            repository's index.
+        :return: A :class:`~git.index.base.IndexFile` representing this repository's
+            index.
 
         :note: This property can be expensive, as the returned
-            :class:`IndexFile <git.index.base.IndexFile>` will be reinitialized.
+            :class:`~git.index.base.IndexFile` will be reinitialized.
             It is recommended to reuse the object.
         """
         return IndexFile(self)
@@ -520,7 +520,7 @@ class Repo:
         :note: For more documentation, please see the
             :meth:`Head.create <git.refs.head.Head.create>` method.
 
-        :return: Newly created :class:`Head <git.refs.head.Head>` Reference
+        :return: Newly created :class:`~git.refs.head.Head` Reference
         """
         return Head.create(self, path, commit, logmsg, force)
 
@@ -544,7 +544,7 @@ class Repo:
         :note: For more documentation, please see the
             :meth:`TagReference.create <git.refs.tag.TagReference.create>` method.
 
-        :return: :class:`TagReference <git.refs.tag.TagReference>` object
+        :return: :class:`~git.refs.tag.TagReference` object
         """
         return TagReference.create(self, path, ref, message, force, **kwargs)
 
@@ -558,7 +558,7 @@ class Repo:
         For more information, please see the documentation of the
         :meth:`Remote.create <git.remote.Remote.create>` method.
 
-        :return: :class:`Remote <git.remote.Remote>` reference
+        :return: :class:`~git.remote.Remote` reference
         """
         return Remote.create(self, name, url, **kwargs)
 
@@ -599,8 +599,8 @@ class Repo:
     ) -> GitConfigParser:
         """
         :return:
-            :class:`GitConfigParser <git.config.GitConfigParser>` allowing to read the
-            full git configuration, but not to write it.
+            :class:`~git.config.GitConfigParser` allowing to read the full git
+            configuration, but not to write it.
 
             The configuration will include values from the system, user and repository
             configuration files.
@@ -633,11 +633,10 @@ class Repo:
     def config_writer(self, config_level: Lit_config_levels = "repository") -> GitConfigParser:
         """
         :return:
-            A :class:`GitConfigParser <git.config.GitConfigParser>` allowing to write
-            values of the specified configuration file level. Config writers should be
-            retrieved, used to change the configuration, and written right away as they
-            will lock the configuration file in question and prevent other's to write
-            it.
+            A :class:`~git.config.GitConfigParser` allowing to write values of the
+            specified configuration file level. Config writers should be retrieved, used
+            to change the configuration, and written right away as they will lock the
+            configuration file in question and prevent other's to write it.
 
         :param config_level:
             One of the following values:
@@ -720,10 +719,10 @@ class Repo:
         :param rev: At least two revs to find the common ancestor for.
         :param kwargs: Additional arguments to be passed to the
             ``repo.git.merge_base()`` command which does all the work.
-        :return: A list of :class:`Commit <git.objects.commit.Commit>` objects. If
-            ``--all`` was not passed as a keyword argument, the list will have at max
-            one :class:`Commit <git.objects.commit.Commit>`, or is empty if no common
-            merge base exists.
+        :return: A list of :class:`~git.objects.commit.Commit` objects. If ``--all`` was
+            not passed as a keyword argument, the list will have at max one
+            :class:`~git.objects.commit.Commit`, or is empty if no common merge base
+            exists.
         :raises ValueError: If not at least two revs are provided.
         """
         if len(rev) < 2:

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -131,8 +131,8 @@ class Repo(object):
 
     # precompiled regex
     re_whitespace = re.compile(r"\s+")
-    re_hexsha_only = re.compile("^[0-9A-Fa-f]{40}$")
-    re_hexsha_shortened = re.compile("^[0-9A-Fa-f]{4,40}$")
+    re_hexsha_only = re.compile(r"^[0-9A-Fa-f]{40}$")
+    re_hexsha_shortened = re.compile(r"^[0-9A-Fa-f]{4,40}$")
     re_envvars = re.compile(r"(\$(\{\s?)?[a-zA-Z_]\w*(\}\s?)?|%\s?[a-zA-Z_]\w*\s?%)")
     re_author_committer_start = re.compile(r"^(author|committer)")
     re_tab_full_line = re.compile(r"^\t(.*)$")

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -1,5 +1,7 @@
-"""Package with general repository related functions"""
+"""Module with general repository-related functions."""
+
 from __future__ import annotations
+
 import os
 import stat
 from pathlib import Path

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -118,7 +118,7 @@ def find_submodule_git_dir(d: "PathLike") -> Optional["PathLike"]:
             if not osp.isabs(path):
                 path = osp.normpath(osp.join(osp.dirname(d), path))
             return find_submodule_git_dir(path)
-    # end handle exception
+    # END handle exception
     return None
 
 

--- a/git/types.py
+++ b/git/types.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 # flake8: noqa
 
 import os
@@ -75,9 +76,11 @@ ConfigLevels_Tup = Tuple[Literal["system"], Literal["user"], Literal["global"], 
 
 def assert_never(inp: NoReturn, raise_error: bool = True, exc: Union[Exception, None] = None) -> None:
     """For use in exhaustive checking of literal or Enum in if/else chain.
+
     Should only be reached if all members not handled OR attempt to pass non-members through chain.
 
     If all members handled, type is Empty. Otherwise, will cause mypy error.
+
     If non-members given, should cause mypy error at variable creation.
 
     If raise_error is True, will also raise AssertionError or the Exception passed to exc.

--- a/git/types.py
+++ b/git/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 

--- a/git/util.py
+++ b/git/util.py
@@ -239,7 +239,7 @@ def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 *
 
 
 def join_path(a: PathLike, *p: PathLike) -> PathLike:
-    """Join path tokens together similar to osp.join, but always use
+    R"""Join path tokens together similar to osp.join, but always use
     '/' instead of possibly '\' on windows."""
     path = str(a)
     for b in p:
@@ -277,7 +277,7 @@ else:
 
 
 def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
-    """
+    R"""
     As join path, but makes sure an OS native path is returned. This is only
         needed to play it safe on my dear windows and to assure nice paths that only
         use '\'"""

--- a/git/util.py
+++ b/git/util.py
@@ -668,7 +668,8 @@ class RemoteProgress:
         def handler(line: AnyStr) -> None:
             return self._parse_progress_line(line.rstrip())
 
-        # end
+        # END def handler
+
         return handler
 
     def line_dropped(self, line: str) -> None:

--- a/git/util.py
+++ b/git/util.py
@@ -144,7 +144,7 @@ T = TypeVar("T")
 
 def unbare_repo(func: Callable[..., T]) -> Callable[..., T]:
     """Methods with this decorator raise :class:`.exc.InvalidGitRepositoryError` if they
-    encounter a bare repository"""
+    encounter a bare repository."""
 
     from .exc import InvalidGitRepositoryError
 
@@ -164,8 +164,9 @@ def unbare_repo(func: Callable[..., T]) -> Callable[..., T]:
 def cwd(new_dir: PathLike) -> Generator[PathLike, None, None]:
     """Context manager to temporarily change directory.
 
-    This is similar to contextlib.chdir introduced in Python 3.11, but the context
-    manager object returned by a single call to this function is not reentrant."""
+    This is similar to :func:`contextlib.chdir` introduced in Python 3.11, but the
+    context manager object returned by a single call to this function is not reentrant.
+    """
     old_dir = os.getcwd()
     os.chdir(new_dir)
     try:
@@ -191,8 +192,10 @@ def patch_env(name: str, value: str) -> Generator[None, None, None]:
 def rmtree(path: PathLike) -> None:
     """Remove the given directory tree recursively.
 
-    :note: We use :func:`shutil.rmtree` but adjust its behaviour to see whether files that
-        couldn't be deleted are read-only. Windows will not remove them in that case."""
+    :note: We use :func:`shutil.rmtree` but adjust its behaviour to see whether files
+        that couldn't be deleted are read-only. Windows will not remove them in that
+        case.
+    """
 
     def handler(function: Callable, path: PathLike, _excinfo: Any) -> None:
         """Callback for :func:`shutil.rmtree`. Works either as ``onexc`` or ``onerror``."""
@@ -224,9 +227,10 @@ def rmfile(path: PathLike) -> None:
 
 def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 * 1024) -> int:
     """Copy all data from the source stream into the destination stream in chunks
-    of size chunk_size
+    of size chunk_size.
 
-    :return: amount of bytes written"""
+    :return: Number of bytes written
+    """
     br = 0
     while True:
         chunk = source.read(chunk_size)
@@ -240,7 +244,7 @@ def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 *
 
 def join_path(a: PathLike, *p: PathLike) -> PathLike:
     R"""Join path tokens together similar to osp.join, but always use
-    '/' instead of possibly '\' on windows."""
+    '/' instead of possibly '\' on Windows."""
     path = str(a)
     for b in p:
         b = str(b)
@@ -269,7 +273,7 @@ if is_win:
     __all__.append("to_native_path_windows")
     to_native_path = to_native_path_windows
 else:
-    # no need for any work on linux
+    # No need for any work on Linux.
     def to_native_path_linux(path: PathLike) -> str:
         return str(path)
 
@@ -277,19 +281,22 @@ else:
 
 
 def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
-    R"""
-    As join path, but makes sure an OS native path is returned. This is only
-        needed to play it safe on my dear windows and to assure nice paths that only
-        use '\'"""
+    R"""Like join_path, but makes sure an OS native path is returned.
+
+    This is only needed to play it safe on Windows and to assure nice paths that only
+    use '\'.
+    """
     return to_native_path(join_path(a, *p))
 
 
 def assure_directory_exists(path: PathLike, is_file: bool = False) -> bool:
-    """Assure that the directory pointed to by path exists.
+    """Make sure that the directory pointed to by path exists.
 
-    :param is_file: If True, path is assumed to be a file and handled correctly.
-        Otherwise it must be a directory
-    :return: True if the directory was created, False if it already existed"""
+    :param is_file: If True, ``path`` is assumed to be a file and handled correctly.
+        Otherwise it must be a directory.
+
+    :return: True if the directory was created, False if it already existed.
+    """
     if is_file:
         path = osp.dirname(path)
     # END handle file
@@ -365,9 +372,9 @@ _cygpath_parsers: Tuple[Tuple[Pattern[str], Callable, bool], ...] = (
 
 
 def cygpath(path: str) -> str:
-    """Use :meth:`git.cmd.Git.polish_url()` instead, that works on any environment."""
-    path = str(path)  # ensure is str and not AnyPath.
-    # Fix to use Paths when 3.5 dropped. or to be just str if only for urls?
+    """Use :meth:`git.cmd.Git.polish_url` instead, that works on any environment."""
+    path = str(path)  # Ensure is str and not AnyPath.
+    # Fix to use Paths when 3.5 dropped. Or to be just str if only for URLs?
     if not path.startswith(("/cygdrive", "//", "/proc/cygdrive")):
         for regex, parser, recurse in _cygpath_parsers:
             match = regex.match(path)
@@ -477,11 +484,10 @@ def expand_path(p: Union[None, PathLike], expand_vars: bool = True) -> Optional[
 
 
 def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
-    """
-    Parse any command line argument and if on of the element is an URL with a
+    """Parse any command line argument and if one of the elements is an URL with a
     username and/or password, replace them by stars (in-place).
 
-    If nothing found just returns the command line as-is.
+    If nothing is found, this just returns the command line as-is.
 
     This should be used for every log line that print a command line, as well as
     exception messages.
@@ -491,7 +497,7 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
         new_cmdline.append(to_parse)
         try:
             url = urlsplit(to_parse)
-            # Remove password from the URL if present
+            # Remove password from the URL if present.
             if url.password is None and url.username is None:
                 continue
 
@@ -501,7 +507,7 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
                 url = url._replace(netloc=url.netloc.replace(url.username, "*****"))
             new_cmdline[index] = urlunsplit(url)
         except ValueError:
-            # This is not a valid URL
+            # This is not a valid URL.
             continue
     return new_cmdline
 
@@ -555,14 +561,15 @@ class RemoteProgress(object):
         or git-fetch.
 
         - Lines that do not contain progress info are stored in :attr:`other_lines`.
-        - Lines that seem to contain an error (i.e. start with error: or fatal:) are stored
-            in :attr:`error_lines`."""
+        - Lines that seem to contain an error (i.e. start with ``error:`` or ``fatal:``)
+          are stored in :attr:`error_lines`.
+        """
         # handle
         # Counting objects: 4, done.
         # Compressing objects:  50% (1/2)
         # Compressing objects: 100% (2/2)
         # Compressing objects: 100% (2/2), done.
-        if isinstance(line, bytes):  # mypy argues about ternary assignment
+        if isinstance(line, bytes):  # mypy argues about ternary assignment.
             line_str = line.decode("utf-8")
         else:
             line_str = line
@@ -572,14 +579,14 @@ class RemoteProgress(object):
             self.error_lines.append(self._cur_line)
             return
 
-        # find escape characters and cut them away - regex will not work with
-        # them as they are non-ascii. As git might expect a tty, it will send them
+        # Find escape characters and cut them away - regex will not work with
+        # them as they are non-ASCII. As git might expect a tty, it will send them.
         last_valid_index = None
         for i, c in enumerate(reversed(line_str)):
             if ord(c) < 32:
                 # its a slice index
                 last_valid_index = -i - 1
-            # END character was non-ascii
+            # END character was non-ASCII
         # END for each character in line
         if last_valid_index is not None:
             line_str = line_str[:last_valid_index]
@@ -600,7 +607,7 @@ class RemoteProgress(object):
         op_code = 0
         _remote, op_name, _percent, cur_count, max_count, message = match.groups()
 
-        # get operation id
+        # Get operation ID.
         if op_name == "Counting objects":
             op_code |= self.COUNTING
         elif op_name == "Compressing objects":
@@ -616,7 +623,7 @@ class RemoteProgress(object):
         elif op_name == "Checking out files":
             op_code |= self.CHECKING_OUT
         else:
-            # Note: On windows it can happen that partial lines are sent
+            # Note: On Windows it can happen that partial lines are sent.
             # Hence we get something like "CompreReceiving objects", which is
             # a blend of "Compressing objects" and "Receiving objects".
             # This can't really be prevented, so we drop the line verbosely
@@ -624,11 +631,11 @@ class RemoteProgress(object):
             # commands at some point.
             self.line_dropped(line_str)
             # Note: Don't add this line to the other lines, as we have to silently
-            # drop it
+            # drop it.
             return None
         # END handle op code
 
-        # figure out stage
+        # Figure out stage.
         if op_code not in self._seen_ops:
             self._seen_ops.append(op_code)
             op_code |= self.BEGIN
@@ -655,8 +662,9 @@ class RemoteProgress(object):
     def new_message_handler(self) -> Callable[[str], None]:
         """
         :return:
-            a progress handler suitable for handle_process_output(), passing lines on to this Progress
-            handler in a suitable format"""
+            A progress handler suitable for handle_process_output(), passing lines on to
+            this Progress handler in a suitable format
+        """
 
         def handler(line: AnyStr) -> None:
             return self._parse_progress_line(line.rstrip())
@@ -675,7 +683,7 @@ class RemoteProgress(object):
         max_count: Union[str, float, None] = None,
         message: str = "",
     ) -> None:
-        """Called whenever the progress changes
+        """Called whenever the progress changes.
 
         :param op_code:
             Integer allowing to be compared against Operation IDs and stage IDs.
@@ -683,11 +691,12 @@ class RemoteProgress(object):
             Stage IDs are BEGIN and END. BEGIN will only be set once for each Operation
             ID as well as END. It may be that BEGIN and END are set at once in case only
             one progress message was emitted due to the speed of the operation.
-            Between BEGIN and END, none of these flags will be set
+            Between BEGIN and END, none of these flags will be set.
 
             Operation IDs are all held within the OP_MASK. Only one Operation ID will
             be active per call.
-        :param cur_count: Current absolute count of items
+
+        :param cur_count: Current absolute count of items.
 
         :param max_count:
             The maximum count of items we expect. It may be None in case there is
@@ -697,12 +706,13 @@ class RemoteProgress(object):
             In case of the 'WRITING' operation, it contains the amount of bytes
             transferred. It may possibly be used for other purposes as well.
 
-        You may read the contents of the current line in self._cur_line"""
+        You may read the contents of the current line in ``self._cur_line``.
+        """
         pass
 
 
 class CallableRemoteProgress(RemoteProgress):
-    """An implementation forwarding updates to any callable"""
+    """An implementation forwarding updates to any callable."""
 
     __slots__ = "_callable"
 
@@ -724,7 +734,7 @@ class Actor(object):
     name_email_regex = re.compile(r"(.*) <(.*?)>")
 
     # ENVIRONMENT VARIABLES
-    # read when creating new commits
+    # These are read when creating new commits.
     env_author_name = "GIT_AUTHOR_NAME"
     env_author_email = "GIT_AUTHOR_EMAIL"
     env_committer_name = "GIT_COMMITTER_NAME"
@@ -758,11 +768,13 @@ class Actor(object):
     @classmethod
     def _from_string(cls, string: str) -> "Actor":
         """Create an Actor from a string.
-        :param string: is the string, which is expected to be in regular git format
 
-                John Doe <jdoe@example.com>
+        :param string: The string, which is expected to be in regular git format::
 
-        :return: Actor"""
+            John Doe <jdoe@example.com>
+
+        :return: Actor
+        """
         m = cls.name_email_regex.search(string)
         if m:
             name, email = m.groups()
@@ -771,7 +783,7 @@ class Actor(object):
             m = cls.name_only_regex.search(string)
             if m:
                 return Actor(m.group(1), None)
-            # assume best and use the whole string as name
+            # Assume the best and use the whole string as name.
             return Actor(string, None)
             # END special case name
         # END handle name/email matching
@@ -784,7 +796,7 @@ class Actor(object):
         config_reader: Union[None, "GitConfigParser", "SectionConstraint"] = None,
     ) -> "Actor":
         actor = Actor("", "")
-        user_id = None  # We use this to avoid multiple calls to getpass.getuser()
+        user_id = None  # We use this to avoid multiple calls to getpass.getuser().
 
         def default_email() -> str:
             nonlocal user_id
@@ -822,20 +834,21 @@ class Actor(object):
         :return: Actor instance corresponding to the configured committer. It behaves
             similar to the git implementation, such that the environment will override
             configuration values of config_reader. If no value is set at all, it will be
-            generated
+            generated.
+
         :param config_reader: ConfigReader to use to retrieve the values from in case
-            they are not set in the environment"""
+            they are not set in the environment.
+        """
         return cls._main_actor(cls.env_committer_name, cls.env_committer_email, config_reader)
 
     @classmethod
     def author(cls, config_reader: Union[None, "GitConfigParser", "SectionConstraint"] = None) -> "Actor":
-        """Same as committer(), but defines the main author. It may be specified in the environment,
-        but defaults to the committer"""
+        """Same as committer(), but defines the main author. It may be specified in the
+        environment, but defaults to the committer."""
         return cls._main_actor(cls.env_author_name, cls.env_author_email, config_reader)
 
 
 class Stats(object):
-
     """
     Represents stat information as presented by git at the end of a merge. It is
     created from the output of a diff operation.
@@ -859,7 +872,8 @@ class Stats(object):
 
     In addition to the items in the stat-dict, it features additional information::
 
-     files = number of changed files as int"""
+     files = number of changed files as int
+    """
 
     __slots__ = ("total", "files")
 
@@ -871,7 +885,8 @@ class Stats(object):
     def _list_from_string(cls, repo: "Repo", text: str) -> "Stats":
         """Create a Stat object from output retrieved by git-diff.
 
-        :return: git.Stat"""
+        :return: git.Stat
+        """
 
         hsh: HSH_TD = {
             "total": {"insertions": 0, "deletions": 0, "lines": 0, "files": 0},
@@ -895,14 +910,14 @@ class Stats(object):
 
 
 class IndexFileSHA1Writer(object):
-
     """Wrapper around a file-like object that remembers the SHA1 of
     the data written to it. It will write a sha when the stream is closed
     or if the asked for explicitly using write_sha.
 
-    Only useful to the indexfile
+    Only useful to the index file.
 
-    :note: Based on the dulwich project"""
+    :note: Based on the dulwich project.
+    """
 
     __slots__ = ("f", "sha1")
 
@@ -929,13 +944,13 @@ class IndexFileSHA1Writer(object):
 
 
 class LockFile(object):
-
     """Provides methods to obtain, check for, and release a file based lock which
     should be used to handle concurrent access to the same file.
 
     As we are a utility class to be derived from, we only use protected methods.
 
-    Locks will automatically be released on destruction"""
+    Locks will automatically be released on destruction.
+    """
 
     __slots__ = ("_file_path", "_owns_lock")
 
@@ -951,14 +966,18 @@ class LockFile(object):
         return "%s.lock" % (self._file_path)
 
     def _has_lock(self) -> bool:
-        """:return: True if we have a lock and if the lockfile still exists
-        :raise AssertionError: if our lock-file does not exist"""
+        """
+        :return: True if we have a lock and if the lockfile still exists
+
+        :raise AssertionError: If our lock-file does not exist
+        """
         return self._owns_lock
 
     def _obtain_lock_or_raise(self) -> None:
-        """Create a lock file as flag for other instances, mark our instance as lock-holder
+        """Create a lock file as flag for other instances, mark our instance as lock-holder.
 
-        :raise IOError: if a lock was already present or a lock file could not be written"""
+        :raise IOError: If a lock was already present or a lock file could not be written
+        """
         if self._has_lock():
             return
         lock_file = self._lock_file_path()
@@ -978,15 +997,15 @@ class LockFile(object):
 
     def _obtain_lock(self) -> None:
         """The default implementation will raise if a lock cannot be obtained.
-        Subclasses may override this method to provide a different implementation"""
+        Subclasses may override this method to provide a different implementation."""
         return self._obtain_lock_or_raise()
 
     def _release_lock(self) -> None:
-        """Release our lock if we have one"""
+        """Release our lock if we have one."""
         if not self._has_lock():
             return
 
-        # if someone removed our file beforhand, lets just flag this issue
+        # If someone removed our file beforehand, lets just flag this issue
         # instead of failing, to make it more usable.
         lfp = self._lock_file_path()
         try:
@@ -997,13 +1016,13 @@ class LockFile(object):
 
 
 class BlockingLockFile(LockFile):
-
     """The lock file will block until a lock could be obtained, or fail after
     a specified timeout.
 
     :note: If the directory containing the lock was removed, an exception will
         be raised during the blocking period, preventing hangs as the lock
-        can never be obtained."""
+        can never be obtained.
+    """
 
     __slots__ = ("_check_interval", "_max_block_time")
 
@@ -1013,13 +1032,14 @@ class BlockingLockFile(LockFile):
         check_interval_s: float = 0.3,
         max_block_time_s: int = sys.maxsize,
     ) -> None:
-        """Configure the instance
+        """Configure the instance.
 
         :param check_interval_s:
             Period of time to sleep until the lock is checked the next time.
-            By default, it waits a nearly unlimited time
+            By default, it waits a nearly unlimited time.
 
-        :param max_block_time_s: Maximum amount of seconds we may lock"""
+        :param max_block_time_s: Maximum amount of seconds we may lock.
+        """
         super(BlockingLockFile, self).__init__(file_path)
         self._check_interval = check_interval_s
         self._max_block_time = max_block_time_s
@@ -1027,7 +1047,9 @@ class BlockingLockFile(LockFile):
     def _obtain_lock(self) -> None:
         """This method blocks until it obtained the lock, or raises IOError if
         it ran out of time or if the parent directory was not available anymore.
-        If this method returns, you are guaranteed to own the lock"""
+
+        If this method returns, you are guaranteed to own the lock.
+        """
         starttime = time.time()
         maxtime = starttime + float(self._max_block_time)
         while True:
@@ -1059,7 +1081,6 @@ class BlockingLockFile(LockFile):
 
 
 class IterableList(List[T_IterableObj]):
-
     """
     List of iterable objects allowing to query an object by id or by named index::
 
@@ -1070,13 +1091,14 @@ class IterableList(List[T_IterableObj]):
 
     Iterable parent objects = [Commit, SubModule, Reference, FetchInfo, PushInfo]
     Iterable via inheritance = [Head, TagReference, RemoteReference]
-    ]
+
     It requires an id_attribute name to be set which will be queried from its
     contained items to have a means for comparison.
 
     A prefix can be specified which is to be used in case the id returned by the
     items always contains a prefix that does not matter to the user, so it
-    can be left out."""
+    can be left out.
+    """
 
     __slots__ = ("_id_attr", "_prefix")
 
@@ -1088,7 +1110,7 @@ class IterableList(List[T_IterableObj]):
         self._prefix = prefix
 
     def __contains__(self, attr: object) -> bool:
-        # first try identity match for performance
+        # First try identity match for performance.
         try:
             rval = list.__contains__(self, attr)
             if rval:
@@ -1097,9 +1119,9 @@ class IterableList(List[T_IterableObj]):
             pass
         # END handle match
 
-        # otherwise make a full name search
+        # Otherwise make a full name search.
         try:
-            getattr(self, cast(str, attr))  # use cast to silence mypy
+            getattr(self, cast(str, attr))  # Use cast to silence mypy.
             return True
         except (AttributeError, TypeError):
             return False
@@ -1148,7 +1170,7 @@ class IterableList(List[T_IterableObj]):
 
 
 class IterableClassWatcher(type):
-    """Metaclass that watches"""
+    """Metaclass that watches."""
 
     def __init__(cls, name: str, bases: Tuple, clsdict: Dict) -> None:
         for base in bases:
@@ -1164,24 +1186,26 @@ class IterableClassWatcher(type):
 
 
 class Iterable(metaclass=IterableClassWatcher):
-
     """Defines an interface for iterable items which is to assure a uniform
-    way to retrieve and iterate items within the git repository"""
+    way to retrieve and iterate items within the git repository."""
 
     __slots__ = ()
+
     _id_attribute_ = "attribute that most suitably identifies your instance"
 
     @classmethod
     def list_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> Any:
         """
         Deprecated, use IterableObj instead.
+
         Find all items of this type - subclasses can specify args and kwargs differently.
         If no args are given, subclasses are obliged to return all items if no additional
         arguments arg given.
 
         :note: Favor the iter_items method as it will
 
-        :return: list(Item,...) list of item instances"""
+        :return: list(Item,...) list of item instances
+        """
         out_list: Any = IterableList(cls._id_attribute_)
         out_list.extend(cls.iter_items(repo, *args, **kwargs))
         return out_list
@@ -1189,19 +1213,23 @@ class Iterable(metaclass=IterableClassWatcher):
     @classmethod
     def iter_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> Any:
         # return typed to be compatible with subtypes e.g. Remote
-        """For more information about the arguments, see list_items
-        :return:  iterator yielding Items"""
+        """For more information about the arguments, see list_items.
+
+        :return: Iterator yielding Items
+        """
         raise NotImplementedError("To be implemented by Subclass")
 
 
 @runtime_checkable
 class IterableObj(Protocol):
     """Defines an interface for iterable items which is to assure a uniform
-    way to retrieve and iterate items within the git repository
+    way to retrieve and iterate items within the git repository.
 
-    Subclasses = [Submodule, Commit, Reference, PushInfo, FetchInfo, Remote]"""
+    Subclasses = [Submodule, Commit, Reference, PushInfo, FetchInfo, Remote]
+    """
 
     __slots__ = ()
+
     _id_attribute_: str
 
     @classmethod
@@ -1213,7 +1241,8 @@ class IterableObj(Protocol):
 
         :note: Favor the iter_items method as it will
 
-        :return: list(Item,...) list of item instances"""
+        :return: list(Item,...) list of item instances
+        """
         out_list: IterableList = IterableList(cls._id_attribute_)
         out_list.extend(cls.iter_items(repo, *args, **kwargs))
         return out_list
@@ -1221,9 +1250,11 @@ class IterableObj(Protocol):
     @classmethod
     @abstractmethod
     def iter_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> Iterator[T_IterableObj]:  # Iterator[T_IterableObj]:
-        # return typed to be compatible with subtypes e.g. Remote
-        """For more information about the arguments, see list_items
-        :return:  iterator yielding Items"""
+        # Return-typed to be compatible with subtypes e.g. Remote.
+        """For more information about the arguments, see list_items.
+
+        :return: Iterator yielding Items
+        """
         raise NotImplementedError("To be implemented by Subclass")
 
 

--- a/git/util.py
+++ b/git/util.py
@@ -713,7 +713,7 @@ class RemoteProgress:
 class CallableRemoteProgress(RemoteProgress):
     """An implementation forwarding updates to any callable."""
 
-    __slots__ = "_callable"
+    __slots__ = ("_callable",)
 
     def __init__(self, fn: Callable) -> None:
         self._callable = fn

--- a/git/util.py
+++ b/git/util.py
@@ -419,8 +419,7 @@ def is_cygwin_git(git_executable: PathLike) -> bool:
 
 def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
     if is_win:
-        # is_win seems to be true only for Windows-native pythons
-        # cygwin has os.name = posix, I think
+        # is_win is only True on native Windows systems. On Cygwin, os.name == "posix".
         return False
 
     if git_executable is None:

--- a/git/util.py
+++ b/git/util.py
@@ -1,4 +1,4 @@
-# utils.py
+# util.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/git/util.py
+++ b/git/util.py
@@ -516,7 +516,7 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
 # { Classes
 
 
-class RemoteProgress(object):
+class RemoteProgress:
     """
     Handler providing an interface to parse progress information emitted by git-push
     and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
@@ -723,7 +723,7 @@ class CallableRemoteProgress(RemoteProgress):
         self._callable(*args, **kwargs)
 
 
-class Actor(object):
+class Actor:
     """Actors hold information about a person acting on the repository. They
     can be committers and authors or anything with a name and an email as
     mentioned in the git log entries."""
@@ -847,7 +847,7 @@ class Actor(object):
         return cls._main_actor(cls.env_author_name, cls.env_author_email, config_reader)
 
 
-class Stats(object):
+class Stats:
     """
     Represents stat information as presented by git at the end of a merge. It is
     created from the output of a diff operation.
@@ -908,7 +908,7 @@ class Stats(object):
         return Stats(hsh["total"], hsh["files"])
 
 
-class IndexFileSHA1Writer(object):
+class IndexFileSHA1Writer:
     """Wrapper around a file-like object that remembers the SHA1 of
     the data written to it. It will write a sha when the stream is closed
     or if the asked for explicitly using write_sha.
@@ -942,7 +942,7 @@ class IndexFileSHA1Writer(object):
         return self.f.tell()
 
 
-class LockFile(object):
+class LockFile:
     """Provides methods to obtain, check for, and release a file based lock which
     should be used to handle concurrent access to the same file.
 

--- a/git/util.py
+++ b/git/util.py
@@ -283,7 +283,7 @@ else:
 def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
     R"""Like join_path, but makes sure an OS native path is returned.
 
-    This is only needed to play it safe on Windows and to assure nice paths that only
+    This is only needed to play it safe on Windows and to ensure nice paths that only
     use '\'.
     """
     return to_native_path(join_path(a, *p))
@@ -1185,8 +1185,8 @@ class IterableClassWatcher(type):
 
 
 class Iterable(metaclass=IterableClassWatcher):
-    """Defines an interface for iterable items which is to assure a uniform
-    way to retrieve and iterate items within the git repository."""
+    """Defines an interface for iterable items, so there is a uniform way to retrieve
+    and iterate items within the git repository."""
 
     __slots__ = ()
 
@@ -1221,8 +1221,8 @@ class Iterable(metaclass=IterableClassWatcher):
 
 @runtime_checkable
 class IterableObj(Protocol):
-    """Defines an interface for iterable items which is to assure a uniform
-    way to retrieve and iterate items within the git repository.
+    """Defines an interface for iterable items, so there is a uniform way to retrieve
+    and iterate items within the git repository.
 
     Subclasses = [Submodule, Commit, Reference, PushInfo, FetchInfo, Remote]
     """

--- a/git/util.py
+++ b/git/util.py
@@ -668,7 +668,7 @@ class RemoteProgress:
         def handler(line: AnyStr) -> None:
             return self._parse_progress_line(line.rstrip())
 
-        # END def handler
+        # END handler
 
         return handler
 

--- a/test/fixtures/env_case.py
+++ b/test/fixtures/env_case.py
@@ -1,4 +1,4 @@
-# Steps 3 and 4 for test_it_avoids_upcasing_unrelated_environment_variable_names.
+"""Steps 3 and 4 for test_it_avoids_upcasing_unrelated_environment_variable_names."""
 
 import subprocess
 import sys

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -65,7 +65,7 @@ def fixture(name):
 # { Adapters
 
 
-class StringProcessAdapter(object):
+class StringProcessAdapter:
     """Allows strings to be used as process objects returned by subprocess.Popen.
 
     This is tailored to work with the test system only.

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -213,14 +213,6 @@ def git_daemon_launched(base_path, ip, port):
           and setting the environment variable GIT_PYTHON_TEST_GIT_DAEMON_PORT to <port>
         """
         )
-        if is_win:
-            msg += textwrap.dedent(
-                R"""
-
-            On Windows,
-              the `git-daemon.exe` must be in PATH.
-              For MINGW, look into \Git\mingw64\libexec\git-core\, but problems with paths might appear."""
-            )
         log.warning(msg, ex, ip, port, base_path, base_path, exc_info=1)
 
         yield  # OK, assume daemon started manually.

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -3,6 +3,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import contextlib
 from functools import wraps
 import gc
@@ -65,9 +66,10 @@ def fixture(name):
 
 
 class StringProcessAdapter(object):
+    """Allows strings to be used as process objects returned by subprocess.Popen.
 
-    """Allows to use strings as Process object as returned by SubProcess.Popen.
-    Its tailored to work with the test system only"""
+    This is tailored to work with the test system only.
+    """
 
     def __init__(self, input_string):
         self.stdout = io.BytesIO(input_string)
@@ -86,7 +88,7 @@ class StringProcessAdapter(object):
 
 def with_rw_directory(func):
     """Create a temporary directory which can be written to, remove it if the
-    test succeeds, but leave it otherwise to aid additional debugging"""
+    test succeeds, but leave it otherwise to aid additional debugging."""
 
     @wraps(func)
     def wrapper(self):
@@ -106,7 +108,7 @@ def with_rw_directory(func):
             raise
         finally:
             # Need to collect here to be sure all handles have been closed. It appears
-            # a windows-only issue. In fact things should be deleted, as well as
+            # a Windows-only issue. In fact things should be deleted, as well as
             # memory maps closed, once objects go out of scope. For some reason
             # though this is not the case here unless we collect explicitly.
             gc.collect()
@@ -117,8 +119,7 @@ def with_rw_directory(func):
 
 
 def with_rw_repo(working_tree_ref, bare=False):
-    """
-    Same as with_bare_repo, but clones the rorepo as non-bare repository, checking
+    """Same as with_bare_repo, but clones the rorepo as non-bare repository, checking
     out the working tree at the given working_tree_ref.
 
     This repository type is more costly due to the working copy checkout.
@@ -199,7 +200,7 @@ def git_daemon_launched(base_path, ip, port):
                 base_path=base_path,
                 as_process=True,
             )
-        # yes, I know ... fortunately, this is always going to work if sleep time is just large enough
+        # Yes, I know... fortunately, this is always going to work if sleep time is just large enough.
         time.sleep(0.5 * (1 + is_win))
     except Exception as ex:
         msg = textwrap.dedent(
@@ -225,33 +226,36 @@ def git_daemon_launched(base_path, ip, port):
                 log.debug("Killing git-daemon...")
                 gd.proc.kill()
             except Exception as ex:
-                ## Either it has died (and we're here), or it won't die, again here...
+                # Either it has died (and we're here), or it won't die, again here...
                 log.debug("Hidden error while Killing git-daemon: %s", ex, exc_info=1)
 
 
 def with_rw_and_rw_remote_repo(working_tree_ref):
-    """
-    Same as with_rw_repo, but also provides a writable remote repository from which the
-    rw_repo has been forked as well as a handle for a git-daemon that may be started to
-    run the remote_repo.
-    The remote repository was cloned as bare repository from the ro repo, whereas
-    the rw repo has a working tree and was cloned from the remote repository.
+    """Same as with_rw_repo, but also provides a writable remote repository from which
+    the rw_repo has been forked as well as a handle for a git-daemon that may be started
+    to run the remote_repo.
 
-    remote_repo has two remotes: origin and daemon_origin. One uses a local url,
-    the other uses a server url. The daemon setup must be done on system level
-    and should be an inetd service that serves tempdir.gettempdir() and all
-    directories in it.
+    The remote repository was cloned as bare repository from the ro repo, whereas the rw
+    repo has a working tree and was cloned from the remote repository.
+
+    remote_repo has two remotes: origin and daemon_origin. One uses a local url, the
+    other uses a server url. The daemon setup must be done on system level and should be
+    an inetd service that serves tempdir.gettempdir() and all directories in it.
 
     The following sketch demonstrates this::
-     rorepo ---<bare clone>---> rw_remote_repo ---<clone>---> rw_repo
+
+        rorepo ---<bare clone>---> rw_remote_repo ---<clone>---> rw_repo
 
     The test case needs to support the following signature::
+
         def case(self, rw_repo, rw_daemon_repo)
 
     This setup allows you to test push and pull scenarios and hooks nicely.
 
-    See working dir info in with_rw_repo
-    :note: We attempt to launch our own invocation of git-daemon, which will be shutdown at the end of the test.
+    See working dir info in :func:`with_rw_repo`.
+
+    :note: We attempt to launch our own invocation of git-daemon, which will be shut
+        down at the end of the test.
     """
     from git import Git, Remote  # To avoid circular deps.
 
@@ -264,16 +268,16 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
             rw_repo_dir = tempfile.mktemp(prefix="daemon_cloned_repo-%s-" % func.__name__)
 
             rw_daemon_repo = self.rorepo.clone(rw_daemon_repo_dir, shared=True, bare=True)
-            # recursive alternates info ?
+            # Recursive alternates info?
             rw_repo = rw_daemon_repo.clone(rw_repo_dir, shared=True, bare=False, n=True)
             try:
                 rw_repo.head.commit = working_tree_ref
                 rw_repo.head.reference.checkout()
 
-                # prepare for git-daemon
+                # Prepare for git-daemon.
                 rw_daemon_repo.daemon_export = True
 
-                # this thing is just annoying !
+                # This thing is just annoying!
                 with rw_daemon_repo.config_writer() as crw:
                     section = "daemon"
                     try:
@@ -340,9 +344,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
 
 
 class TestBase(TestCase):
-
-    """
-    Base Class providing default functionality to all tests such as:
+    """Base class providing default functionality to all tests such as:
 
     - Utility functions provided by the TestCase base of the unittest method such as::
         self.fail("todo")
@@ -355,20 +357,20 @@ class TestBase(TestCase):
 
       The rorepo is in fact your current project's git repo. If you refer to specific
       shas for your objects, be sure you choose some that are part of the immutable portion
-      of the project history ( to assure tests don't fail for others ).
+      of the project history (so that tests don't fail for others).
     """
 
     def _small_repo_url(self):
-        """:return" a path to a small, clonable repository"""
+        """:return: A path to a small, clonable repository"""
         from git.cmd import Git
 
         return Git.polish_url(osp.join(self.rorepo.working_tree_dir, "git/ext/gitdb/gitdb/ext/smmap"))
 
     @classmethod
     def setUpClass(cls):
-        """
-        Dynamically add a read-only repository to our actual type. This way
-        each test type has its own repository
+        """Dynamically add a read-only repository to our actual type.
+
+        This way, each test type has its own repository.
         """
         from git import Repo
 
@@ -383,7 +385,9 @@ class TestBase(TestCase):
     def _make_file(self, rela_path, data, repo=None):
         """
         Create a file at the given path relative to our repository, filled
-        with the given data. Returns absolute path to created file.
+        with the given data.
+
+        :return: An absolute path to the created file.
         """
         repo = repo or self.rorepo
         abs_path = osp.join(repo.working_tree_dir, rela_path)

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -45,7 +45,7 @@ class TestBigRepoR(TestBase):
                 k_env_git_repo,
             )
             repo_path = osp.dirname(__file__)
-        # end set some repo path
+        # END set some repo path
         self.gitrorepo = Repo(repo_path, odbt=GitCmdObjectDB, search_parent_directories=True)
         self.puregitrorepo = Repo(repo_path, odbt=GitDB, search_parent_directories=True)
 

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -45,8 +45,9 @@ class TestBigRepoR(TestBase):
         repo_path = os.environ.get(k_env_git_repo)
         if repo_path is None:
             logging.info(
-                ("You can set the %s environment variable to a .git repository of" % k_env_git_repo)
-                + "your choice - defaulting to the gitpython repository"
+                "You can set the %s environment variable to a .git repository of your"
+                " choice - defaulting to the GitPython repository",
+                k_env_git_repo,
             )
             repo_path = osp.dirname(__file__)
         # end set some repo path

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -1,4 +1,5 @@
-"""Contains library functions"""
+"""Support library for tests."""
+
 import logging
 import os
 import tempfile
@@ -20,21 +21,15 @@ k_env_git_repo = "GIT_PYTHON_TEST_GIT_REPO_BASE"
 
 
 class TestBigRepoR(TestBase):
-
     """TestCase providing access to readonly 'big' repositories using the following
     member variables:
 
-    * gitrorepo
+    * gitrorepo:
+      Read-Only git repository - actually (by default) the repo of GitPython itself.
 
-     * Read-Only git repository - actually the repo of git itself
-
-    * puregitrorepo
-
-     * As gitrepo, but uses pure python implementation
+    * puregitrorepo:
+      Like gitrorepo, but uses a pure Python implementation for its object database.
     """
-
-    # { Invariants
-    # } END invariants
 
     def setUp(self):
         try:
@@ -62,10 +57,10 @@ class TestBigRepoR(TestBase):
 
 
 class TestBigRepoRW(TestBigRepoR):
+    """Like :class:`TestBigRepoR`, but provides a big repository that we can write to.
 
-    """As above, but provides a big repository that we can write to.
-
-    Provides ``self.gitrwrepo`` and ``self.puregitrwrepo``"""
+    Provides ``self.gitrwrepo`` and ``self.puregitrwrepo``.
+    """
 
     def setUp(self):
         self.gitrwrepo = None

--- a/test/performance/test_commit.py
+++ b/test/performance/test_commit.py
@@ -1,8 +1,10 @@
-# test_performance.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
+"""Performance tests for commits (iteration, traversal, and serialization)."""
+
 from io import BytesIO
 from time import time
 import sys
@@ -19,7 +21,7 @@ class TestPerformance(TestBigRepoRW, TestCommitSerialization):
 
         gc.collect()
 
-    # ref with about 100 commits in its history
+    # ref with about 100 commits in its history.
     ref_100 = "0.1.6"
 
     def _query_commit_info(self, c):
@@ -36,9 +38,9 @@ class TestPerformance(TestBigRepoRW, TestCommitSerialization):
         no = 0
         nc = 0
 
-        # find the first commit containing the given path - always do a full
-        # iteration ( restricted to the path in question ), but in fact it should
-        # return quite a lot of commits, we just take one and hence abort the operation
+        # Find the first commit containing the given path. Always do a full iteration
+        # (restricted to the path in question). This should return quite a lot of
+        # commits. We just take one and hence abort the operation.
 
         st = time()
         for c in self.rorepo.iter_commits(self.ref_100):
@@ -57,7 +59,7 @@ class TestPerformance(TestBigRepoRW, TestCommitSerialization):
         )
 
     def test_commit_traversal(self):
-        # bound to cat-file parsing performance
+        # Bound to cat-file parsing performance.
         nc = 0
         st = time()
         for c in self.gitrorepo.commit().traverse(branch_first=False):
@@ -71,7 +73,7 @@ class TestPerformance(TestBigRepoRW, TestCommitSerialization):
         )
 
     def test_commit_iteration(self):
-        # bound to stream parsing performance
+        # Bound to stream parsing performance.
         nc = 0
         st = time()
         for c in Commit.iter_items(self.gitrorepo, self.gitrorepo.head):
@@ -89,8 +91,8 @@ class TestPerformance(TestBigRepoRW, TestCommitSerialization):
 
         rwrepo = self.gitrwrepo
         make_object = rwrepo.odb.store
-        # direct serialization - deserialization can be tested afterwards
-        # serialization is probably limited on IO
+        # Direct serialization - deserialization can be tested afterwards.
+        # Serialization is probably limited on IO.
         hc = rwrepo.commit(rwrepo.head)
 
         nc = 5000

--- a/test/performance/test_odb.py
+++ b/test/performance/test_odb.py
@@ -1,4 +1,5 @@
-"""Performance tests for object store"""
+"""Performance tests for object store."""
+
 import sys
 from time import time
 
@@ -24,7 +25,7 @@ class TestObjDBPerformance(TestBigRepoR):
             results[0].append(elapsed)
 
             # GET TREES
-            # walk all trees of all commits
+            # Walk all trees of all commits.
             st = time()
             blobs_per_commit = []
             nt = 0
@@ -35,7 +36,7 @@ class TestObjDBPerformance(TestBigRepoR):
                     nt += 1
                     if item.type == "blob":
                         blobs.append(item)
-                    # direct access for speed
+                    # Direct access for speed.
                 # END while trees are there for walking
                 blobs_per_commit.append(blobs)
             # END for each commit
@@ -75,7 +76,7 @@ class TestObjDBPerformance(TestBigRepoR):
             results[2].append(elapsed)
         # END for each repo type
 
-        # final results
+        # Final results.
         for test_name, a, b in results:
             print(
                 "%s: %f s vs %f s, pure is %f times slower" % (test_name, a, b, b / a),

--- a/test/performance/test_streams.py
+++ b/test/performance/test_streams.py
@@ -1,4 +1,5 @@
-"""Performance data streaming performance"""
+"""Performance tests for data streaming."""
+
 import os
 import subprocess
 import sys
@@ -15,13 +16,13 @@ from .lib import TestBigRepoR
 
 
 class TestObjDBPerformance(TestBigRepoR):
-    large_data_size_bytes = 1000 * 1000 * 10  # some MiB should do it
-    moderate_data_size_bytes = 1000 * 1000 * 1  # just 1 MiB
+    large_data_size_bytes = 1000 * 1000 * 10  # Some MiB should do it.
+    moderate_data_size_bytes = 1000 * 1000 * 1  # Just 1 MiB.
 
     @with_rw_repo("HEAD", bare=True)
     def test_large_data_streaming(self, rwrepo):
-        # TODO: This part overlaps with the same file in gitdb.test.performance.test_stream
-        # It should be shared if possible
+        # TODO: This part overlaps with the same file in gitdb.test.performance.test_stream.
+        # It should be shared if possible.
         ldb = LooseObjectDB(osp.join(rwrepo.git_dir, "objects"))
 
         for randomize in range(2):
@@ -32,7 +33,7 @@ class TestObjDBPerformance(TestBigRepoR):
             elapsed = time() - st
             print("Done (in %f s)" % elapsed, file=sys.stderr)
 
-            # writing - due to the compression it will seem faster than it is
+            # Writing - due to the compression it will seem faster than it is.
             st = time()
             binsha = ldb.store(IStream("blob", size, stream)).binsha
             elapsed_add = time() - st
@@ -45,7 +46,7 @@ class TestObjDBPerformance(TestBigRepoR):
             msg %= (size_kib, fsize_kib, desc, elapsed_add, size_kib / elapsed_add)
             print(msg, file=sys.stderr)
 
-            # reading all at once
+            # Reading all at once.
             st = time()
             ostream = ldb.stream(binsha)
             shadata = ostream.read()
@@ -57,7 +58,7 @@ class TestObjDBPerformance(TestBigRepoR):
             msg %= (size_kib, desc, elapsed_readall, size_kib / elapsed_readall)
             print(msg, file=sys.stderr)
 
-            # reading in chunks of 1 MiB
+            # Reading in chunks of 1 MiB.
             cs = 512 * 1000
             chunks = []
             st = time()
@@ -86,7 +87,7 @@ class TestObjDBPerformance(TestBigRepoR):
                 file=sys.stderr,
             )
 
-            # del db file so git has something to do
+            # del db file so git has something to do.
             ostream = None
             import gc
 
@@ -95,11 +96,11 @@ class TestObjDBPerformance(TestBigRepoR):
 
             # VS. CGIT
             ##########
-            # CGIT ! Can using the cgit programs be faster ?
+            # CGIT! Can using the cgit programs be faster?
             proc = rwrepo.git.hash_object("-w", "--stdin", as_process=True, istream=subprocess.PIPE)
 
-            # write file - pump everything in at once to be a fast as possible
-            data = stream.getvalue()  # cache it
+            # Write file - pump everything in at once to be a fast as possible.
+            data = stream.getvalue()  # Cache it.
             st = time()
             proc.stdin.write(data)
             proc.stdin.close()
@@ -107,22 +108,22 @@ class TestObjDBPerformance(TestBigRepoR):
             proc.wait()
             gelapsed_add = time() - st
             del data
-            assert gitsha == bin_to_hex(binsha)  # we do it the same way, right ?
+            assert gitsha == bin_to_hex(binsha)  # We do it the same way, right?
 
-            #  as its the same sha, we reuse our path
+            # As it's the same sha, we reuse our path.
             fsize_kib = osp.getsize(db_file) / 1000
             msg = "Added %i KiB (filesize = %i KiB) of %s data to using git-hash-object in %f s ( %f Write KiB / s)"
             msg %= (size_kib, fsize_kib, desc, gelapsed_add, size_kib / gelapsed_add)
             print(msg, file=sys.stderr)
 
-            # compare ...
+            # Compare.
             print(
                 "Git-Python is %f %% faster than git when adding big %s files"
                 % (100.0 - (elapsed_add / gelapsed_add) * 100, desc),
                 file=sys.stderr,
             )
 
-            # read all
+            # Read all.
             st = time()
             _hexsha, _typename, size, data = rwrepo.git.get_object_data(gitsha)
             gelapsed_readall = time() - st
@@ -132,14 +133,14 @@ class TestObjDBPerformance(TestBigRepoR):
                 file=sys.stderr,
             )
 
-            # compare
+            # Compare.
             print(
                 "Git-Python is %f %% faster than git when reading big %sfiles"
                 % (100.0 - (elapsed_readall / gelapsed_readall) * 100, desc),
                 file=sys.stderr,
             )
 
-            # read chunks
+            # Read chunks.
             st = time()
             _hexsha, _typename, size, stream = rwrepo.git.stream_object_data(gitsha)
             while True:
@@ -158,7 +159,7 @@ class TestObjDBPerformance(TestBigRepoR):
             )
             print(msg, file=sys.stderr)
 
-            # compare
+            # Compare.
             print(
                 "Git-Python is %f %% faster than git when reading big %s files in chunks"
                 % (100.0 - (elapsed_readchunks / gelapsed_readchunks) * 100, desc),

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -14,7 +14,7 @@ class TestActor(TestBase):
         self.assertEqual("Michael Trier", a.name)
         self.assertEqual("mtrier@example.com", a.email)
 
-        # base type capabilities
+        # Base type capabilities
         assert a == a
         assert not (a != a)
         m = set()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -142,5 +142,5 @@ class TestBase(_TestBase):
         else:
             # On POSIX, we can just add Unicode files without problems.
             rw_repo.git.add(rw_repo.working_dir)
-        # end
+
         rw_repo.index.commit("message")

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import os
 import sys
 import tempfile
@@ -34,7 +35,7 @@ class TestBase(_TestBase):
     )
 
     def test_base_object(self):
-        # test interface of base object classes
+        # Test interface of base object classes.
         types = (Blob, Tree, Commit, TagObject)
         self.assertEqual(len(types), len(self.type_tuples))
 
@@ -61,12 +62,12 @@ class TestBase(_TestBase):
 
             if isinstance(item, base.IndexObject):
                 num_index_objs += 1
-                if hasattr(item, "path"):  # never runs here
-                    assert not item.path.startswith("/")  # must be relative
+                if hasattr(item, "path"):  # Never runs here.
+                    assert not item.path.startswith("/")  # Must be relative.
                     assert isinstance(item.mode, int)
             # END index object check
 
-            # read from stream
+            # Read from stream.
             data_stream = item.data_stream
             data = data_stream.read()
             assert data
@@ -79,7 +80,7 @@ class TestBase(_TestBase):
             os.remove(tmpfilename)
         # END for each object type to create
 
-        # each has a unique sha
+        # Each has a unique sha.
         self.assertEqual(len(s), num_objs)
         self.assertEqual(len(s | s), num_objs)
         self.assertEqual(num_index_objs, 2)
@@ -92,7 +93,7 @@ class TestBase(_TestBase):
         self.assertRaises(ValueError, get_object_type_by_name, b"doesntexist")
 
     def test_object_resolution(self):
-        # objects must be resolved to shas so they compare equal
+        # Objects must be resolved to shas so they compare equal.
         self.assertEqual(self.rorepo.head.reference.object, self.rorepo.active_branch.object)
 
     @with_rw_repo("HEAD", bare=True)
@@ -122,7 +123,7 @@ class TestBase(_TestBase):
 
         file_path = osp.join(rw_repo.working_dir, filename)
 
-        # verify first that we could encode file name in this environment
+        # Verify first that we could encode file name in this environment.
         try:
             file_path.encode(sys.getfilesystemencoding())
         except UnicodeEncodeError as e:
@@ -132,14 +133,14 @@ class TestBase(_TestBase):
             fp.write(b"something")
 
         if is_win:
-            # on windows, there is no way this works, see images on
+            # On Windows, there is no way this works, see images on:
             # https://github.com/gitpython-developers/GitPython/issues/147#issuecomment-68881897
-            # Therefore, it must be added using the python implementation
+            # Therefore, it must be added using the Python implementation.
             rw_repo.index.add([file_path])
             # However, when the test winds down, rmtree fails to delete this file, which is recognized
             # as ??? only.
         else:
-            # on posix, we can just add unicode files without problems
+            # On POSIX, we can just add Unicode files without problems.
             rw_repo.git.add(rw_repo.working_dir)
         # end
         rw_repo.index.commit("message")

--- a/test/test_blob_filter.py
+++ b/test/test_blob_filter.py
@@ -1,4 +1,5 @@
 """Test the blob filter."""
+
 from pathlib import Path
 from typing import Sequence, Tuple
 from unittest.mock import MagicMock

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -21,7 +21,7 @@ class TestClone(TestBase):
         garbage_file.write_text("Garbage!")
 
         # Verify that cloning into the non-empty dir fails while complaining about
-        # the target directory not being empty/non-existent
+        # the target directory not being empty/non-existent.
         try:
             self.rorepo.clone(non_empty_dir)
         except git.GitCommandError as exc:

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import copy
 from datetime import datetime
 from io import BytesIO
@@ -28,18 +29,20 @@ import os.path as osp
 
 class TestCommitSerialization(TestBase):
     def assert_commit_serialization(self, rwrepo, commit_id, print_performance_info=False):
-        """traverse all commits in the history of commit identified by commit_id and check
+        """Traverse all commits in the history of commit identified by commit_id and check
         if the serialization works.
-        :param print_performance_info: if True, we will show how fast we are"""
-        ns = 0  # num serializations
-        nds = 0  # num deserializations
+
+        :param print_performance_info: If True, we will show how fast we are.
+        """
+        ns = 0  # Number of serializations.
+        nds = 0  # Number of deserializations.
 
         st = time.time()
         for cm in rwrepo.commit(commit_id).traverse():
             nds += 1
 
-            # assert that we deserialize commits correctly, hence we get the same
-            # sha on serialization
+            # Assert that we deserialize commits correctly, hence we get the same
+            # sha on serialization.
             stream = BytesIO()
             cm._serialize(stream)
             ns += 1
@@ -71,13 +74,13 @@ class TestCommitSerialization(TestBase):
             streamlen = stream.tell()
             stream.seek(0)
 
-            # reuse istream
+            # Reuse istream.
             istream.size = streamlen
             istream.stream = stream
             istream.binsha = None
             nc.binsha = rwrepo.odb.store(istream).binsha
 
-            # if it worked, we have exactly the same contents !
+            # If it worked, we have exactly the same contents!
             self.assertEqual(nc.hexsha, cm.hexsha)
         # END check commits
         elapsed = time.time() - st
@@ -94,7 +97,7 @@ class TestCommitSerialization(TestBase):
 class TestCommit(TestCommitSerialization):
     def test_bake(self):
         commit = self.rorepo.commit("2454ae89983a4496a445ce347d7a41c0bb0ea7ae")
-        # commits have no dict
+        # Commits have no dict.
         self.assertRaises(AttributeError, setattr, commit, "someattr", 1)
         commit.author  # bake
 
@@ -148,7 +151,7 @@ class TestCommit(TestCommitSerialization):
             check_entries(d)
         # END for each stated file
 
-        # assure data is parsed properly
+        # Check that data is parsed properly.
         michael = Actor._from_string("Michael Trier <mtrier@gmail.com>")
         self.assertEqual(commit.author, michael)
         self.assertEqual(commit.committer, michael)
@@ -162,9 +165,9 @@ class TestCommit(TestCommitSerialization):
         commit = self.rorepo.commit("185d847ec7647fd2642a82d9205fb3d07ea71715")
         files = commit.stats.files
 
-        # when a file is renamed, the output of git diff is like "dir/{old => new}"
-        # unless we disable rename with --no-renames, which produces two lines
-        # one with the old path deletes and another with the new added
+        # When a file is renamed, the output of git diff is like "dir/{old => new}"
+        # unless we disable rename with --no-renames, which produces two lines,
+        # one with the old path deletes and another with the new added.
         self.assertEqual(len(files), 2)
 
         def check_entries(path, changes):
@@ -190,7 +193,7 @@ class TestCommit(TestCommitSerialization):
         # END for each stated file
 
     def test_unicode_actor(self):
-        # assure we can parse unicode actors correctly
+        # Check that we can parse Unicode actors correctly.
         name = "Üäöß ÄußÉ"
         self.assertEqual(len(name), 9)
         special = Actor._from_string("%s <something@this.com>" % name)
@@ -205,7 +208,7 @@ class TestCommit(TestCommitSerialization):
         p00 = p0.parents[0]
         p10 = p1.parents[0]
 
-        # basic branch first, depth first
+        # Basic branch first, depth first.
         dfirst = start.traverse(branch_first=False)
         bfirst = start.traverse(branch_first=True)
         self.assertEqual(next(dfirst), p0)
@@ -216,7 +219,7 @@ class TestCommit(TestCommitSerialization):
         self.assertEqual(next(bfirst), p00)
         self.assertEqual(next(bfirst), p10)
 
-        # at some point, both iterations should stop
+        # At some point, both iterations should stop.
         self.assertEqual(list(bfirst)[-1], first)
 
         stoptraverse = self.rorepo.commit("254d04aa3180eb8b8daf7b7ff25f010cd69b4e7d").traverse(
@@ -235,40 +238,39 @@ class TestCommit(TestCommitSerialization):
         stoptraverse = self.rorepo.commit("254d04aa3180eb8b8daf7b7ff25f010cd69b4e7d").traverse(as_edge=True)
         self.assertEqual(len(next(stoptraverse)), 2)
 
-        # ignore self
+        # Ignore self
         self.assertEqual(next(start.traverse(ignore_self=False)), start)
 
-        # depth
+        # Depth
         self.assertEqual(len(list(start.traverse(ignore_self=False, depth=0))), 1)
 
-        # prune
+        # Prune
         self.assertEqual(next(start.traverse(branch_first=1, prune=lambda i, d: i == p0)), p1)
 
-        # predicate
+        # Predicate
         self.assertEqual(next(start.traverse(branch_first=1, predicate=lambda i, d: i == p1)), p1)
 
-        # traversal should stop when the beginning is reached
+        # Traversal should stop when the beginning is reached.
         self.assertRaises(StopIteration, next, first.traverse())
 
-        # parents of the first commit should be empty ( as the only parent has a null
-        # sha )
+        # Parents of the first commit should be empty (as the only parent has a null sha)
         self.assertEqual(len(first.parents), 0)
 
     def test_iteration(self):
-        # we can iterate commits
+        # We can iterate commits.
         all_commits = Commit.list_items(self.rorepo, self.rorepo.head)
         assert all_commits
         self.assertEqual(all_commits, list(self.rorepo.iter_commits()))
 
-        # this includes merge commits
+        # This includes merge commits.
         mcomit = self.rorepo.commit("d884adc80c80300b4cc05321494713904ef1df2d")
         assert mcomit in all_commits
 
-        # we can limit the result to paths
+        # We can limit the result to paths.
         ltd_commits = list(self.rorepo.iter_commits(paths="CHANGES"))
         assert ltd_commits and len(ltd_commits) < len(all_commits)
 
-        # show commits of multiple paths, resulting in a union of commits
+        # Show commits of multiple paths, resulting in a union of commits.
         less_ltd_commits = list(Commit.iter_items(self.rorepo, "master", paths=("CHANGES", "AUTHORS")))
         assert len(ltd_commits) < len(less_ltd_commits)
 
@@ -280,7 +282,7 @@ class TestCommit(TestCommitSerialization):
         assert type(child_commits[0]) is Child
 
     def test_iter_items(self):
-        # pretty not allowed
+        # pretty not allowed.
         self.assertRaises(ValueError, Commit.iter_items, self.rorepo, "master", pretty="raw")
 
     def test_rev_list_bisect_all(self):
@@ -311,14 +313,14 @@ class TestCommit(TestCommitSerialization):
         touch(path)
         rw_repo.index.add([path])
         rw_repo.index.commit("initial commit")
-        list(rw_repo.iter_commits(rw_repo.head.ref))  # should fail unless bug is fixed
+        list(rw_repo.iter_commits(rw_repo.head.ref))  # Should fail unless bug is fixed.
 
     def test_count(self):
         self.assertEqual(self.rorepo.tag("refs/tags/0.1.5").commit.count(), 143)
 
     def test_list(self):
         # This doesn't work anymore, as we will either attempt getattr with bytes, or compare 20 byte string
-        # with actual 20 byte bytes. This usage makes no sense anyway
+        # with actual 20 byte bytes. This usage makes no sense anyway.
         assert isinstance(
             Commit.list_items(self.rorepo, "0.1.5", max_count=5)["5117c9c8a4d3af19a9958677e45cda9269de1541"],
             Commit,
@@ -340,7 +342,7 @@ class TestCommit(TestCommitSerialization):
         self.assertNotEqual(commit2, commit3)
 
     def test_iter_parents(self):
-        # should return all but ourselves, even if skip is defined
+        # Should return all but ourselves, even if skip is defined.
         c = self.rorepo.commit("0.1.5")
         for skip in (0, 1):
             piter = c.iter_parents(skip=skip)
@@ -355,17 +357,17 @@ class TestCommit(TestCommitSerialization):
 
     @with_rw_repo("HEAD", bare=True)
     def test_serialization(self, rwrepo):
-        # create all commits of our repo
+        # Create all commits of our repo.
         self.assert_commit_serialization(rwrepo, "0.1.6")
 
     def test_serialization_unicode_support(self):
         self.assertEqual(Commit.default_encoding.lower(), "utf-8")
 
-        # create a commit with unicode in the message, and the author's name
-        # Verify its serialization and deserialization
+        # Create a commit with Unicode in the message, and the author's name.
+        # Verify its serialization and deserialization.
         cmt = self.rorepo.commit("0.1.6")
-        assert isinstance(cmt.message, str)  # it automatically decodes it as such
-        assert isinstance(cmt.author.name, str)  # same here
+        assert isinstance(cmt.message, str)  # It automatically decodes it as such.
+        assert isinstance(cmt.author.name, str)  # Same here.
 
         cmt.message = "üäêèß"
         self.assertEqual(len(cmt.message), 5)
@@ -383,8 +385,8 @@ class TestCommit(TestCommitSerialization):
 
         self.assertEqual(cmt.author.name, ncmt.author.name)
         self.assertEqual(cmt.message, ncmt.message)
-        # actually, it can't be printed in a shell as repr wants to have ascii only
-        # it appears
+        # Actually, it can't be printed in a shell as repr wants to have ascii only
+        # it appears.
         cmt.author.__repr__()
 
     def test_invalid_commit(self):
@@ -498,14 +500,14 @@ JzJMZDRLQLFvnzqZuCjE
         KEY_2 = "Key"
         VALUE_2 = "Value with inner spaces"
 
-        # Check the following trailer example is extracted from multiple msg variations
+        # Check that the following trailer example is extracted from multiple msg variations.
         TRAILER = f"{KEY_1}: {VALUE_1_1}\n{KEY_2}: {VALUE_2}\n{KEY_1}: {VALUE_1_2}"
         msgs = [
             f"Subject\n\n{TRAILER}\n",
             f"Subject\n  \nSome body of a function\n \n{TRAILER}\n",
             f"Subject\n  \nSome body of a function\n\nnon-key: non-value\n\n{TRAILER}\n",
             (
-                # check when trailer has inconsistent whitespace
+                # Check when trailer has inconsistent whitespace.
                 f"Subject\n  \nSome multiline\n body of a function\n\nnon-key: non-value\n\n"
                 f"{KEY_1}:{VALUE_1_1}\n{KEY_2} :      {VALUE_2}\n{KEY_1}:    {VALUE_1_2}\n"
             ),
@@ -523,7 +525,7 @@ JzJMZDRLQLFvnzqZuCjE
                 KEY_2: [VALUE_2],
             }
 
-        # check that trailer stays empty for multiple msg combinations
+        # Check that the trailer stays empty for multiple msg combinations.
         msgs = [
             "Subject\n",
             "Subject\n\nBody with some\nText\n",
@@ -539,7 +541,7 @@ JzJMZDRLQLFvnzqZuCjE
             assert commit.trailers_list == []
             assert commit.trailers_dict == {}
 
-        # check that only the last key value paragraph is evaluated
+        # Check that only the last key value paragraph is evaluated.
         commit = copy.copy(self.rorepo.commit("master"))
         commit.message = f"Subject\n\nMultiline\nBody\n\n{KEY_1}: {VALUE_1_1}\n\n{KEY_2}: {VALUE_2}\n"
         assert commit.trailers_list == [(KEY_2, VALUE_2)]

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_commit.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -50,25 +50,25 @@ class TestBase(TestCase):
         for filename in ("git_config", "git_config_global"):
             file_obj = self._to_memcache(fixture_path(filename))
             with GitConfigParser(file_obj, read_only=False) as w_config:
-                w_config.read()  # enforce reading
+                w_config.read()  # Enforce reading.
                 assert w_config._sections
-                w_config.write()  # enforce writing
+                w_config.write()  # Enforce writing.
 
-                # we stripped lines when reading, so the results differ
+                # We stripped lines when reading, so the results differ.
                 assert file_obj.getvalue()
                 self.assertEqual(
                     file_obj.getvalue(),
                     self._to_memcache(fixture_path(filename)).getvalue(),
                 )
 
-                # creating an additional config writer must fail due to exclusive access
+                # Creating an additional config writer must fail due to exclusive access.
                 with self.assertRaises(IOError):
                     GitConfigParser(file_obj, read_only=False)
 
-                # should still have a lock and be able to make changes
+                # Should still have a lock and be able to make changes.
                 assert w_config._lock._has_lock()
 
-                # changes should be written right away
+                # Changes should be written right away.
                 sname = "my_section"
                 oname = "mykey"
                 val = "myvalue"
@@ -93,11 +93,11 @@ class TestBase(TestCase):
 
     def test_includes_order(self):
         with GitConfigParser(list(map(fixture_path, ("git_config", "git_config_global")))) as r_config:
-            r_config.read()  # enforce reading
-            # Simple inclusions, again checking them taking precedence
+            r_config.read()  # Enforce reading.
+            # Simple inclusions, again checking them taking precedence.
             assert r_config.get_value("sec", "var0") == "value0_included"
             # This one should take the git_config_global value since included
-            # values must be considered as soon as they get them
+            # values must be considered as soon as they get them.
             assert r_config.get_value("diff", "tool") == "meld"
             try:
                 # FIXME: Split this assertion out somehow and mark it xfail (or fix it).
@@ -111,16 +111,16 @@ class TestBase(TestCase):
         gcp = GitConfigParser(fpl, read_only=False)
         with gcp as cw:
             cw.set_value("include", "some_value", "a")
-        # entering again locks the file again...
+        # Entering again locks the file again...
         with gcp as cw:
             cw.set_value("include", "some_other_value", "b")
-            # ...so creating an additional config writer must fail due to exclusive access
+            # ...so creating an additional config writer must fail due to exclusive access.
             with self.assertRaises(IOError):
                 GitConfigParser(fpl, read_only=False)
         # but work when the lock is removed
         with GitConfigParser(fpl, read_only=False):
             assert osp.exists(fpl)
-            # reentering with an existing lock must fail due to exclusive access
+            # Reentering with an existing lock must fail due to exclusive access.
             with self.assertRaises(IOError):
                 gcp.__enter__()
 
@@ -152,7 +152,7 @@ class TestBase(TestCase):
         num_sections = 0
         num_options = 0
 
-        # test reader methods
+        # Test reader methods.
         assert r_config._is_initialized is False
         for section in r_config.sections():
             num_sections += 1
@@ -165,7 +165,7 @@ class TestBase(TestCase):
                 assert "\n" not in option
                 assert "\n" not in val
 
-                # writing must fail
+                # Writing must fail.
                 with self.assertRaises(IOError):
                     r_config.set(section, option, None)
                 with self.assertRaises(IOError):
@@ -177,11 +177,11 @@ class TestBase(TestCase):
         assert num_sections and num_options
         assert r_config._is_initialized is True
 
-        # get value which doesn't exist, with default
+        # Get value which doesn't exist, with default.
         default = "my default value"
         assert r_config.get_value("doesnt", "exist", default) == default
 
-        # it raises if there is no default though
+        # It raises if there is no default though.
         with self.assertRaises(cp.NoSectionError):
             r_config.get_value("doesnt", "exist")
 
@@ -228,7 +228,7 @@ class TestBase(TestCase):
             # end for each test to verify
             assert len(cr.items("include")) == 8, "Expected all include sections to be merged"
 
-        # test writable config writers - assure write-back doesn't involve includes
+        # Test writable config writers - assure write-back doesn't involve includes.
         with GitConfigParser(fpa, read_only=False, merge_includes=True) as cw:
             tv = "x"
             write_test_value(cw, tv)
@@ -237,7 +237,7 @@ class TestBase(TestCase):
             with self.assertRaises(cp.NoSectionError):
                 check_test_value(cr, tv)
 
-        # But can make it skip includes altogether, and thus allow write-backs
+        # But can make it skip includes altogether, and thus allow write-backs.
         with GitConfigParser(fpa, read_only=False, merge_includes=False) as cw:
             write_test_value(cw, tv)
 
@@ -246,11 +246,11 @@ class TestBase(TestCase):
 
     @with_rw_directory
     def test_conditional_includes_from_git_dir(self, rw_dir):
-        # Initiate repository path
+        # Initiate repository path.
         git_dir = osp.join(rw_dir, "target1", "repo1")
         os.makedirs(git_dir)
 
-        # Initiate mocked repository
+        # Initiate mocked repository.
         repo = mock.Mock(git_dir=git_dir)
 
         # Initiate config files.
@@ -313,11 +313,11 @@ class TestBase(TestCase):
 
     @with_rw_directory
     def test_conditional_includes_from_branch_name(self, rw_dir):
-        # Initiate mocked branch
+        # Initiate mocked branch.
         branch = mock.Mock()
         type(branch).name = mock.PropertyMock(return_value="/foo/branch")
 
-        # Initiate mocked repository
+        # Initiate mocked repository.
         repo = mock.Mock(active_branch=branch)
 
         # Initiate config files.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -190,12 +190,8 @@ class TestBase(TestCase):
         def write_test_value(cw, value):
             cw.set_value(value, "value", value)
 
-        # end
-
         def check_test_value(cr, value):
             assert cr.get_value(value, "value") == value
-
-        # end
 
         # PREPARE CONFIG FILE A
         fpa = osp.join(rw_dir, "a")
@@ -225,7 +221,7 @@ class TestBase(TestCase):
         with GitConfigParser(fpa, read_only=True) as cr:
             for tv in ("a", "b", "c"):
                 check_test_value(cr, tv)
-            # end for each test to verify
+            # END for each test to verify
             assert len(cr.items("include")) == 8, "Expected all include sections to be merged"
 
         # Test writable config writers - assure write-back doesn't involve includes.

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -3,6 +3,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 from git.db import GitCmdObjectDB
 from git.exc import BadObject
 from test.lib import TestBase
@@ -15,12 +16,12 @@ class TestDB(TestBase):
     def test_base(self):
         gdb = GitCmdObjectDB(osp.join(self.rorepo.git_dir, "objects"), self.rorepo.git)
 
-        # partial to complete - works with everything
+        # Partial to complete - works with everything.
         hexsha = bin_to_hex(gdb.partial_to_complete_sha_hex("0.1.6"))
         assert len(hexsha) == 40
 
         assert bin_to_hex(gdb.partial_to_complete_sha_hex(hexsha[:20])) == hexsha
 
-        # fails with BadObject
+        # Fails with BadObject.
         for invalid_rev in ("0000", "bad/ref", "super bad"):
             self.assertRaises(BadObject, gdb.partial_to_complete_sha_hex, invalid_rev)

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,4 +1,4 @@
-# test_repo.py
+# test_db.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import ddt
 import shutil
 import tempfile
@@ -44,7 +45,7 @@ class TestDiff(TestBase):
         shutil.rmtree(self.submodule_dir)
 
     def _assert_diff_format(self, diffs):
-        # verify that the format of the diff is sane
+        # Verify that the format of the diff is sane.
         for diff in diffs:
             if diff.a_mode:
                 assert isinstance(diff.a_mode, int)
@@ -60,7 +61,7 @@ class TestDiff(TestBase):
 
     @with_rw_directory
     def test_diff_with_staged_file(self, rw_dir):
-        # SETUP INDEX WITH MULTIPLE STAGES
+        # SET UP INDEX WITH MULTIPLE STAGES
         r = Repo.init(rw_dir)
         fp = osp.join(rw_dir, "hello.txt")
         with open(fp, "w") as fs:
@@ -88,11 +89,11 @@ class TestDiff(TestBase):
             fs.write("Hallo Welt")
         r.git.commit(all=True, message="change on topic branch")
 
-        # there must be a merge-conflict
+        # There must be a merge conflict.
         with self.assertRaises(GitCommandError):
             r.git.cherry_pick("master")
 
-        # Now do the actual testing - this should just work
+        # Now do the actual testing - this should just work.
         self.assertEqual(len(r.index.diff(None)), 2)
 
         self.assertEqual(
@@ -255,7 +256,7 @@ class TestDiff(TestBase):
         self.assertIsNotNone(diff_index[0].new_file)
         self.assertEqual(diff_index[0].diff, "")
 
-        # ...and with creating a patch
+        # ...and with creating a patch.
         diff_index = initial_commit.diff(NULL_TREE, create_patch=True)
         self.assertIsNone(diff_index[0].a_path, repr(diff_index[0].a_path))
         self.assertEqual(diff_index[0].b_path, "CHANGES", repr(diff_index[0].b_path))
@@ -292,8 +293,8 @@ class TestDiff(TestBase):
         self.assertEqual(res[13].b_path, 'b/"with even more quotes"')
 
     def test_diff_patch_format(self):
-        # test all of the 'old' format diffs for completeness - it should at least
-        # be able to deal with it
+        # Test all of the 'old' format diffs for completeness - it should at least
+        # be able to deal with it.
         fixtures = (
             "diff_2",
             "diff_2f",
@@ -321,14 +322,14 @@ class TestDiff(TestBase):
 
     def test_diff_submodule(self):
         """Test that diff is able to correctly diff commits that cover submodule changes"""
-        # Init a temp git repo that will be referenced as a submodule
+        # Init a temp git repo that will be referenced as a submodule.
         sub = Repo.init(self.submodule_dir)
         with open(self.submodule_dir + "/subfile", "w") as sub_subfile:
             sub_subfile.write("")
         sub.index.add(["subfile"])
         sub.index.commit("first commit")
 
-        # Init a temp git repo that will incorporate the submodule
+        # Init a temp git repo that will incorporate the submodule.
         repo = Repo.init(self.repo_dir)
         with open(self.repo_dir + "/test", "w") as foo_test:
             foo_test.write("")
@@ -337,7 +338,7 @@ class TestDiff(TestBase):
         repo.index.commit("first commit")
         repo.create_tag("1")
 
-        # Add a commit to the submodule
+        # Add a commit to the submodule.
         submodule = repo.submodule("subtest")
         with open(self.repo_dir + "/sub/subfile", "w") as foo_sub_subfile:
             foo_sub_subfile.write("blub")
@@ -345,19 +346,19 @@ class TestDiff(TestBase):
         submodule.module().index.commit("changed subfile")
         submodule.binsha = submodule.module().head.commit.binsha
 
-        # Commit submodule updates in parent repo
+        # Commit submodule updates in parent repo.
         repo.index.add([submodule])
         repo.index.commit("submodule changed")
         repo.create_tag("2")
 
         diff = repo.commit("1").diff(repo.commit("2"))[0]
         # If diff is unable to find the commit hashes (looks in wrong repo) the *_blob.size
-        # property will be a string containing exception text, an int indicates success
+        # property will be a string containing exception text, an int indicates success.
         self.assertIsInstance(diff.a_blob.size, int)
         self.assertIsInstance(diff.b_blob.size, int)
 
     def test_diff_interface(self):
-        # test a few variations of the main diff routine
+        # Test a few variations of the main diff routine.
         assertion_map = {}
         for i, commit in enumerate(self.rorepo.iter_commits("0.1.6", max_count=2)):
             diff_item = commit
@@ -379,7 +380,7 @@ class TestDiff(TestBase):
                                 assertion_map[key] = assertion_map[key] + len(list(diff_index.iter_change_type(ct)))
                             # END for each changetype
 
-                            # check entries
+                            # Check entries.
                             diff_set = set()
                             diff_set.add(diff_index[0])
                             diff_set.add(diff_index[0])
@@ -398,14 +399,14 @@ class TestDiff(TestBase):
             # END for each other side
         # END for each commit
 
-        # assert we could always find at least one instance of the members we
+        # Assert that we could always find at least one instance of the members we
         # can iterate in the diff index - if not this indicates its not working correctly
-        # or our test does not span the whole range of possibilities
+        # or our test does not span the whole range of possibilities.
         for key, value in assertion_map.items():
             self.assertIsNotNone(value, "Did not find diff for %s" % key)
         # END for each iteration type
 
-        # test path not existing in the index - should be ignored
+        # Test path not existing in the index - should be ignored.
         c = self.rorepo.head.commit
         cp = c.parents[0]
         diff_index = c.diff(cp, ["does/not/exist"])
@@ -415,7 +416,7 @@ class TestDiff(TestBase):
     def test_rename_override(self, rw_dir):
         """Test disabling of diff rename detection"""
 
-        # create and commit file_a.txt
+        # Create and commit file_a.txt.
         repo = Repo.init(rw_dir)
         file_a = osp.join(rw_dir, "file_a.txt")
         with open(file_a, "w", encoding="utf-8") as outfile:
@@ -423,10 +424,10 @@ class TestDiff(TestBase):
         repo.git.add(Git.polish_url(file_a))
         repo.git.commit(message="Added file_a.txt")
 
-        # remove file_a.txt
+        # Remove file_a.txt.
         repo.git.rm(Git.polish_url(file_a))
 
-        # create and commit file_b.txt with similarity index of 52
+        # Create and commit file_b.txt with similarity index of 52.
         file_b = osp.join(rw_dir, "file_b.txt")
         with open(file_b, "w", encoding="utf-8") as outfile:
             outfile.write("hello world\nhello world")
@@ -436,7 +437,7 @@ class TestDiff(TestBase):
         commit_a = repo.commit("HEAD")
         commit_b = repo.commit("HEAD~1")
 
-        # check default diff command with renamed files enabled
+        # Check default diff command with renamed files enabled.
         diffs = commit_b.diff(commit_a)
         self.assertEqual(1, len(diffs))
         diff = diffs[0]
@@ -444,35 +445,35 @@ class TestDiff(TestBase):
         self.assertEqual("file_a.txt", diff.rename_from)
         self.assertEqual("file_b.txt", diff.rename_to)
 
-        # check diff with rename files disabled
+        # Check diff with rename files disabled.
         diffs = commit_b.diff(commit_a, no_renames=True)
         self.assertEqual(2, len(diffs))
 
-        # check fileA.txt deleted
+        # Check fileA.txt deleted.
         diff = diffs[0]
         self.assertEqual(True, diff.deleted_file)
         self.assertEqual("file_a.txt", diff.a_path)
 
-        # check fileB.txt added
+        # Check fileB.txt added.
         diff = diffs[1]
         self.assertEqual(True, diff.new_file)
         self.assertEqual("file_b.txt", diff.a_path)
 
-        # check diff with high similarity index
+        # Check diff with high similarity index.
         diffs = commit_b.diff(commit_a, split_single_char_options=False, M="75%")
         self.assertEqual(2, len(diffs))
 
-        # check fileA.txt deleted
+        # Check fileA.txt deleted.
         diff = diffs[0]
         self.assertEqual(True, diff.deleted_file)
         self.assertEqual("file_a.txt", diff.a_path)
 
-        # check fileB.txt added
+        # Check fileB.txt added.
         diff = diffs[1]
         self.assertEqual(True, diff.new_file)
         self.assertEqual("file_b.txt", diff.a_path)
 
-        # check diff with low similarity index
+        # Check diff with low similarity index.
         diffs = commit_b.diff(commit_a, split_single_char_options=False, M="40%")
         self.assertEqual(1, len(diffs))
         diff = diffs[0]

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # test_diff.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -223,7 +223,7 @@ class TestDiff(TestBase):
         for dr in res:
             self.assertTrue(dr.diff.startswith(b"@@"), dr)
             self.assertIsNotNone(str(dr), "Diff to string conversion should be possible")
-        # end for each diff
+        # END for each diff
 
         dr = res[3]
         assert dr.diff.endswith(b"+Binary files a/rps and b/rps differ\n")

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import os
 import sys
 
@@ -34,7 +35,7 @@ class Tutorials(TestBase):
 
         # rorepo is a Repo instance pointing to the git-python repository.
         # For all you know, the first argument to Repo is a path to the repository
-        # you want to work with
+        # you want to work with.
         repo = Repo(self.rorepo.working_tree_dir)
         assert not repo.bare
         # ![1-test_init_repo_object]
@@ -45,20 +46,20 @@ class Tutorials(TestBase):
         # ![2-test_init_repo_object]
 
         # [3-test_init_repo_object]
-        repo.config_reader()  # get a config reader for read-only access
-        with repo.config_writer():  # get a config writer to change configuration
-            pass  # call release() to be sure changes are written and locks are released
+        repo.config_reader()  # Get a config reader for read-only access.
+        with repo.config_writer():  # Get a config writer to change configuration.
+            pass  # Call release() to be sure changes are written and locks are released.
         # ![3-test_init_repo_object]
 
         # [4-test_init_repo_object]
-        assert not bare_repo.is_dirty()  # check the dirty state
-        repo.untracked_files  # retrieve a list of untracked files
+        assert not bare_repo.is_dirty()  # Check the dirty state.
+        repo.untracked_files  # Retrieve a list of untracked files.
         # ['my_untracked_file']
         # ![4-test_init_repo_object]
 
         # [5-test_init_repo_object]
         cloned_repo = repo.clone(os.path.join(rw_dir, "to/this/path"))
-        assert cloned_repo.__class__ is Repo  # clone an existing repository
+        assert cloned_repo.__class__ is Repo  # Clone an existing repository.
         assert Repo.init(os.path.join(rw_dir, "path/for/new/repo")).__class__ is Repo
         # ![5-test_init_repo_object]
 
@@ -69,9 +70,9 @@ class Tutorials(TestBase):
 
         # repository paths
         # [7-test_init_repo_object]
-        assert os.path.isdir(cloned_repo.working_tree_dir)  # directory with your work files
-        assert cloned_repo.git_dir.startswith(cloned_repo.working_tree_dir)  # directory containing the git repository
-        assert bare_repo.working_tree_dir is None  # bare repositories have no working tree
+        assert os.path.isdir(cloned_repo.working_tree_dir)  # Directory with your work files.
+        assert cloned_repo.git_dir.startswith(cloned_repo.working_tree_dir)  # Directory containing the git repository.
+        assert bare_repo.working_tree_dir is None  # Bare repositories have no working tree.
         # ![7-test_init_repo_object]
 
         # heads, tags and references
@@ -79,59 +80,59 @@ class Tutorials(TestBase):
         # [8-test_init_repo_object]
         self.assertEqual(
             repo.head.ref,
-            repo.heads.master,  # head is a sym-ref pointing to master
+            repo.heads.master,  # head is a sym-ref pointing to master.
             "It's ok if TC not running from `master`.",
         )
-        self.assertEqual(repo.tags["0.3.5"], repo.tag("refs/tags/0.3.5"))  # you can access tags in various ways too
-        self.assertEqual(repo.refs.master, repo.heads["master"])  # .refs provides all refs, ie heads ...
+        self.assertEqual(repo.tags["0.3.5"], repo.tag("refs/tags/0.3.5"))  # You can access tags in various ways too.
+        self.assertEqual(repo.refs.master, repo.heads["master"])  # .refs provides all refs, i.e. heads...
 
         if "TRAVIS" not in os.environ:
             self.assertEqual(repo.refs["origin/master"], repo.remotes.origin.refs.master)  # ... remotes ...
-        self.assertEqual(repo.refs["0.3.5"], repo.tags["0.3.5"])  # ... and tags
+        self.assertEqual(repo.refs["0.3.5"], repo.tags["0.3.5"])  # ... and tags.
         # ![8-test_init_repo_object]
 
-        # create a new head/branch
+        # Create a new head/branch.
         # [9-test_init_repo_object]
-        new_branch = cloned_repo.create_head("feature")  # create a new branch ...
+        new_branch = cloned_repo.create_head("feature")  # Create a new branch ...
         assert cloned_repo.active_branch != new_branch  # which wasn't checked out yet ...
-        self.assertEqual(new_branch.commit, cloned_repo.active_branch.commit)  # pointing to the checked-out commit
-        # It's easy to let a branch point to the previous commit, without affecting anything else
-        # Each reference provides access to the git object it points to, usually commits
+        self.assertEqual(new_branch.commit, cloned_repo.active_branch.commit)  # pointing to the checked-out commit.
+        # It's easy to let a branch point to the previous commit, without affecting anything else.
+        # Each reference provides access to the git object it points to, usually commits.
         assert new_branch.set_commit("HEAD~1").commit == cloned_repo.active_branch.commit.parents[0]
         # ![9-test_init_repo_object]
 
-        # create a new tag reference
+        # Create a new tag reference.
         # [10-test_init_repo_object]
         past = cloned_repo.create_tag(
             "past",
             ref=new_branch,
             message="This is a tag-object pointing to %s" % new_branch.name,
         )
-        self.assertEqual(past.commit, new_branch.commit)  # the tag points to the specified commit
-        assert past.tag.message.startswith("This is")  # and its object carries the message provided
+        self.assertEqual(past.commit, new_branch.commit)  # The tag points to the specified commit
+        assert past.tag.message.startswith("This is")  # and its object carries the message provided.
 
-        now = cloned_repo.create_tag("now")  # This is a tag-reference. It may not carry meta-data
+        now = cloned_repo.create_tag("now")  # This is a tag-reference. It may not carry meta-data.
         assert now.tag is None
         # ![10-test_init_repo_object]
 
         # Object handling
         # [11-test_init_repo_object]
         assert now.commit.message != past.commit.message
-        # You can read objects directly through binary streams, no working tree required
+        # You can read objects directly through binary streams, no working tree required.
         assert (now.commit.tree / "VERSION").data_stream.read().decode("ascii").startswith("3")
 
-        # You can traverse trees as well to handle all contained files of a particular commit
+        # You can traverse trees as well to handle all contained files of a particular commit.
         file_count = 0
         tree_count = 0
         tree = past.commit.tree
         for item in tree.traverse():
             file_count += item.type == "blob"
             tree_count += item.type == "tree"
-        assert file_count and tree_count  # we have accumulated all directories and files
-        self.assertEqual(len(tree.blobs) + len(tree.trees), len(tree))  # a tree is iterable on its children
+        assert file_count and tree_count  # We have accumulated all directories and files.
+        self.assertEqual(len(tree.blobs) + len(tree.trees), len(tree))  # A tree is iterable on its children.
         # ![11-test_init_repo_object]
 
-        # remotes allow handling push, pull and fetch operations
+        # Remotes allow handling push, pull and fetch operations.
         # [12-test_init_repo_object]
         from git import RemoteProgress
 
@@ -147,67 +148,67 @@ class Tutorials(TestBase):
 
         # end
 
-        self.assertEqual(len(cloned_repo.remotes), 1)  # we have been cloned, so should be one remote
-        self.assertEqual(len(bare_repo.remotes), 0)  # this one was just initialized
+        self.assertEqual(len(cloned_repo.remotes), 1)  # We have been cloned, so should be one remote.
+        self.assertEqual(len(bare_repo.remotes), 0)  # This one was just initialized.
         origin = bare_repo.create_remote("origin", url=cloned_repo.working_tree_dir)
         assert origin.exists()
         for fetch_info in origin.fetch(progress=MyProgressPrinter()):
             print("Updated %s to %s" % (fetch_info.ref, fetch_info.commit))
-        # create a local branch at the latest fetched master. We specify the name statically, but you have all
+        # Create a local branch at the latest fetched master. We specify the name statically, but you have all
         # information to do it programmatically as well.
         bare_master = bare_repo.create_head("master", origin.refs.master)
         bare_repo.head.set_reference(bare_master)
         assert not bare_repo.delete_remote(origin).exists()
-        # push and pull behave very similarly
+        # push and pull behave very similarly.
         # ![12-test_init_repo_object]
 
         # index
         # [13-test_init_repo_object]
-        self.assertEqual(new_branch.checkout(), cloned_repo.active_branch)  # checking out branch adjusts the wtree
-        self.assertEqual(new_branch.commit, past.commit)  # Now the past is checked out
+        self.assertEqual(new_branch.checkout(), cloned_repo.active_branch)  # Checking out branch adjusts the wtree.
+        self.assertEqual(new_branch.commit, past.commit)  # Now the past is checked out.
 
         new_file_path = os.path.join(cloned_repo.working_tree_dir, "my-new-file")
-        open(new_file_path, "wb").close()  # create new file in working tree
-        cloned_repo.index.add([new_file_path])  # add it to the index
-        # Commit the changes to deviate masters history
+        open(new_file_path, "wb").close()  # Create new file in working tree.
+        cloned_repo.index.add([new_file_path])  # Add it to the index.
+        # Commit the changes to deviate masters history.
         cloned_repo.index.commit("Added a new file in the past - for later merge")
 
-        # prepare a merge
-        master = cloned_repo.heads.master  # right-hand side is ahead of us, in the future
-        merge_base = cloned_repo.merge_base(new_branch, master)  # allows for a three-way merge
-        cloned_repo.index.merge_tree(master, base=merge_base)  # write the merge result into index
+        # Prepare a merge.
+        master = cloned_repo.heads.master  # Right-hand side is ahead of us, in the future.
+        merge_base = cloned_repo.merge_base(new_branch, master)  # Allows for a three-way merge.
+        cloned_repo.index.merge_tree(master, base=merge_base)  # Write the merge result into index.
         cloned_repo.index.commit(
             "Merged past and now into future ;)",
             parent_commits=(new_branch.commit, master.commit),
         )
 
-        # now new_branch is ahead of master, which probably should be checked out and reset softly.
-        # note that all these operations didn't touch the working tree, as we managed it ourselves.
-        # This definitely requires you to know what you are doing :) !
-        assert os.path.basename(new_file_path) in new_branch.commit.tree  # new file is now in tree
-        master.commit = new_branch.commit  # let master point to most recent commit
-        cloned_repo.head.reference = master  # we adjusted just the reference, not the working tree or index
+        # Now new_branch is ahead of master, which probably should be checked out and reset softly.
+        # Note that all these operations didn't touch the working tree, as we managed it ourselves.
+        # This definitely requires you to know what you are doing! :)
+        assert os.path.basename(new_file_path) in new_branch.commit.tree  # New file is now in tree.
+        master.commit = new_branch.commit  # Let master point to most recent commit.
+        cloned_repo.head.reference = master  # We adjusted just the reference, not the working tree or index.
         # ![13-test_init_repo_object]
 
         # submodules
 
         # [14-test_init_repo_object]
-        # create a new submodule and check it out on the spot, setup to track master branch of `bare_repo`
+        # Create a new submodule and check it out on the spot, setup to track master branch of `bare_repo`.
         # As our GitPython repository has submodules already that point to GitHub, make sure we don't
-        # interact with them
+        # interact with them.
         for sm in cloned_repo.submodules:
             assert not sm.remove().exists()  # after removal, the sm doesn't exist anymore
         sm = cloned_repo.create_submodule("mysubrepo", "path/to/subrepo", url=bare_repo.git_dir, branch="master")
 
-        # .gitmodules was written and added to the index, which is now being committed
+        # .gitmodules was written and added to the index, which is now being committed.
         cloned_repo.index.commit("Added submodule")
-        assert sm.exists() and sm.module_exists()  # this submodule is definitely available
-        sm.remove(module=True, configuration=False)  # remove the working tree
-        assert sm.exists() and not sm.module_exists()  # the submodule itself is still available
+        assert sm.exists() and sm.module_exists()  # This submodule is definitely available.
+        sm.remove(module=True, configuration=False)  # Remove the working tree.
+        assert sm.exists() and not sm.module_exists()  # The submodule itself is still available.
 
-        # update all submodules, non-recursively to save time, this method is very powerful, go have a look
+        # Update all submodules, non-recursively to save time. This method is very powerful, go have a look.
         cloned_repo.submodule_update(recursive=False)
-        assert sm.module_exists()  # The submodules working tree was checked out by update
+        assert sm.module_exists()  # The submodule's working tree was checked out by update.
         # ![14-test_init_repo_object]
 
     @with_rw_directory
@@ -218,25 +219,25 @@ class Tutorials(TestBase):
         repo = git.Repo.clone_from(self._small_repo_url(), os.path.join(rw_dir, "repo"), branch="master")
 
         heads = repo.heads
-        master = heads.master  # lists can be accessed by name for convenience
-        master.commit  # the commit pointed to by head called master
-        master.rename("new_name")  # rename heads
+        master = heads.master  # Lists can be accessed by name for convenience.
+        master.commit  # the commit pointed to by head called master.
+        master.rename("new_name")  # Rename heads.
         master.rename("master")
         # ![1-test_references_and_objects]
 
         # [2-test_references_and_objects]
         tags = repo.tags
         tagref = tags[0]
-        tagref.tag  # tags may have tag objects carrying additional information
-        tagref.commit  # but they always point to commits
-        repo.delete_tag(tagref)  # delete or
-        repo.create_tag("my_tag")  # create tags using the repo for convenience
+        tagref.tag  # Tags may have tag objects carrying additional information
+        tagref.commit  # but they always point to commits.
+        repo.delete_tag(tagref)  # Delete or
+        repo.create_tag("my_tag")  # create tags using the repo for convenience.
         # ![2-test_references_and_objects]
 
         # [3-test_references_and_objects]
-        head = repo.head  # the head points to the active branch/ref
-        master = head.reference  # retrieve the reference the head points to
-        master.commit  # from here you use it as any other reference
+        head = repo.head  # The head points to the active branch/ref.
+        master = head.reference  # Retrieve the reference the head points to.
+        master.commit  # From here you use it as any other reference.
         # ![3-test_references_and_objects]
         #
         # [4-test_references_and_objects]
@@ -246,14 +247,14 @@ class Tutorials(TestBase):
         # ![4-test_references_and_objects]
 
         # [5-test_references_and_objects]
-        new_branch = repo.create_head("new")  # create a new one
-        new_branch.commit = "HEAD~10"  # set branch to another commit without changing index or working trees
-        repo.delete_head(new_branch)  # delete an existing head - only works if it is not checked out
+        new_branch = repo.create_head("new")  # Create a new one.
+        new_branch.commit = "HEAD~10"  # Set branch to another commit without changing index or working trees.
+        repo.delete_head(new_branch)  # Delete an existing head - only works if it is not checked out.
         # ![5-test_references_and_objects]
 
         # [6-test_references_and_objects]
         new_tag = repo.create_tag("my_new_tag", message="my message")
-        # You cannot change the commit a tag points to. Tags need to be re-created
+        # You cannot change the commit a tag points to. Tags need to be re-created.
         self.assertRaises(AttributeError, setattr, new_tag, "commit", repo.commit("HEAD~1"))
         repo.delete_tag(new_tag)
         # ![6-test_references_and_objects]
@@ -272,22 +273,22 @@ class Tutorials(TestBase):
         # ![8-test_references_and_objects]
 
         # [9-test_references_and_objects]
-        self.assertEqual(hct.type, "tree")  # preset string type, being a class attribute
+        self.assertEqual(hct.type, "tree")  # Preset string type, being a class attribute.
         assert hct.size > 0  # size in bytes
         assert len(hct.hexsha) == 40
         assert len(hct.binsha) == 20
         # ![9-test_references_and_objects]
 
         # [10-test_references_and_objects]
-        self.assertEqual(hct.path, "")  # root tree has no path
-        assert hct.trees[0].path != ""  # the first contained item has one though
-        self.assertEqual(hct.mode, 0o40000)  # trees have the mode of a linux directory
-        self.assertEqual(hct.blobs[0].mode, 0o100644)  # blobs have specific mode, comparable to a standard linux fs
+        self.assertEqual(hct.path, "")  # Root tree has no path.
+        assert hct.trees[0].path != ""  # The first contained item has one though.
+        self.assertEqual(hct.mode, 0o40000)  # Trees have the mode of a Linux directory.
+        self.assertEqual(hct.blobs[0].mode, 0o100644)  # Blobs have specific mode, comparable to a standard Linux fs.
         # ![10-test_references_and_objects]
 
         # [11-test_references_and_objects]
-        hct.blobs[0].data_stream.read()  # stream object to read data from
-        hct.blobs[0].stream_data(open(os.path.join(rw_dir, "blob_data"), "wb"))  # write data to given stream
+        hct.blobs[0].data_stream.read()  # Stream object to read data from.
+        hct.blobs[0].stream_data(open(os.path.join(rw_dir, "blob_data"), "wb"))  # Write data to a given stream.
         # ![11-test_references_and_objects]
 
         # [12-test_references_and_objects]
@@ -299,7 +300,7 @@ class Tutorials(TestBase):
         # [13-test_references_and_objects]
         fifty_first_commits = list(repo.iter_commits("master", max_count=50))
         assert len(fifty_first_commits) == 50
-        # this will return commits 21-30 from the commit list as traversed backwards master
+        # This will return commits 21-30 from the commit list as traversed backwards master.
         ten_commits_past_twenty = list(repo.iter_commits("master", max_count=10, skip=20))
         assert len(ten_commits_past_twenty) == 10
         assert fifty_first_commits[20:30] == ten_commits_past_twenty
@@ -334,20 +335,20 @@ class Tutorials(TestBase):
         # ![17-test_references_and_objects]
 
         # [18-test_references_and_objects]
-        assert len(tree.trees) > 0  # trees are subdirectories
-        assert len(tree.blobs) > 0  # blobs are files
+        assert len(tree.trees) > 0  # Trees are subdirectories.
+        assert len(tree.blobs) > 0  # Blobs are files.
         assert len(tree.blobs) + len(tree.trees) == len(tree)
         # ![18-test_references_and_objects]
 
         # [19-test_references_and_objects]
-        self.assertEqual(tree["smmap"], tree / "smmap")  # access by index and by sub-path
-        for entry in tree:  # intuitive iteration of tree members
+        self.assertEqual(tree["smmap"], tree / "smmap")  # Access by index and by sub-path.
+        for entry in tree:  # Intuitive iteration of tree members.
             print(entry)
-        blob = tree.trees[1].blobs[0]  # let's get a blob in a sub-tree
+        blob = tree.trees[1].blobs[0]  # Let's get a blob in a sub-tree.
         assert blob.name
         assert len(blob.path) < len(blob.abspath)
-        self.assertEqual(tree.trees[1].name + "/" + blob.name, blob.path)  # this is how relative blob path generated
-        self.assertEqual(tree[blob.path], blob)  # you can use paths like 'dir/file' in tree
+        self.assertEqual(tree.trees[1].name + "/" + blob.name, blob.path)  # This is how relative blob path generated.
+        self.assertEqual(tree[blob.path], blob)  # You can use paths like 'dir/file' in tree,
         # ![19-test_references_and_objects]
 
         # [20-test_references_and_objects]
@@ -356,11 +357,11 @@ class Tutorials(TestBase):
         # ![20-test_references_and_objects]
 
         # [21-test_references_and_objects]
-        # This example shows the various types of allowed ref-specs
+        # This example shows the various types of allowed ref-specs.
         assert repo.tree() == repo.head.commit.tree
         past = repo.commit("HEAD~5")
         assert repo.tree(past) == repo.tree(past.hexsha)
-        self.assertEqual(repo.tree("v0.8.1").type, "tree")  # yes, you can provide any refspec - works everywhere
+        self.assertEqual(repo.tree("v0.8.1").type, "tree")  # Yes, you can provide any refspec - works everywhere.
         # ![21-test_references_and_objects]
 
         # [22-test_references_and_objects]
@@ -369,36 +370,36 @@ class Tutorials(TestBase):
 
         # [23-test_references_and_objects]
         index = repo.index
-        # The index contains all blobs in a flat list
+        # The index contains all blobs in a flat list.
         assert len(list(index.iter_blobs())) == len([o for o in repo.head.commit.tree.traverse() if o.type == "blob"])
-        # Access blob objects
+        # Access blob objects.
         for (_path, _stage), _entry in index.entries.items():
             pass
         new_file_path = os.path.join(repo.working_tree_dir, "new-file-name")
         open(new_file_path, "w").close()
-        index.add([new_file_path])  # add a new file to the index
-        index.remove(["LICENSE"])  # remove an existing one
-        assert os.path.isfile(os.path.join(repo.working_tree_dir, "LICENSE"))  # working tree is untouched
+        index.add([new_file_path])  # Add a new file to the index.
+        index.remove(["LICENSE"])  # Remove an existing one.
+        assert os.path.isfile(os.path.join(repo.working_tree_dir, "LICENSE"))  # Working tree is untouched.
 
-        self.assertEqual(index.commit("my commit message").type, "commit")  # commit changed index
-        repo.active_branch.commit = repo.commit("HEAD~1")  # forget last commit
+        self.assertEqual(index.commit("my commit message").type, "commit")  # Commit changed index.
+        repo.active_branch.commit = repo.commit("HEAD~1")  # Forget last commit.
 
         from git import Actor
 
         author = Actor("An author", "author@example.com")
         committer = Actor("A committer", "committer@example.com")
-        # commit by commit message and author and committer
+        # Commit with a commit message, author, and committer.
         index.commit("my commit message", author=author, committer=committer)
         # ![23-test_references_and_objects]
 
         # [24-test_references_and_objects]
         from git import IndexFile
 
-        # loads a tree into a temporary index, which exists just in memory
+        # Load a tree into a temporary index, which exists just in memory.
         IndexFile.from_tree(repo, "HEAD~1")
-        # merge two trees three-way into memory
+        # Merge two trees three-way into memory...
         merge_index = IndexFile.from_tree(repo, "HEAD~10", "HEAD", repo.merge_base("HEAD~10", "HEAD"))
-        # and persist it
+        # ...and persist it.
         merge_index.write(os.path.join(rw_dir, "merged_index"))
         # ![24-test_references_and_objects]
 
@@ -407,20 +408,20 @@ class Tutorials(TestBase):
         origin = empty_repo.create_remote("origin", repo.remotes.origin.url)
         assert origin.exists()
         assert origin == empty_repo.remotes.origin == empty_repo.remotes["origin"]
-        origin.fetch()  # assure we actually have data. fetch() returns useful information
-        # Setup a local tracking branch of a remote branch
-        empty_repo.create_head("master", origin.refs.master)  # create local branch "master" from remote "master"
-        empty_repo.heads.master.set_tracking_branch(origin.refs.master)  # set local "master" to track remote "master
-        empty_repo.heads.master.checkout()  # checkout local "master" to working tree
+        origin.fetch()  # Ensure we actually have data. fetch() returns useful information.
+        # Set up a local tracking branch of a remote branch.
+        empty_repo.create_head("master", origin.refs.master)  # Create local branch "master" from remote "master".
+        empty_repo.heads.master.set_tracking_branch(origin.refs.master)  # Set local "master" to track remote "master.
+        empty_repo.heads.master.checkout()  # Check out local "master" to working tree.
         # Three above commands in one:
         empty_repo.create_head("master", origin.refs.master).set_tracking_branch(origin.refs.master).checkout()
-        # rename remotes
+        # Rename remotes.
         origin.rename("new_origin")
-        # push and pull behaves similarly to `git push|pull`
+        # Push and pull behaves similarly to `git push|pull`.
         origin.pull()
-        origin.push()  # attempt push, ignore errors
-        origin.push().raise_if_error()  # push and raise error if it fails
-        # assert not empty_repo.delete_remote(origin).exists()     # create and delete remotes
+        origin.push()  # Attempt push, ignore errors.
+        origin.push().raise_if_error()  # Push and raise error if it fails.
+        # assert not empty_repo.delete_remote(origin).exists()     # Create and delete remotes.
         # ![25-test_references_and_objects]
 
         # [26-test_references_and_objects]
@@ -428,20 +429,20 @@ class Tutorials(TestBase):
         with origin.config_writer as cw:
             cw.set("pushurl", "other_url")
 
-        # Please note that in python 2, writing origin.config_writer.set(...) is totally safe.
+        # Please note that in Python 2, writing origin.config_writer.set(...) is totally safe.
         # In py3 __del__ calls can be delayed, thus not writing changes in time.
         # ![26-test_references_and_objects]
 
         # [27-test_references_and_objects]
         hcommit = repo.head.commit
-        hcommit.diff()  # diff tree against index
-        hcommit.diff("HEAD~1")  # diff tree against previous tree
-        hcommit.diff(None)  # diff tree against working tree
+        hcommit.diff()  # diff tree against index.
+        hcommit.diff("HEAD~1")  # diff tree against previous tree.
+        hcommit.diff(None)  # diff tree against working tree.
 
         index = repo.index
-        index.diff()  # diff index against itself yielding empty diff
-        index.diff(None)  # diff index against working copy
-        index.diff("HEAD")  # diff index against current HEAD tree
+        index.diff()  # diff index against itself yielding empty diff.
+        index.diff(None)  # diff index against working copy.
+        index.diff("HEAD")  # diff index against current HEAD tree.
         # ![27-test_references_and_objects]
 
         # [28-test_references_and_objects]
@@ -451,32 +452,32 @@ class Tutorials(TestBase):
         # ![28-test_references_and_objects]
 
         # [29-test_references_and_objects]
-        # Reset our working tree 10 commits into the past
+        # Reset our working tree 10 commits into the past.
         past_branch = repo.create_head("past_branch", "HEAD~10")
         repo.head.reference = past_branch
         assert not repo.head.is_detached
-        # reset the index and working tree to match the pointed-to commit
+        # Reset the index and working tree to match the pointed-to commit.
         repo.head.reset(index=True, working_tree=True)
 
-        # To detach your head, you have to point to a commit directly
+        # To detach your head, you have to point to a commit directly.
         repo.head.reference = repo.commit("HEAD~5")
         assert repo.head.is_detached
-        # now our head points 15 commits into the past, whereas the working tree
-        # and index are 10 commits in the past
+        # Now our head points 15 commits into the past, whereas the working tree
+        # and index are 10 commits in the past.
         # ![29-test_references_and_objects]
 
         # [30-test_references_and_objects]
-        # checkout the branch using git-checkout. It will fail as the working tree appears dirty
+        # Check out the branch using git-checkout. It will fail as the working tree appears dirty.
         self.assertRaises(git.GitCommandError, repo.heads.master.checkout)
         repo.heads.past_branch.checkout()
         # ![30-test_references_and_objects]
 
         # [31-test_references_and_objects]
         git = repo.git
-        git.checkout("HEAD", b="my_new_branch")  # create a new branch
+        git.checkout("HEAD", b="my_new_branch")  # Create a new branch.
         git.branch("another-new-one")
-        git.branch("-D", "another-new-one")  # pass strings for full control over argument order
-        git.for_each_ref()  # '-' becomes '_' when calling it
+        git.branch("-D", "another-new-one")  # Pass strings for full control over argument order.
+        git.for_each_ref()  # '-' becomes '_' when calling it.
         # ![31-test_references_and_objects]
 
         repo.git.clear_cache()
@@ -493,19 +494,19 @@ class Tutorials(TestBase):
 
         assert len(sms) == 1
         sm = sms[0]
-        self.assertEqual(sm.name, "gitdb")  # git-python has gitdb as single submodule ...
-        self.assertEqual(sm.children()[0].name, "smmap")  # ... which has smmap as single submodule
+        self.assertEqual(sm.name, "gitdb")  # GitPython has gitdb as its one and only (direct) submodule...
+        self.assertEqual(sm.children()[0].name, "smmap")  # ...which has smmap as its one and only submodule.
 
-        # The module is the repository referenced by the submodule
-        assert sm.module_exists()  # the module is available, which doesn't have to be the case.
+        # The module is the repository referenced by the submodule.
+        assert sm.module_exists()  # The module is available, which doesn't have to be the case.
         assert sm.module().working_tree_dir.endswith("gitdb")
-        # the submodule's absolute path is the module's path
+        # The submodule's absolute path is the module's path.
         assert sm.abspath == sm.module().working_tree_dir
-        self.assertEqual(len(sm.hexsha), 40)  # Its sha defines the commit to checkout
-        assert sm.exists()  # yes, this submodule is valid and exists
-        # read its configuration conveniently
+        self.assertEqual(len(sm.hexsha), 40)  # Its sha defines the commit to check out.
+        assert sm.exists()  # Yes, this submodule is valid and exists.
+        # Read its configuration conveniently.
         assert sm.config_reader().get_value("path") == sm.path
-        self.assertEqual(len(sm.children()), 1)  # query the submodule hierarchy
+        self.assertEqual(len(sm.children()), 1)  # Query the submodule hierarchy.
         # ![1-test_submodules]
 
     @with_rw_directory
@@ -516,7 +517,7 @@ class Tutorials(TestBase):
         file_name = os.path.join(repo_dir, "new-file")
 
         r = git.Repo.init(repo_dir)
-        # This function just creates an empty file ...
+        # This function just creates an empty file.
         open(file_name, "wb").close()
         r.index.add([file_name])
         r.index.commit("initial commit")

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -146,8 +146,6 @@ class Tutorials(TestBase):
                     message or "NO MESSAGE",
                 )
 
-        # end
-
         self.assertEqual(len(cloned_repo.remotes), 1)  # We have been cloned, so should be one remote.
         self.assertEqual(len(bare_repo.remotes), 0)  # This one was just initialized.
         origin = bare_repo.create_remote("origin", url=cloned_repo.working_tree_dir)

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# test_git.py
+# test_docs.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_docs.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_exc.py
 # Copyright (C) 2008, 2009, 2016 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -102,7 +102,7 @@ class TExc(TestBase):
 
             if subs is not None:
                 # Substrings (must) already contain opening `'`.
-                subs = "(?<!')%s(?!')" % re.escape(subs)
+                subs = r"(?<!')%s(?!')" % re.escape(subs)
                 self.assertRegex(s, subs)
 
         if not stream:

--- a/test/test_fun.py
+++ b/test/test_fun.py
@@ -32,21 +32,21 @@ class TestFun(TestBase):
         # END assert entry matches fully
 
     def test_aggressive_tree_merge(self):
-        # head tree with additions, removals and modification compared to its predecessor
+        # Head tree with additions, removals and modification compared to its predecessor.
         odb = self.rorepo.odb
         HC = self.rorepo.commit("6c1faef799095f3990e9970bc2cb10aa0221cf9c")
         H = HC.tree
         B = HC.parents[0].tree
 
-        # entries from single tree
+        # Entries from single tree.
         trees = [H.binsha]
         self._assert_index_entries(aggressive_tree_merge(odb, trees), trees)
 
-        # from multiple trees
+        # From multiple trees.
         trees = [B.binsha, H.binsha]
         self._assert_index_entries(aggressive_tree_merge(odb, trees), trees)
 
-        # three way, no conflict
+        # Three way, no conflict.
         tree = self.rorepo.tree
         B = tree("35a09c0534e89b2d43ec4101a5fb54576b577905")
         H = tree("4fe5cfa0e063a8d51a1eb6f014e2aaa994e5e7d4")
@@ -54,18 +54,18 @@ class TestFun(TestBase):
         trees = [B.binsha, H.binsha, M.binsha]
         self._assert_index_entries(aggressive_tree_merge(odb, trees), trees)
 
-        # three-way, conflict in at least one file, both modified
+        # Three-way, conflict in at least one file, both modified.
         B = tree("a7a4388eeaa4b6b94192dce67257a34c4a6cbd26")
         H = tree("f9cec00938d9059882bb8eabdaf2f775943e00e5")
         M = tree("44a601a068f4f543f73fd9c49e264c931b1e1652")
         trees = [B.binsha, H.binsha, M.binsha]
         self._assert_index_entries(aggressive_tree_merge(odb, trees), trees)
 
-        # too many trees
+        # Too many trees.
         self.assertRaises(ValueError, aggressive_tree_merge, odb, trees * 2)
 
     def mktree(self, odb, entries):
-        """create a tree from the given tree entries and safe it to the database"""
+        """Create a tree from the given tree entries and safe it to the database."""
         sio = BytesIO()
         tree_to_stream(entries, sio.write)
         sio.seek(0)
@@ -92,84 +92,84 @@ class TestFun(TestBase):
 
         odb = rwrepo.odb
 
-        # base tree
+        # Base tree.
         bfn = "basefile"
         fbase = mkfile(bfn, shaa)
         tb = mktree(odb, [fbase])
 
-        # non-conflicting new files, same data
+        # Non-conflicting new files, same data.
         fa = mkfile("1", shab)
         th = mktree(odb, [fbase, fa])
         fb = mkfile("2", shac)
         tm = mktree(odb, [fbase, fb])
 
-        # two new files, same base file
+        # Two new files, same base file.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 3)
 
-        # both delete same file, add own one
+        # Both delete same file, add own one.
         fa = mkfile("1", shab)
         th = mktree(odb, [fa])
         fb = mkfile("2", shac)
         tm = mktree(odb, [fb])
 
-        # two new files
+        # Two new files.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 2)
 
-        # same file added in both, differently
+        # Same file added in both, differently.
         fa = mkfile("1", shab)
         th = mktree(odb, [fa])
         fb = mkfile("1", shac)
         tm = mktree(odb, [fb])
 
-        # expect conflict
+        # Expect conflict.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 2, True)
 
-        # same file added, different mode
+        # Same file added, different mode.
         fa = mkfile("1", shab)
         th = mktree(odb, [fa])
         fb = mkcommit("1", shab)
         tm = mktree(odb, [fb])
 
-        # expect conflict
+        # Expect conflict.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 2, True)
 
-        # same file added in both
+        # Same file added in both.
         fa = mkfile("1", shab)
         th = mktree(odb, [fa])
         fb = mkfile("1", shab)
         tm = mktree(odb, [fb])
 
-        # expect conflict
+        # Expect conflict.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 1)
 
-        # modify same base file, differently
+        # Modify same base file, differently.
         fa = mkfile(bfn, shab)
         th = mktree(odb, [fa])
         fb = mkfile(bfn, shac)
         tm = mktree(odb, [fb])
 
-        # conflict, 3 versions on 3 stages
+        # Conflict, 3 versions on 3 stages.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 3, True)
 
-        # change mode on same base file, by making one a commit, the other executable
-        # no content change ( this is totally unlikely to happen in the real world )
+        # Change mode on same base file, by making one a commit, the other executable,
+        # no content change (this is totally unlikely to happen in the real world).
         fa = mkcommit(bfn, shaa)
         th = mktree(odb, [fa])
         fb = mkfile(bfn, shaa, executable=1)
         tm = mktree(odb, [fb])
 
-        # conflict, 3 versions on 3 stages, because of different mode
+        # Conflict, 3 versions on 3 stages, because of different mode.
         trees = [tb, th, tm]
         assert_entries(aggressive_tree_merge(odb, trees), 3, True)
 
         for is_them in range(2):
-            # only we/they change contents
+            # Only we/they change contents.
             fa = mkfile(bfn, shab)
             th = mktree(odb, [fa])
 
@@ -179,7 +179,7 @@ class TestFun(TestBase):
             entries = aggressive_tree_merge(odb, trees)
             assert len(entries) == 1 and entries[0].binsha == shab
 
-            # only we/they change the mode
+            # Only we/they change the mode.
             fa = mkcommit(bfn, shaa)
             th = mktree(odb, [fa])
 
@@ -189,14 +189,14 @@ class TestFun(TestBase):
             entries = aggressive_tree_merge(odb, trees)
             assert len(entries) == 1 and entries[0].binsha == shaa and entries[0].mode == fa[1]
 
-            # one side deletes, the other changes = conflict
+            # One side deletes, the other changes = conflict.
             fa = mkfile(bfn, shab)
             th = mktree(odb, [fa])
             tm = mktree(odb, [])
             trees = [tb, th, tm]
             if is_them:
                 trees = [tb, tm, th]
-            # as one is deleted, there are only 2 entries
+            # As one is deleted, there are only 2 entries.
             assert_entries(aggressive_tree_merge(odb, trees), 2, True)
         # END handle ours, theirs
 
@@ -227,19 +227,19 @@ class TestFun(TestBase):
             assert len(entry) == num_trees
             paths = {e[2] for e in entry if e}
 
-            # only one path per set of entries
+            # Only one path per set of entries.
             assert len(paths) == 1
         # END verify entry
 
     def test_tree_traversal(self):
-        # low level tree tarversal
+        # Low level tree traversal.
         odb = self.rorepo.odb
         H = self.rorepo.tree("29eb123beb1c55e5db4aa652d843adccbd09ae18")  # head tree
         M = self.rorepo.tree("e14e3f143e7260de9581aee27e5a9b2645db72de")  # merge tree
         B = self.rorepo.tree("f606937a7a21237c866efafcad33675e6539c103")  # base tree
         B_old = self.rorepo.tree("1f66cfbbce58b4b552b041707a12d437cc5f400a")  # old base tree
 
-        # two very different trees
+        # Two very different trees.
         entries = traverse_trees_recursive(odb, [B_old.binsha, H.binsha], "")
         self._assert_tree_entries(entries, 2)
 
@@ -247,17 +247,17 @@ class TestFun(TestBase):
         assert len(oentries) == len(entries)
         self._assert_tree_entries(oentries, 2)
 
-        # single tree
+        # Single tree.
         is_no_tree = lambda i, d: i.type != "tree"
         entries = traverse_trees_recursive(odb, [B.binsha], "")
         assert len(entries) == len(list(B.traverse(predicate=is_no_tree)))
         self._assert_tree_entries(entries, 1)
 
-        # two trees
+        # Two trees.
         entries = traverse_trees_recursive(odb, [B.binsha, H.binsha], "")
         self._assert_tree_entries(entries, 2)
 
-        # tree trees
+        # Three trees.
         entries = traverse_trees_recursive(odb, [B.binsha, H.binsha, M.binsha], "")
         self._assert_tree_entries(entries, 3)
 
@@ -275,7 +275,7 @@ class TestFun(TestBase):
 
     @with_rw_directory
     def test_linked_worktree_traversal(self, rw_dir):
-        """Check that we can identify a linked worktree based on a .git file"""
+        """Check that we can identify a linked worktree based on a .git file."""
         git = Git(rw_dir)
         if git.version_info[:3] < (2, 5, 1):
             raise RuntimeError("worktree feature unsupported (test needs git 2.5.1 or later)")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_git.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import inspect
 import logging
 import os
@@ -77,14 +78,14 @@ class TestGit(TestBase):
         self.assertEqual(["--max-count=0"], self.git.transform_kwargs(**{"max_count": 0}))
         self.assertEqual([], self.git.transform_kwargs(**{"max_count": None}))
 
-        # Multiple args are supported by using lists/tuples
+        # Multiple args are supported by using lists/tuples.
         self.assertEqual(
             ["-L", "1-3", "-L", "12-18"],
             self.git.transform_kwargs(**{"L": ("1-3", "12-18")}),
         )
         self.assertEqual(["-C", "-C"], self.git.transform_kwargs(**{"C": [True, True, None, False]}))
 
-        # order is undefined
+        # Order is undefined.
         res = self.git.transform_kwargs(**{"s": True, "t": True})
         self.assertEqual({"-s", "-t"}, set(res))
 
@@ -189,7 +190,7 @@ class TestGit(TestBase):
 
     @mock.patch.object(Git, "execute")
     def test_it_ignores_false_kwargs(self, git):
-        # this_should_not_be_ignored=False implies it *should* be ignored
+        # this_should_not_be_ignored=False implies it *should* be ignored.
         self.git.version(pass_this_kwarg=False)
         self.assertTrue("pass_this_kwarg" not in git.call_args[1])
 
@@ -218,31 +219,31 @@ class TestGit(TestBase):
             self.assertEqual(commit, "4cfd6b0314682d5a58f80be39850bad1640e9241")
 
     def test_persistent_cat_file_command(self):
-        # read header only
+        # Read header only.
         hexsha = "b2339455342180c7cc1e9bba3e9f181f7baa5167"
         g = self.git.cat_file(batch_check=True, istream=subprocess.PIPE, as_process=True)
         g.stdin.write(b"b2339455342180c7cc1e9bba3e9f181f7baa5167\n")
         g.stdin.flush()
         obj_info = g.stdout.readline()
 
-        # read header + data
+        # Read header + data.
         g = self.git.cat_file(batch=True, istream=subprocess.PIPE, as_process=True)
         g.stdin.write(b"b2339455342180c7cc1e9bba3e9f181f7baa5167\n")
         g.stdin.flush()
         obj_info_two = g.stdout.readline()
         self.assertEqual(obj_info, obj_info_two)
 
-        # read data - have to read it in one large chunk
+        # Read data - have to read it in one large chunk.
         size = int(obj_info.split()[2])
         g.stdout.read(size)
         g.stdout.read(1)
 
-        # now we should be able to read a new object
+        # Now we should be able to read a new object.
         g.stdin.write(b"b2339455342180c7cc1e9bba3e9f181f7baa5167\n")
         g.stdin.flush()
         self.assertEqual(g.stdout.readline(), obj_info)
 
-        # same can be achieved using the respective command functions
+        # Same can be achieved using the respective command functions.
         hexsha, typename, size = self.git.get_object_header(hexsha)
         hexsha, typename_two, size_two, _ = self.git.get_object_data(hexsha)
         self.assertEqual(typename, typename_two)
@@ -264,31 +265,31 @@ class TestGit(TestBase):
             self.assertRaises(GitCommandNotFound, self.git.version)
 
     def test_refresh(self):
-        # test a bad git path refresh
+        # Test a bad git path refresh.
         self.assertRaises(GitCommandNotFound, refresh, "yada")
 
-        # test a good path refresh
+        # Test a good path refresh.
         which_cmd = "where" if is_win else "command -v"
         path = os.popen("{0} git".format(which_cmd)).read().strip().split("\n")[0]
         refresh(path)
 
     def test_options_are_passed_to_git(self):
-        # This work because any command after git --version is ignored
+        # This works because any command after git --version is ignored.
         git_version = self.git(version=True).NoOp()
         git_command_version = self.git.version()
         self.assertEqual(git_version, git_command_version)
 
     def test_persistent_options(self):
         git_command_version = self.git.version()
-        # analog to test_options_are_passed_to_git
+        # Analog to test_options_are_passed_to_git.
         self.git.set_persistent_git_options(version=True)
         git_version = self.git.NoOp()
         self.assertEqual(git_version, git_command_version)
-        # subsequent calls keep this option:
+        # Subsequent calls keep this option:
         git_version_2 = self.git.NoOp()
         self.assertEqual(git_version_2, git_command_version)
 
-        # reset to empty:
+        # Reset to empty:
         self.git.set_persistent_git_options()
         self.assertRaises(GitCommandError, self.git.NoOp)
 
@@ -301,7 +302,7 @@ class TestGit(TestBase):
         self.git.log(n=1)
 
     def test_insert_after_kwarg_raises(self):
-        # This isn't a complete add command, which doesn't matter here
+        # This isn't a complete add command, which doesn't matter here.
         self.assertRaises(ValueError, self.git.remote, "add", insert_kwargs_after="foo")
 
     def test_env_vars_passed_to_git(self):
@@ -311,10 +312,10 @@ class TestGit(TestBase):
 
     @with_rw_directory
     def test_environment(self, rw_dir):
-        # sanity check
+        # Sanity check.
         self.assertEqual(self.git.environment(), {})
 
-        # make sure the context manager works and cleans up after itself
+        # Make sure the context manager works and cleans up after itself.
         with self.git.custom_environment(PWD="/tmp"):
             self.assertEqual(self.git.environment(), {"PWD": "/tmp"})
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -868,7 +868,7 @@ class TestIndex(TestBase):
     def test__to_relative_path_at_root(self):
         root = osp.abspath(os.sep)
 
-        class Mocked(object):
+        class Mocked:
             bare = False
             git_dir = root
             working_tree_dir = root

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -635,7 +635,7 @@ class TestIndex(TestBase):
                 )
 
                 os.remove(link_file)
-            # end for each target
+            # END for each target
         # END real symlink test
 
         # Add fake symlink and assure it checks-our as symlink.

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -93,7 +93,7 @@ class TestIndex(TestBase):
         self._fprogress(path, done, item)
 
     def _reset_progress(self):
-        # maps paths to the count of calls
+        # Maps paths to the count of calls.
         self._fprogress_map = {}
 
     def _assert_entries(self, entries):
@@ -104,12 +104,12 @@ class TestIndex(TestBase):
         # END for each entry
 
     def test_index_file_base(self):
-        # read from file
+        # Read from file.
         index = IndexFile(self.rorepo, fixture_path("index"))
         assert index.entries
         assert index.version > 0
 
-        # test entry
+        # Test entry.
         entry = next(iter(index.entries.values()))
         for attr in (
             "path",
@@ -128,17 +128,17 @@ class TestIndex(TestBase):
             getattr(entry, attr)
         # END for each method
 
-        # test update
+        # Test update.
         entries = index.entries
         assert isinstance(index.update(), IndexFile)
         assert entries is not index.entries
 
-        # test stage
+        # Test stage.
         index_merge = IndexFile(self.rorepo, fixture_path("index_merge"))
         self.assertEqual(len(index_merge.entries), 106)
         assert len([e for e in index_merge.entries.values() if e.stage != 0])
 
-        # write the data - it must match the original
+        # Write the data - it must match the original.
         tmpfile = tempfile.mktemp()
         index_merge.write(tmpfile)
         with open(tmpfile, "rb") as fp:
@@ -146,7 +146,7 @@ class TestIndex(TestBase):
         os.remove(tmpfile)
 
     def _cmp_tree_index(self, tree, index):
-        # fail unless both objects contain the same paths and blobs
+        # Fail unless both objects contain the same paths and blobs.
         if isinstance(tree, str):
             tree = self.rorepo.commit(tree).tree
 
@@ -169,14 +169,14 @@ class TestIndex(TestBase):
             rw_repo.index.add([Blob(rw_repo, b"f" * 20, "bad-permissions", "foo")])
 
         try:
-            ## 1st fail on purpose adding into index.
+            ## First, fail on purpose adding into index.
             add_bad_blob()
         except Exception as ex:
             msg_py3 = "required argument is not an integer"
             msg_py2 = "cannot convert argument to integer"
             assert msg_py2 in str(ex) or msg_py3 in str(ex)
 
-        ## 2nd time should not fail due to stray lock file
+        ## The second time should not fail due to stray lock file.
         try:
             add_bad_blob()
         except Exception as ex:
@@ -188,17 +188,17 @@ class TestIndex(TestBase):
         cur_sha = "4b43ca7ff72d5f535134241e7c797ddc9c7a3573"
         other_sha = "39f85c4358b7346fee22169da9cad93901ea9eb9"
 
-        # simple index from tree
+        # Simple index from tree.
         base_index = IndexFile.from_tree(rw_repo, common_ancestor_sha)
         assert base_index.entries
         self._cmp_tree_index(common_ancestor_sha, base_index)
 
-        # merge two trees - its like a fast-forward
+        # Merge two trees - it's like a fast-forward.
         two_way_index = IndexFile.from_tree(rw_repo, common_ancestor_sha, cur_sha)
         assert two_way_index.entries
         self._cmp_tree_index(cur_sha, two_way_index)
 
-        # merge three trees - here we have a merge conflict
+        # Merge three trees - here we have a merge conflict.
         three_way_index = IndexFile.from_tree(rw_repo, common_ancestor_sha, cur_sha, other_sha)
         assert len([e for e in three_way_index.entries.values() if e.stage != 0])
 
@@ -209,19 +209,19 @@ class TestIndex(TestBase):
         assert merge_blobs[0][0] in (1, 2, 3)
         assert isinstance(merge_blobs[0][1], Blob)
 
-        # test BlobFilter
+        # Test BlobFilter.
         prefix = "lib/git"
         for _stage, blob in base_index.iter_blobs(BlobFilter([prefix])):
             assert blob.path.startswith(prefix)
 
-        # writing a tree should fail with an unmerged index
+        # Writing a tree should fail with an unmerged index.
         self.assertRaises(UnmergedEntriesError, three_way_index.write_tree)
 
-        # removed unmerged entries
+        # Removed unmerged entries.
         unmerged_blob_map = three_way_index.unmerged_blobs()
         assert unmerged_blob_map
 
-        # pick the first blob at the first stage we find and use it as resolved version
+        # Pick the first blob at the first stage we find and use it as resolved version.
         three_way_index.resolve_blobs(line[0][1] for line in unmerged_blob_map.values())
         tree = three_way_index.write_tree()
         assert isinstance(tree, Tree)
@@ -239,13 +239,13 @@ class TestIndex(TestBase):
         self.assertEqual(len({self.rorepo, self.rorepo, rw_repo, rw_repo}), 2)
 
         # SINGLE TREE MERGE
-        # current index is at the (virtual) cur_commit
+        # Current index is at the (virtual) cur_commit.
         next_commit = "4c39f9da792792d4e73fc3a5effde66576ae128c"
         parent_commit = rw_repo.head.commit.parents[0]
         manifest_key = IndexFile.entry_key("MANIFEST.in", 0)
         manifest_entry = rw_repo.index.entries[manifest_key]
         rw_repo.index.merge_tree(next_commit)
-        # only one change should be recorded
+        # Only one change should be recorded.
         assert manifest_entry.binsha != rw_repo.index.entries[manifest_key].binsha
 
         rw_repo.index.reset(rw_repo.head)
@@ -255,40 +255,40 @@ class TestIndex(TestBase):
         #############
         # Add a change with a NULL sha that should conflict with next_commit. We
         # pretend there was a change, but we do not even bother adding a proper
-        # sha for it ( which makes things faster of course )
+        # sha for it (which makes things faster of course).
         manifest_fake_entry = BaseIndexEntry((manifest_entry[0], b"\0" * 20, 0, manifest_entry[3]))
-        # try write flag
+        # Try write flag.
         self._assert_entries(rw_repo.index.add([manifest_fake_entry], write=False))
-        # add actually resolves the null-hex-sha for us as a feature, but we can
-        # edit the index manually
+        # Add actually resolves the null-hex-sha for us as a feature, but we can
+        # edit the index manually.
         assert rw_repo.index.entries[manifest_key].binsha != Object.NULL_BIN_SHA
-        # must operate on the same index for this ! Its a bit problematic as
-        # it might confuse people
+        # We must operate on the same index for this! It's a bit problematic as
+        # it might confuse people.
         index = rw_repo.index
         index.entries[manifest_key] = IndexEntry.from_base(manifest_fake_entry)
         index.write()
         self.assertEqual(rw_repo.index.entries[manifest_key].hexsha, Diff.NULL_HEX_SHA)
 
-        # write an unchanged index ( just for the fun of it )
+        # Write an unchanged index (just for the fun of it).
         rw_repo.index.write()
 
-        # a three way merge would result in a conflict and fails as the command will
+        # A three way merge would result in a conflict and fails as the command will
         # not overwrite any entries in our index and hence leave them unmerged. This is
-        # mainly a protection feature as the current index is not yet in a tree
+        # mainly a protection feature as the current index is not yet in a tree.
         self.assertRaises(GitCommandError, index.merge_tree, next_commit, base=parent_commit)
 
-        # the only way to get the merged entries is to safe the current index away into a tree,
-        # which is like a temporary commit for us. This fails as well as the NULL sha deos not
-        # have a corresponding object
-        # NOTE: missing_ok is not a kwarg anymore, missing_ok is always true
+        # The only way to get the merged entries is to safe the current index away into a tree,
+        # which is like a temporary commit for us. This fails as well as the NULL sha does not
+        # have a corresponding object.
+        # NOTE: missing_ok is not a kwarg anymore, missing_ok is always true.
         # self.assertRaises(GitCommandError, index.write_tree)
 
-        # if missing objects are okay, this would work though ( they are always okay now )
-        # As we can't read back the tree with NULL_SHA, we rather set it to something else
+        # If missing objects are okay, this would work though (they are always okay now).
+        # As we can't read back the tree with NULL_SHA, we rather set it to something else.
         index.entries[manifest_key] = IndexEntry(manifest_entry[:1] + (hex_to_bin("f" * 40),) + manifest_entry[2:])
         tree = index.write_tree()
 
-        # now make a proper three way merge with unmerged entries
+        # Now make a proper three way merge with unmerged entries.
         unmerged_tree = IndexFile.from_tree(rw_repo, parent_commit, tree, next_commit)
         unmerged_blobs = unmerged_tree.unmerged_blobs()
         self.assertEqual(len(unmerged_blobs), 1)
@@ -296,49 +296,49 @@ class TestIndex(TestBase):
 
     @with_rw_repo("0.1.6")
     def test_index_file_diffing(self, rw_repo):
-        # default Index instance points to our index
+        # Default Index instance points to our index.
         index = IndexFile(rw_repo)
         assert index.path is not None
         assert len(index.entries)
 
-        # write the file back
+        # Write the file back.
         index.write()
 
-        # could sha it, or check stats
+        # Could sha it, or check stats.
 
-        # test diff
-        # resetting the head will leave the index in a different state, and the
-        # diff will yield a few changes
+        # Test diff.
+        # Resetting the head will leave the index in a different state, and the
+        # diff will yield a few changes.
         cur_head_commit = rw_repo.head.reference.commit
         rw_repo.head.reset("HEAD~6", index=True, working_tree=False)
 
-        # diff against same index is 0
+        # Diff against same index is 0.
         diff = index.diff()
         self.assertEqual(len(diff), 0)
 
-        # against HEAD as string, must be the same as it matches index
+        # Against HEAD as string, must be the same as it matches index.
         diff = index.diff("HEAD")
         self.assertEqual(len(diff), 0)
 
-        # against previous head, there must be a difference
+        # Against previous head, there must be a difference.
         diff = index.diff(cur_head_commit)
         assert len(diff)
 
-        # we reverse the result
+        # We reverse the result.
         adiff = index.diff(str(cur_head_commit), R=True)
-        odiff = index.diff(cur_head_commit, R=False)  # now its not reversed anymore
+        odiff = index.diff(cur_head_commit, R=False)  # Now its not reversed anymore.
         assert adiff != odiff
-        self.assertEqual(odiff, diff)  # both unreversed diffs against HEAD
+        self.assertEqual(odiff, diff)  # Both unreversed diffs against HEAD.
 
-        # against working copy - its still at cur_commit
+        # Against working copy - it's still at cur_commit.
         wdiff = index.diff(None)
         assert wdiff != adiff
         assert wdiff != odiff
 
-        # against something unusual
+        # Against something unusual.
         self.assertRaises(ValueError, index.diff, int)
 
-        # adjust the index to match an old revision
+        # Adjust the index to match an old revision.
         cur_branch = rw_repo.active_branch
         cur_commit = cur_branch.commit
         rev_head_parent = "HEAD~1"
@@ -347,10 +347,10 @@ class TestIndex(TestBase):
         self.assertEqual(cur_branch, rw_repo.active_branch)
         self.assertEqual(cur_commit, rw_repo.head.commit)
 
-        # there must be differences towards the working tree which is in the 'future'
+        # There must be differences towards the working tree which is in the 'future'.
         assert index.diff(None)
 
-        # reset the working copy as well to current head,to pull 'back' as well
+        # Reset the working copy as well to current head, to pull 'back' as well.
         new_data = b"will be reverted"
         file_path = osp.join(rw_repo.working_tree_dir, "CHANGES")
         with open(file_path, "wb") as fp:
@@ -362,7 +362,7 @@ class TestIndex(TestBase):
         with open(file_path, "rb") as fp:
             assert fp.read() != new_data
 
-        # test full checkout
+        # Test full checkout.
         test_file = osp.join(rw_repo.working_tree_dir, "CHANGES")
         with open(test_file, "ab") as fd:
             fd.write(b"some data")
@@ -377,25 +377,25 @@ class TestIndex(TestBase):
         self._assert_fprogress([None])
         assert osp.isfile(test_file)
 
-        # individual file
+        # Individual file.
         os.remove(test_file)
         rval = index.checkout(test_file, fprogress=self._fprogress)
         self.assertEqual(list(rval)[0], "CHANGES")
         self._assert_fprogress([test_file])
         assert osp.exists(test_file)
 
-        # checking out non-existing file throws
+        # Checking out non-existing file throws.
         self.assertRaises(CheckoutError, index.checkout, "doesnt_exist_ever.txt.that")
         self.assertRaises(CheckoutError, index.checkout, paths=["doesnt/exist"])
 
-        # checkout file with modifications
+        # Check out file with modifications.
         append_data = b"hello"
         with open(test_file, "ab") as fp:
             fp.write(append_data)
         try:
             index.checkout(test_file)
         except CheckoutError as e:
-            # detailed exceptions are only possible in older git versions
+            # Detailed exceptions are only possible in older git versions.
             if rw_repo.git._version_info < (2, 29):
                 self.assertEqual(len(e.failed_files), 1)
                 self.assertEqual(e.failed_files[0], osp.basename(test_file))
@@ -408,19 +408,17 @@ class TestIndex(TestBase):
         else:
             raise AssertionError("Exception CheckoutError not thrown")
 
-        # if we force it it should work
+        # If we force it, it should work.
         index.checkout(test_file, force=True)
         assert not open(test_file, "rb").read().endswith(append_data)
 
-        # checkout directory
+        # Check out directory.
         rmtree(osp.join(rw_repo.working_tree_dir, "lib"))
         rval = index.checkout("lib")
         assert len(list(rval)) > 1
 
     def _count_existing(self, repo, files):
-        """
-        Returns count of files that actually exist in the repository directory.
-        """
+        """Return count of files that actually exist in the repository directory."""
         existing = 0
         basedir = repo.working_tree_dir
         for f in files:
@@ -443,8 +441,8 @@ class TestIndex(TestBase):
             writer.set_value("user", "email", umail)
         self.assertEqual(writer.get_value("user", "name"), uname)
 
-        # remove all of the files, provide a wild mix of paths, BaseIndexEntries,
-        # IndexEntries
+        # Remove all of the files, provide a wild mix of paths, BaseIndexEntries,
+        # IndexEntries.
         def mixed_iterator():
             count = 0
             for entry in index.entries.values():
@@ -468,29 +466,29 @@ class TestIndex(TestBase):
         self.assertEqual(self._count_existing(rw_repo, deleted_files), len(deleted_files))
         self.assertEqual(len(index.entries), 0)
 
-        # reset the index to undo our changes
+        # Reset the index to undo our changes.
         index.reset()
         self.assertEqual(len(index.entries), num_entries)
 
-        # remove with working copy
+        # Remove with working copy.
         deleted_files = index.remove(mixed_iterator(), working_tree=True)
         assert deleted_files
         self.assertEqual(self._count_existing(rw_repo, deleted_files), 0)
 
-        # reset everything
+        # Reset everything.
         index.reset(working_tree=True)
         self.assertEqual(self._count_existing(rw_repo, deleted_files), len(deleted_files))
 
-        # invalid type
+        # Invalid type.
         self.assertRaises(TypeError, index.remove, [1])
 
-        # absolute path
+        # Absolute path.
         deleted_files = index.remove([osp.join(rw_repo.working_tree_dir, "lib")], r=True)
         assert len(deleted_files) > 1
         self.assertRaises(ValueError, index.remove, ["/doesnt/exists"])
 
         # TEST COMMITTING
-        # commit changed index
+        # Commit changed index.
         cur_commit = cur_head.commit
         commit_message = "commit default head by Frèderic Çaufl€"
 
@@ -505,7 +503,7 @@ class TestIndex(TestBase):
         self.assertEqual(len(new_commit.parents), 1)
         self.assertEqual(cur_head.commit, cur_commit)
 
-        # commit with other actor
+        # Commit with other actor.
         cur_commit = cur_head.commit
 
         my_author = Actor("Frèderic Çaufl€", "author@example.com")
@@ -522,7 +520,7 @@ class TestIndex(TestBase):
         self.assertEqual(cur_head.commit, commit_actor)
         self.assertEqual(cur_head.log()[-1].actor, my_committer)
 
-        # commit with author_date and commit_date
+        # Commit with author_date and commit_date.
         cur_commit = cur_head.commit
         commit_message = "commit with dates by Avinash Sajjanshetty"
 
@@ -537,14 +535,14 @@ class TestIndex(TestBase):
         self.assertEqual(new_commit.authored_date, 1144447993)
         self.assertEqual(new_commit.committed_date, 1112911993)
 
-        # same index, no parents
+        # Same index, no parents.
         commit_message = "index without parents"
         commit_no_parents = index.commit(commit_message, parent_commits=[], head=True)
         self.assertEqual(commit_no_parents.message, commit_message)
         self.assertEqual(len(commit_no_parents.parents), 0)
         self.assertEqual(cur_head.commit, commit_no_parents)
 
-        # same index, multiple parents
+        # same index, multiple parents.
         commit_message = "Index with multiple parents\n    commit with another line"
         commit_multi_parent = index.commit(commit_message, parent_commits=(commit_no_parents, new_commit))
         self.assertEqual(commit_multi_parent.message, commit_message)
@@ -553,41 +551,41 @@ class TestIndex(TestBase):
         self.assertEqual(commit_multi_parent.parents[1], new_commit)
         self.assertEqual(cur_head.commit, commit_multi_parent)
 
-        # re-add all files in lib
-        # get the lib folder back on disk, but get an index without it
+        # Re-add all files in lib.
+        # Get the lib folder back on disk, but get an index without it.
         index.reset(new_commit.parents[0], working_tree=True).reset(new_commit, working_tree=False)
         lib_file_path = osp.join("lib", "git", "__init__.py")
         assert (lib_file_path, 0) not in index.entries
         assert osp.isfile(osp.join(rw_repo.working_tree_dir, lib_file_path))
 
-        # directory
+        # Directory.
         entries = index.add(["lib"], fprogress=self._fprogress_add)
         self._assert_entries(entries)
         self._assert_fprogress(entries)
         assert len(entries) > 1
 
-        # glob
+        # Glob.
         entries = index.reset(new_commit).add([osp.join("lib", "git", "*.py")], fprogress=self._fprogress_add)
         self._assert_entries(entries)
         self._assert_fprogress(entries)
         self.assertEqual(len(entries), 14)
 
-        # same file
+        # Same file.
         entries = index.reset(new_commit).add(
             [osp.join(rw_repo.working_tree_dir, "lib", "git", "head.py")] * 2,
             fprogress=self._fprogress_add,
         )
         self._assert_entries(entries)
         self.assertEqual(entries[0].mode & 0o644, 0o644)
-        # would fail, test is too primitive to handle this case
+        # Would fail, test is too primitive to handle this case.
         # self._assert_fprogress(entries)
         self._reset_progress()
         self.assertEqual(len(entries), 2)
 
-        # missing path
+        # Missing path.
         self.assertRaises(OSError, index.reset(new_commit).add, ["doesnt/exist/must/raise"])
 
-        # blob from older revision overrides current index revision
+        # Blob from older revision overrides current index revision.
         old_blob = new_commit.parents[0].tree.blobs[0]
         entries = index.reset(new_commit).add([old_blob], fprogress=self._fprogress_add)
         self._assert_entries(entries)
@@ -595,7 +593,7 @@ class TestIndex(TestBase):
         self.assertEqual(index.entries[(old_blob.path, 0)].hexsha, old_blob.hexsha)
         self.assertEqual(len(entries), 1)
 
-        # mode 0 not allowed
+        # Mode 0 not allowed.
         null_hex_sha = Diff.NULL_HEX_SHA
         null_bin_sha = b"\0" * 20
         self.assertRaises(
@@ -604,7 +602,7 @@ class TestIndex(TestBase):
             [BaseIndexEntry((0, null_bin_sha, 0, "doesntmatter"))],
         )
 
-        # add new file
+        # Add new file.
         new_file_relapath = "my_new_file"
         self._make_file(new_file_relapath, "hello world", rw_repo)
         entries = index.reset(new_commit).add(
@@ -616,7 +614,7 @@ class TestIndex(TestBase):
         self.assertEqual(len(entries), 1)
         self.assertNotEqual(entries[0].hexsha, null_hex_sha)
 
-        # add symlink
+        # Add symlink.
         if not is_win:
             for target in ("/etc/nonexisting", "/etc/passwd", "/etc"):
                 basename = "my_real_symlink"
@@ -630,7 +628,7 @@ class TestIndex(TestBase):
                 self.assertTrue(S_ISLNK(entries[0].mode))
                 self.assertTrue(S_ISLNK(index.entries[index.entry_key("my_real_symlink", 0)].mode))
 
-                # we expect only the target to be written
+                # We expect only the target to be written.
                 self.assertEqual(
                     index.repo.odb.stream(entries[0].binsha).read().decode("ascii"),
                     target,
@@ -640,7 +638,7 @@ class TestIndex(TestBase):
             # end for each target
         # END real symlink test
 
-        # add fake symlink and assure it checks-our as symlink
+        # Add fake symlink and assure it checks-our as symlink.
         fake_symlink_relapath = "my_fake_symlink"
         link_target = "/etc/that"
         fake_symlink_path = self._make_file(fake_symlink_relapath, link_target, rw_repo)
@@ -652,7 +650,7 @@ class TestIndex(TestBase):
         self.assertEqual(len(entries), 1)
         self.assertTrue(S_ISLNK(entries[0].mode))
 
-        # assure this also works with an alternate method
+        # Check that this also works with an alternate method.
         full_index_entry = IndexEntry.from_base(BaseIndexEntry((0o120000, entries[0].binsha, 0, entries[0].path)))
         entry_key = index.entry_key(full_index_entry)
         index.reset(new_commit)
@@ -660,24 +658,24 @@ class TestIndex(TestBase):
         assert entry_key not in index.entries
         index.entries[entry_key] = full_index_entry
         index.write()
-        index.update()  # force reread of entries
+        index.update()  # Force reread of entries.
         new_entry = index.entries[entry_key]
         assert S_ISLNK(new_entry.mode)
 
-        # a tree created from this should contain the symlink
+        # A tree created from this should contain the symlink.
         tree = index.write_tree()
         assert fake_symlink_relapath in tree
-        index.write()  # flush our changes for the checkout
+        index.write()  # Flush our changes for the checkout.
 
-        # checkout the fakelink, should be a link then
+        # Check out the fake link, should be a link then.
         assert not S_ISLNK(os.stat(fake_symlink_path)[ST_MODE])
         os.remove(fake_symlink_path)
         index.checkout(fake_symlink_path)
 
-        # on windows we will never get symlinks
+        # On Windows, we will never get symlinks.
         if is_win:
-            # simlinks should contain the link as text ( which is what a
-            # symlink actually is )
+            # Symlinks should contain the link as text (which is what a
+            # symlink actually is).
             with open(fake_symlink_path, "rt") as fd:
                 self.assertEqual(fd.read(), link_target)
         else:
@@ -692,24 +690,24 @@ class TestIndex(TestBase):
         # END move assertion utility
 
         self.assertRaises(ValueError, index.move, ["just_one_path"])
-        # file onto existing file
+        # Try to move a file onto an existing file.
         files = ["AUTHORS", "LICENSE"]
         self.assertRaises(GitCommandError, index.move, files)
 
-        # again, with force
+        # Again, with force.
         assert_mv_rval(index.move(files, f=True))
 
-        # files into directory - dry run
+        # Move files into a directory - dry run.
         paths = ["LICENSE", "VERSION", "doc"]
         rval = index.move(paths, dry_run=True)
         self.assertEqual(len(rval), 2)
         assert osp.exists(paths[0])
 
-        # again, no dry run
+        # Again, no dry run.
         rval = index.move(paths)
         assert_mv_rval(rval)
 
-        # dir into dir
+        # Move dir into dir.
         rval = index.move(["doc", "test"])
         assert_mv_rval(rval)
 
@@ -725,7 +723,7 @@ class TestIndex(TestBase):
         # END rewriter
 
         def make_paths():
-            # two existing ones, one new one
+            """Help out the test by yielding two existing paths and one new path."""
             yield "CHANGES"
             yield "ez_setup.py"
             yield index.entries[index.entry_key("README", 0)]
@@ -766,12 +764,12 @@ class TestIndex(TestBase):
         for fkey in keys:
             assert fkey in index.entries
 
-        # just the index
+        # Just the index.
         index.reset(paths=(arela, afile))
         assert akey not in index.entries
         assert bkey in index.entries
 
-        # now with working tree - files on disk as well as entries must be recreated
+        # Now with working tree - files on disk as well as entries must be recreated.
         rw_repo.head.commit = nc
         for absfile in absfiles:
             os.remove(absfile)
@@ -785,8 +783,8 @@ class TestIndex(TestBase):
 
     @with_rw_repo("HEAD")
     def test_compare_write_tree(self, rw_repo):
-        # write all trees and compare them
-        # its important to have a few submodules in there too
+        """Test writing all trees, comparing them for equality."""
+        # It's important to have a few submodules in there too.
         max_count = 25
         count = 0
         for commit in rw_repo.head.commit.traverse():
@@ -847,7 +845,7 @@ class TestIndex(TestBase):
 
     @with_rw_directory
     def test_add_utf8P_path(self, rw_dir):
-        # NOTE: fp is not a Unicode object in python 2 (which is the source of the problem)
+        # NOTE: fp is not a Unicode object in Python 2 (which is the source of the problem).
         fp = osp.join(rw_dir, "ø.txt")
         with open(fp, "wb") as fs:
             fs.write("content of ø".encode("utf-8"))
@@ -858,7 +856,7 @@ class TestIndex(TestBase):
 
     @with_rw_directory
     def test_add_a_file_with_wildcard_chars(self, rw_dir):
-        # see issue #407
+        # See issue #407.
         fp = osp.join(rw_dir, "[.exe")
         with open(fp, "wb") as f:
             f.write(b"something")

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_index.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -45,7 +45,7 @@ class TestInstallation(TestBase):
         self.assertEqual(
             0,
             result.returncode,
-            msg=result.stderr or result.stdout or "Selftest failed",
+            msg=result.stderr or result.stdout or "Self-test failed",
         )
 
         result = subprocess.run(
@@ -63,7 +63,7 @@ class TestInstallation(TestBase):
         # by inserting its location into PYTHONPATH or otherwise patched into
         # sys.path, make sure it is not wrongly inserted as the *first* entry.
         result = subprocess.run(
-            [self.python, "-c", "import sys;import git; print(sys.path)"],
+            [self.python, "-c", "import sys; import git; print(sys.path)"],
             stdout=subprocess.PIPE,
             cwd=self.sources,
         )

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -28,7 +28,7 @@ class QuickDoc(TestBase):
     def test_cloned_repo_object(self, local_dir):
         from git import Repo
 
-        # code to clone from url
+        # Code to clone from url
         # [1-test_cloned_repo_object]
         # $ git clone <url> <local_dir>
 
@@ -37,7 +37,7 @@ class QuickDoc(TestBase):
         repo = Repo.clone_from(repo_url, local_dir)
         # ![1-test_cloned_repo_object]
 
-        # code to add files
+        # Code to add files
         # [2-test_cloned_repo_object]
         # We must make a change to a file so that we can add the update to git
 
@@ -52,7 +52,7 @@ class QuickDoc(TestBase):
         repo.index.add(add_file)  # notice the add function requires a list of paths
         # ![3-test_cloned_repo_object]
 
-        # code to commit - not sure how to test this
+        # Code to commit - not sure how to test this
         # [4-test_cloned_repo_object]
         # $ git commit -m <message>
         repo.index.commit("Update to file2")
@@ -61,8 +61,8 @@ class QuickDoc(TestBase):
         # [5-test_cloned_repo_object]
         # $ git log <file>
 
-        # relative path from git root
-        repo.iter_commits(all=True, max_count=10, paths=update_file)  # gets the last 10 commits from all branches
+        # Relative path from git root
+        repo.iter_commits(all=True, max_count=10, paths=update_file)  # Gets the last 10 commits from all branches.
 
         # Outputs: <generator object Commit._iter_from_process_or_stream at 0x7fb66c186cf0>
 
@@ -79,7 +79,7 @@ class QuickDoc(TestBase):
 
         # Untracked files - create new file
         # [7-test_cloned_repo_object]
-        f = open(f"{local_dir}/untracked.txt", "w")  # creates an empty file
+        f = open(f"{local_dir}/untracked.txt", "w")  # Creates an empty file.
         f.close()
         # ![7-test_cloned_repo_object]
 
@@ -90,14 +90,14 @@ class QuickDoc(TestBase):
 
         # Modified files
         # [9-test_cloned_repo_object]
-        # Let's modify one of our tracked files
+        # Let's modify one of our tracked files.
 
         with open(f"{local_dir}/Downloads/file3.txt", "w") as f:
-            f.write("file3 version 2")  # overwrite file 3
+            f.write("file3 version 2")  # Overwrite file 3.
         # ![9-test_cloned_repo_object]
 
         # [10-test_cloned_repo_object]
-        repo.index.diff(None)  # compares staging area to working directory
+        repo.index.diff(None)  # Compares staging area to working directory.
 
         # Output: [<git.diff.Diff object at 0x7fb66c076e50>,
         # <git.diff.Diff object at 0x7fb66c076ca0>]
@@ -112,7 +112,7 @@ class QuickDoc(TestBase):
         # Downloads/file3.txt
         # ![11-test_cloned_repo_object]
 
-        # compares staging area to head commit
+        # Compares staging area to head commit
         # [11.1-test_cloned_repo_object]
         diffs = repo.index.diff(repo.head.commit)
         for d in diffs:
@@ -122,7 +122,7 @@ class QuickDoc(TestBase):
 
         # ![11.1-test_cloned_repo_object]
         # [11.2-test_cloned_repo_object]
-        # lets add untracked.txt
+        # Let's add untracked.txt.
         repo.index.add(["untracked.txt"])
         diffs = repo.index.diff(repo.head.commit)
         for d in diffs:
@@ -152,7 +152,7 @@ class QuickDoc(TestBase):
 
         # Previous commit tree
         # [13-test_cloned_repo_object]
-        prev_commits = list(repo.iter_commits(all=True, max_count=10))  # last 10 commits from all branches
+        prev_commits = list(repo.iter_commits(all=True, max_count=10))  # Last 10 commits from all branches.
         tree = prev_commits[0].tree
         # ![13-test_cloned_repo_object]
 
@@ -191,29 +191,29 @@ class QuickDoc(TestBase):
         # Printing text files
         # [17-test_cloned_repo_object]
         print_file = "dir1/file2.txt"
-        tree[print_file]  # the head commit tree
+        tree[print_file]  # The head commit tree.
 
         # Output <git.Blob "SHA1-HEX-HASH">
         # ![17-test_cloned_repo_object]
 
-        # print latest file
+        # Print latest file
         # [18-test_cloned_repo_object]
         blob = tree[print_file]
         print(blob.data_stream.read().decode())
 
         # Output
-        # file 2 version 1
+        # File 2 version 1
         # Update version 2
         # ![18-test_cloned_repo_object]
 
-        # print previous tree
+        # Print previous tree
         # [18.1-test_cloned_repo_object]
         commits_for_file = list(repo.iter_commits(all=True, paths=print_file))
-        tree = commits_for_file[-1].tree  # gets the first commit tree
+        tree = commits_for_file[-1].tree  # Gets the first commit tree.
         blob = tree[print_file]
 
         print(blob.data_stream.read().decode())
 
         # Output
-        # file 2 version 1
+        # File 2 version 1
         # ![18.1-test_cloned_repo_object]

--- a/test/test_reflog.py
+++ b/test/test_reflog.py
@@ -26,7 +26,7 @@ class TestRefLog(TestBase):
         assert e.time[1] == 1
         assert e.message == msg
 
-        # check representation (roughly)
+        # Check representation (roughly).
         assert repr(e).startswith(nullhexsha)
 
     def test_base(self):
@@ -38,27 +38,27 @@ class TestRefLog(TestBase):
         rlp_master_ro = RefLog.path(self.rorepo.head)
         assert osp.isfile(rlp_master_ro)
 
-        # simple read
+        # Simple read.
         reflog = RefLog.from_file(rlp_master_ro)
         assert reflog._path is not None
         assert isinstance(reflog, RefLog)
         assert len(reflog)
 
-        # iter_entries works with path and with stream
+        # iter_entries works with path and with stream.
         assert len(list(RefLog.iter_entries(open(rlp_master, "rb"))))
         assert len(list(RefLog.iter_entries(rlp_master)))
 
-        # raise on invalid revlog
-        # TODO: Try multiple corrupted ones !
+        # Raise on invalid revlog.
+        # TODO: Try multiple corrupted ones!
         pp = "reflog_invalid_"
         for suffix in ("oldsha", "newsha", "email", "date", "sep"):
             self.assertRaises(ValueError, RefLog.from_file, fixture_path(pp + suffix))
         # END for each invalid file
 
-        # cannot write an uninitialized reflog
+        # Cannot write an uninitialized reflog.
         self.assertRaises(ValueError, RefLog().write)
 
-        # test serialize and deserialize - results must match exactly
+        # Test serialize and deserialize - results must match exactly.
         binsha = hex_to_bin(("f" * 40).encode("ascii"))
         msg = "my reflog message"
         cr = self.rorepo.config_reader()
@@ -68,33 +68,33 @@ class TestRefLog(TestBase):
             reflog.to_file(tfile)
             assert reflog.write() is reflog
 
-            # parsed result must match ...
+            # Parsed result must match...
             treflog = RefLog.from_file(tfile)
             assert treflog == reflog
 
-            # ... as well as each bytes of the written stream
+            # ...as well as each bytes of the written stream.
             assert open(tfile).read() == open(rlp).read()
 
-            # append an entry
+            # Append an entry.
             entry = RefLog.append_entry(cr, tfile, IndexObject.NULL_BIN_SHA, binsha, msg)
             assert entry.oldhexsha == IndexObject.NULL_HEX_SHA
             assert entry.newhexsha == "f" * 40
             assert entry.message == msg
             assert RefLog.from_file(tfile)[-1] == entry
 
-            # index entry
-            # raises on invalid index
+            # Index entry.
+            # Raises on invalid index.
             self.assertRaises(IndexError, RefLog.entry_at, rlp, 10000)
 
-            # indices can be positive ...
+            # Indices can be positive...
             assert isinstance(RefLog.entry_at(rlp, 0), RefLogEntry)
             RefLog.entry_at(rlp, 23)
 
-            # ... and negative
+            # ...and negative.
             for idx in (-1, -24):
                 RefLog.entry_at(rlp, idx)
             # END for each index to read
         # END for each reflog
 
-        # finally remove our temporary data
+        # Finally remove our temporary data.
         rmtree(tdir)

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -30,7 +30,7 @@ import tempfile
 
 class TestRefs(TestBase):
     def test_from_path(self):
-        # should be able to create any reference directly
+        # Should be able to create any reference directly.
         for ref_type in (Reference, Head, TagReference, RemoteReference):
             for name in ("rela_name", "path/rela_name"):
                 full_path = ref_type.to_full_path(name)
@@ -39,9 +39,9 @@ class TestRefs(TestBase):
             # END for each name
         # END for each type
 
-        # invalid path
+        # Invalid path.
         self.assertRaises(ValueError, TagReference, self.rorepo, "refs/invalid/tag")
-        # works without path check
+        # Works without path check.
         TagReference(self.rorepo, "refs/invalid/tag", check_path=False)
 
     def test_tag_base(self):
@@ -53,7 +53,7 @@ class TestRefs(TestBase):
             if tag.tag is not None:
                 tag_object_refs.append(tag)
                 tagobj = tag.tag
-                # have no dict
+                # Have no dict.
                 self.assertRaises(AttributeError, setattr, tagobj, "someattr", 1)
                 assert isinstance(tagobj, TagObject)
                 assert tagobj.tag == tag.name
@@ -62,7 +62,7 @@ class TestRefs(TestBase):
                 assert isinstance(tagobj.tagger_tz_offset, int)
                 assert tagobj.message
                 assert tag.object == tagobj
-                # can't assign the object
+                # Can't assign the object.
                 self.assertRaises(AttributeError, setattr, tag, "object", tagobj)
             # END if we have a tag object
         # END for tag in repo-tags
@@ -77,7 +77,7 @@ class TestRefs(TestBase):
         assert tagger_name == "Michael Trier"
 
     def test_tags(self):
-        # tag refs can point to tag objects or to commits
+        # Tag refs can point to tag objects or to commits.
         s = set()
         ref_count = 0
         for ref in chain(self.rorepo.tags, self.rorepo.heads):
@@ -100,8 +100,8 @@ class TestRefs(TestBase):
             assert "refs/heads" in head.path
             prev_object = head.object
             cur_object = head.object
-            assert prev_object == cur_object  # represent the same git object
-            assert prev_object is not cur_object  # but are different instances
+            assert prev_object == cur_object  # Represent the same git object...
+            assert prev_object is not cur_object  # ...but are different instances.
 
             with head.config_writer() as writer:
                 tv = "testopt"
@@ -111,7 +111,7 @@ class TestRefs(TestBase):
             with head.config_writer() as writer:
                 writer.remove_option(tv)
 
-            # after the clone, we might still have a tracking branch setup
+            # After the clone, we might still have a tracking branch setup.
             head.set_tracking_branch(None)
             assert head.tracking_branch() is None
             remote_ref = rwrepo.remotes[0].refs[0]
@@ -123,7 +123,7 @@ class TestRefs(TestBase):
             special_name = "feature#123"
             special_name_remote_ref = SymbolicReference.create(rwrepo, "refs/remotes/origin/%s" % special_name)
             gp_tracking_branch = rwrepo.create_head("gp_tracking#123")
-            special_name_remote_ref = rwrepo.remotes[0].refs[special_name]  # get correct type
+            special_name_remote_ref = rwrepo.remotes[0].refs[special_name]  # Get correct type.
             gp_tracking_branch.set_tracking_branch(special_name_remote_ref)
             TBranch = gp_tracking_branch.tracking_branch()
             if TBranch is not None:
@@ -136,7 +136,7 @@ class TestRefs(TestBase):
                 assert TBranch.name == special_name_remote_ref.name
         # END for each head
 
-        # verify REFLOG gets altered
+        # Verify REFLOG gets altered.
         head = rwrepo.head
         cur_head = head.ref
         cur_commit = cur_head.commit
@@ -144,32 +144,31 @@ class TestRefs(TestBase):
         hlog_len = len(head.log())
         blog_len = len(cur_head.log())
         assert head.set_reference(pcommit, "detached head") is head
-        # one new log-entry
+        # One new log-entry.
         thlog = head.log()
         assert len(thlog) == hlog_len + 1
         assert thlog[-1].oldhexsha == cur_commit.hexsha
         assert thlog[-1].newhexsha == pcommit.hexsha
 
-        # the ref didn't change though
+        # The ref didn't change though.
         assert len(cur_head.log()) == blog_len
 
-        # head changes once again, cur_head doesn't change
+        # head changes once again, cur_head doesn't change.
         head.set_reference(cur_head, "reattach head")
         assert len(head.log()) == hlog_len + 2
         assert len(cur_head.log()) == blog_len
 
-        # adjusting the head-ref also adjust the head, so both reflogs are
-        # altered
+        # Adjusting the head-ref also adjust the head, so both reflogs are altered.
         cur_head.set_commit(pcommit, "changing commit")
         assert len(cur_head.log()) == blog_len + 1
         assert len(head.log()) == hlog_len + 3
 
-        # with automatic dereferencing
+        # With automatic dereferencing.
         assert head.set_commit(cur_commit, "change commit once again") is head
         assert len(head.log()) == hlog_len + 4
         assert len(cur_head.log()) == blog_len + 2
 
-        # a new branch has just a single entry
+        # A new branch has just a single entry.
         other_head = Head.create(rwrepo, "mynewhead", pcommit, logmsg="new head created")
         log = other_head.log()
         assert len(log) == 1
@@ -178,7 +177,7 @@ class TestRefs(TestBase):
 
     @with_rw_repo("HEAD", bare=False)
     def test_set_tracking_branch_with_import(self, rwrepo):
-        # prepare included config file
+        # Prepare included config file.
         included_config = osp.join(rwrepo.git_dir, "config.include")
         with GitConfigParser(included_config, read_only=False) as writer:
             writer.set_value("test", "value", "test")
@@ -230,11 +229,11 @@ class TestRefs(TestBase):
         cur_head.reset(new_head_commit, index=True, working_tree=True)  # index + wt
         assert cur_head.reference.commit == new_head_commit
 
-        # paths - make sure we have something to do
+        # Paths - make sure we have something to do.
         rw_repo.index.reset(old_head_commit.parents[0])
         cur_head.reset(cur_head, paths="test")
         cur_head.reset(new_head_commit, paths="lib")
-        # hard resets with paths don't work, its all or nothing
+        # Hard resets with paths don't work; it's all or nothing.
         self.assertRaises(
             GitCommandError,
             cur_head.reset,
@@ -243,12 +242,12 @@ class TestRefs(TestBase):
             paths="lib",
         )
 
-        # we can do a mixed reset, and then checkout from the index though
+        # We can do a mixed reset, and then checkout from the index though.
         cur_head.reset(new_head_commit)
         rw_repo.index.checkout(["lib"], force=True)
 
-        # now that we have a write write repo, change the HEAD reference - its
-        # like git-reset --soft
+        # Now that we have a write write repo, change the HEAD reference - it's
+        # like "git-reset --soft".
         heads = rw_repo.heads
         assert heads
         for head in heads:
@@ -259,7 +258,7 @@ class TestRefs(TestBase):
             assert not cur_head.is_detached
         # END for each head
 
-        # detach
+        # Detach.
         active_head = heads[0]
         curhead_commit = active_head.commit
         cur_head.reference = curhead_commit
@@ -267,20 +266,20 @@ class TestRefs(TestBase):
         assert cur_head.is_detached
         self.assertRaises(TypeError, getattr, cur_head, "reference")
 
-        # tags are references, hence we can point to them
+        # Tags are references, hence we can point to them.
         some_tag = rw_repo.tags[0]
         cur_head.reference = some_tag
         assert not cur_head.is_detached
         assert cur_head.commit == some_tag.commit
         assert isinstance(cur_head.reference, TagReference)
 
-        # put HEAD back to a real head, otherwise everything else fails
+        # Put HEAD back to a real head, otherwise everything else fails.
         cur_head.reference = active_head
 
-        # type check
+        # Type check.
         self.assertRaises(ValueError, setattr, cur_head, "reference", "that")
 
-        # head handling
+        # Head handling.
         commit = "HEAD"
         prev_head_commit = cur_head.commit
         for count, new_name in enumerate(("my_new_head", "feature/feature1")):
@@ -289,13 +288,13 @@ class TestRefs(TestBase):
             assert new_head.is_detached
             assert cur_head.commit == prev_head_commit
             assert isinstance(new_head, Head)
-            # already exists, but has the same value, so its fine
+            # Already exists, but has the same value, so it's fine.
             Head.create(rw_repo, new_name, new_head.commit)
 
-            # its not fine with a different value
+            # It's not fine with a different value.
             self.assertRaises(OSError, Head.create, rw_repo, new_name, new_head.commit.parents[0])
 
-            # force it
+            # Force it.
             new_head = Head.create(rw_repo, new_name, actual_commit, force=True)
             old_path = new_head.path
             old_name = new_head.name
@@ -304,7 +303,7 @@ class TestRefs(TestBase):
             assert new_head.rename("hello/world").name == "hello/world"
             assert new_head.rename(old_name).name == old_name and new_head.path == old_path
 
-            # rename with force
+            # Rename with force.
             tmp_head = Head.create(rw_repo, "tmphead")
             self.assertRaises(GitCommandError, tmp_head.rename, new_head)
             tmp_head.rename(new_head, force=True)
@@ -313,15 +312,15 @@ class TestRefs(TestBase):
             logfile = RefLog.path(tmp_head)
             assert osp.isfile(logfile)
             Head.delete(rw_repo, tmp_head)
-            # deletion removes the log as well
+            # Deletion removes the log as well.
             assert not osp.isfile(logfile)
             heads = rw_repo.heads
             assert tmp_head not in heads and new_head not in heads
-            # force on deletion testing would be missing here, code looks okay though ;)
+            # Force on deletion testing would be missing here, code looks okay though. ;)
         # END for each new head name
         self.assertRaises(TypeError, RemoteReference.create, rw_repo, "some_name")
 
-        # tag ref
+        # Tag ref.
         tag_name = "5.0.2"
         TagReference.create(rw_repo, tag_name)
         self.assertRaises(GitCommandError, TagReference.create, rw_repo, tag_name)
@@ -331,7 +330,7 @@ class TestRefs(TestBase):
         assert light_tag.commit == cur_head.commit.parents[0]
         assert light_tag.tag is None
 
-        # tag with tag object
+        # Tag with tag object.
         other_tag_name = "releases/1.0.2RC"
         msg = "my mighty tag\nsecond line"
         obj_tag = TagReference.create(rw_repo, other_tag_name, message=msg)
@@ -344,7 +343,7 @@ class TestRefs(TestBase):
         tags = rw_repo.tags
         assert light_tag not in tags and obj_tag not in tags
 
-        # remote deletion
+        # Remote deletion.
         remote_refs_so_far = 0
         remotes = rw_repo.remotes
         assert remotes
@@ -367,11 +366,11 @@ class TestRefs(TestBase):
         assert remote_refs_so_far
 
         for remote in remotes:
-            # remotes without references should produce an empty list
+            # Remotes without references should produce an empty list.
             self.assertEqual(remote.refs, [])
         # END for each remote
 
-        # change where the active head points to
+        # Change where the active head points to.
         if cur_head.is_detached:
             cur_head.reference = rw_repo.heads[0]
 
@@ -382,17 +381,17 @@ class TestRefs(TestBase):
         assert head.commit == cur_head.commit
         head.commit = old_commit
 
-        # setting a non-commit as commit fails, but succeeds as object
+        # Setting a non-commit as commit fails, but succeeds as object.
         head_tree = head.commit.tree
         self.assertRaises(ValueError, setattr, head, "commit", head_tree)
         assert head.commit == old_commit  # and the ref did not change
-        # we allow heads to point to any object
+        # We allow heads to point to any object.
         head.object = head_tree
         assert head.object == head_tree
-        # cannot query tree as commit
+        # Cannot query tree as commit.
         self.assertRaises(TypeError, getattr, head, "commit")
 
-        # set the commit directly using the head. This would never detach the head
+        # Set the commit directly using the head. This would never detach the head.
         assert not cur_head.is_detached
         head.object = old_commit
         cur_head.reference = head.commit
@@ -408,30 +407,30 @@ class TestRefs(TestBase):
         assert not cur_head.is_detached
         assert head.commit == parent_commit
 
-        # test checkout
+        # Test checkout.
         active_branch = rw_repo.active_branch
         for head in rw_repo.heads:
             checked_out_head = head.checkout()
             assert checked_out_head == head
         # END for each head to checkout
 
-        # checkout with branch creation
+        # Check out with branch creation.
         new_head = active_branch.checkout(b="new_head")
         assert active_branch != rw_repo.active_branch
         assert new_head == rw_repo.active_branch
 
-        # checkout  with force as we have a changed a file
-        # clear file
+        # Checkout with force as we have a changed a file.
+        # Clear file.
         open(new_head.commit.tree.blobs[-1].abspath, "w").close()
         assert len(new_head.commit.diff(None))
 
-        # create a new branch that is likely to touch the file we changed
+        # Create a new branch that is likely to touch the file we changed.
         far_away_head = rw_repo.create_head("far_head", "HEAD~100")
         self.assertRaises(GitCommandError, far_away_head.checkout)
         assert active_branch == active_branch.checkout(force=True)
         assert rw_repo.head.reference != far_away_head
 
-        # test reference creation
+        # Test reference creation.
         partial_ref = "sub/ref"
         full_ref = "refs/%s" % partial_ref
         ref = Reference.create(rw_repo, partial_ref)
@@ -439,21 +438,21 @@ class TestRefs(TestBase):
         assert ref.object == rw_repo.head.commit
 
         self.assertRaises(OSError, Reference.create, rw_repo, full_ref, "HEAD~20")
-        # it works if it is at the same spot though and points to the same reference
+        # It works if it is at the same spot though and points to the same reference.
         assert Reference.create(rw_repo, full_ref, "HEAD").path == full_ref
         Reference.delete(rw_repo, full_ref)
 
-        # recreate the reference using a full_ref
+        # Recreate the reference using a full_ref.
         ref = Reference.create(rw_repo, full_ref)
         assert ref.path == full_ref
         assert ref.object == rw_repo.head.commit
 
-        # recreate using force
+        # Recreate using force.
         ref = Reference.create(rw_repo, partial_ref, "HEAD~1", force=True)
         assert ref.path == full_ref
         assert ref.object == rw_repo.head.commit.parents[0]
 
-        # rename it
+        # Rename it.
         orig_obj = ref.object
         for name in ("refs/absname", "rela_name", "feature/rela_name"):
             ref_new_name = ref.rename(name)
@@ -463,19 +462,19 @@ class TestRefs(TestBase):
             assert ref_new_name == ref
         # END for each name type
 
-        # References that don't exist trigger an error if we want to access them
+        # References that don't exist trigger an error if we want to access them.
         self.assertRaises(ValueError, getattr, Reference(rw_repo, "refs/doesntexist"), "commit")
 
-        # exists, fail unless we force
+        # Exists, fail unless we force.
         ex_ref_path = far_away_head.path
         self.assertRaises(OSError, ref.rename, ex_ref_path)
-        # if it points to the same commit it works
+        # If it points to the same commit it works.
         far_away_head.commit = ref.commit
         ref.rename(ex_ref_path)
         assert ref.path == ex_ref_path and ref.object == orig_obj
         assert ref.rename(ref.path).path == ex_ref_path  # rename to same name
 
-        # create symbolic refs
+        # Create symbolic refs.
         symref_path = "symrefs/sym"
         symref = SymbolicReference.create(rw_repo, symref_path, cur_head.reference)
         assert symref.path == symref_path
@@ -488,20 +487,20 @@ class TestRefs(TestBase):
             symref_path,
             cur_head.reference.commit,
         )
-        # it works if the new ref points to the same reference
+        # It works if the new ref points to the same reference.
         assert SymbolicReference.create(rw_repo, symref.path, symref.reference).path == symref.path
         SymbolicReference.delete(rw_repo, symref)
-        # would raise if the symref wouldn't have been deletedpbl
+        # Would raise if the symref wouldn't have been deleted (probably).
         symref = SymbolicReference.create(rw_repo, symref_path, cur_head.reference)
 
-        # test symbolic references which are not at default locations like HEAD
-        # or FETCH_HEAD - they may also be at spots in refs of course
+        # Test symbolic references which are not at default locations like HEAD
+        # or FETCH_HEAD - they may also be at spots in refs of course.
         symbol_ref_path = "refs/symbol_ref"
         symref = SymbolicReference(rw_repo, symbol_ref_path)
         assert symref.path == symbol_ref_path
         symbol_ref_abspath = osp.join(rw_repo.git_dir, symref.path)
 
-        # set it
+        # Set it.
         symref.reference = new_head
         assert symref.reference == new_head
         assert osp.isfile(symbol_ref_abspath)
@@ -516,10 +515,10 @@ class TestRefs(TestBase):
             assert not symref.is_detached
         # END for each ref
 
-        # create a new non-head ref just to be sure we handle it even if packed
+        # Create a new non-head ref just to be sure we handle it even if packed.
         Reference.create(rw_repo, full_ref)
 
-        # test ref listing - assure we have packed refs
+        # Test ref listing - make sure we have packed refs.
         rw_repo.git.pack_refs(all=True, prune=True)
         heads = rw_repo.heads
         assert heads
@@ -527,15 +526,15 @@ class TestRefs(TestBase):
         assert active_branch in heads
         assert rw_repo.tags
 
-        # we should be able to iterate all symbolic refs as well - in that case
-        # we should expect only symbolic references to be returned
+        # We should be able to iterate all symbolic refs as well - in that case
+        # we should expect only symbolic references to be returned.
         for symref in SymbolicReference.iter_items(rw_repo):
             assert not symref.is_detached
 
-        # when iterating references, we can get references and symrefs
-        # when deleting all refs, I'd expect them to be gone ! Even from
-        # the packed ones
-        # For this to work, we must not be on any branch
+        # When iterating references, we can get references and symrefs
+        # when deleting all refs, I'd expect them to be gone! Even from
+        # the packed ones.
+        # For this to work, we must not be on any branch.
         rw_repo.head.reference = rw_repo.head.commit
         deleted_refs = set()
         for ref in Reference.iter_items(rw_repo):
@@ -551,16 +550,15 @@ class TestRefs(TestBase):
                 assert ref not in deleted_refs
         # END for each ref
 
-        # reattach head - head will not be returned if it is not a symbolic
-        # ref
+        # Reattach head - head will not be returned if it is not a symbolic ref.
         rw_repo.head.reference = Head.create(rw_repo, "master")
 
-        # At least the head should still exist
+        # At least the head should still exist.
         assert osp.isfile(osp.join(rw_repo.git_dir, "HEAD"))
         refs = list(SymbolicReference.iter_items(rw_repo))
         assert len(refs) == 1
 
-        # test creation of new refs from scratch
+        # Test creation of new refs from scratch.
         for path in ("basename", "dir/somename", "dir2/subdir/basename"):
             # REFERENCES
             ############
@@ -570,11 +568,11 @@ class TestRefs(TestBase):
             ref = Reference(rw_repo, fpath)
             assert ref == ref_fp
 
-            # can be created by assigning a commit
+            # Can be created by assigning a commit.
             ref.commit = rw_repo.head.commit
             assert ref.is_valid()
 
-            # if the assignment raises, the ref doesn't exist
+            # If the assignment raises, the ref doesn't exist.
             Reference.delete(ref.repo, ref.path)
             assert not ref.is_valid()
             self.assertRaises(ValueError, setattr, ref, "commit", "nonsense")
@@ -614,7 +612,7 @@ class TestRefs(TestBase):
         assert tag_ref.tag.message == "test2"
 
     def test_dereference_recursive(self):
-        # for now, just test the HEAD
+        # For now, just test the HEAD.
         assert SymbolicReference.dereference_recursive(self.rorepo, "HEAD")
 
     def test_reflog(self):
@@ -634,7 +632,7 @@ class TestRefs(TestBase):
 
     def test_validity_ref_names(self):
         check_ref = SymbolicReference._check_ref_name_valid
-        # Based on the rules specified in https://git-scm.com/docs/git-check-ref-format/#_description
+        # Based on the rules specified in https://git-scm.com/docs/git-check-ref-format/#_description.
         # Rule 1
         self.assertRaises(ValueError, check_ref, ".ref/begins/with/dot")
         self.assertRaises(ValueError, check_ref, "ref/component/.begins/with/dot")
@@ -665,5 +663,5 @@ class TestRefs(TestBase):
         self.assertRaises(ValueError, check_ref, "@")
         # Rule 10
         self.assertRaises(ValueError, check_ref, "ref/contain\\s/backslash")
-        # Valid reference name should not raise
+        # Valid reference name should not raise.
         check_ref("valid/ref/name")

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -518,8 +518,7 @@ class TestRemote(TestBase):
             if branch.name != "master":
                 branch.delete(remote_repo, branch, force=True)
                 num_deleted += 1
-            # end
-        # end for each branch
+        # END for each branch
         self.assertGreater(num_deleted, 0)
         self.assertEqual(
             len(rw_repo.remotes.origin.fetch(prune=True)),

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -36,7 +36,7 @@ from git.util import rmtree, HIDE_WINDOWS_FREEZE_ERRORS, IterableList
 import os.path as osp
 
 
-# assure we have repeatable results
+# Make sure we have repeatable results.
 random.seed(0)
 
 
@@ -50,8 +50,8 @@ class TestRemoteProgress(RemoteProgress):
         self._num_progress_messages = 0
 
     def _parse_progress_line(self, line):
-        # we may remove the line later if it is dropped
-        # Keep it for debugging
+        # We may remove the line later if it is dropped.
+        # Keep it for debugging.
         self._seen_lines.append(line)
         rval = super(TestRemoteProgress, self)._parse_progress_line(line)
         return rval
@@ -63,7 +63,7 @@ class TestRemoteProgress(RemoteProgress):
             pass
 
     def update(self, op_code, cur_count, max_count=None, message=""):
-        # check each stage only comes once
+        # Check each stage only comes once.
         op_id = op_code & self.OP_MASK
         assert op_id in (self.COUNTING, self.COMPRESSING, self.WRITING)
 
@@ -85,15 +85,15 @@ class TestRemoteProgress(RemoteProgress):
         self._num_progress_messages += 1
 
     def make_assertion(self):
-        # we don't always receive messages
+        # We don't always receive messages.
         if not self._seen_lines:
             return
 
-        # sometimes objects are not compressed which is okay
+        # Sometimes objects are not compressed which is okay.
         assert len(self._seen_ops) in (2, 3), len(self._seen_ops)
         assert self._stages_per_op
 
-        # must have seen all stages
+        # Must have seen all stages.
         for _op, stages in self._stages_per_op.items():
             assert stages & self.STAGE_MASK == self.STAGE_MASK
         # END for each op/stage
@@ -151,7 +151,7 @@ class TestRemote(TestBase):
                 # END for each bitflag
                 self.assertTrue(has_one)
             else:
-                # there must be a remote commit
+                # There must be a remote commit.
                 if info.flags & info.DELETED == 0:
                     self.assertIsInstance(info.local_ref, Reference)
                 else:
@@ -163,7 +163,7 @@ class TestRemote(TestBase):
         if any(info.flags & info.ERROR for info in results):
             self.assertRaises(GitCommandError, results.raise_if_error)
         else:
-            # No errors, so this should do nothing
+            # No errors, so this should do nothing.
             results.raise_if_error()
 
     def _do_test_fetch_info(self, repo):
@@ -177,8 +177,10 @@ class TestRemote(TestBase):
         )
 
     def _commit_random_file(self, repo):
-        # Create a file with a random name and random data and commit it to  repo.
-        # Return the committed absolute file path
+        """Create a file with a random name and random data and commit it to a repo.
+
+        :return: The committed absolute file path.
+        """
         index = repo.index
         new_file = self._make_file(osp.basename(tempfile.mktemp()), str(random.random()), repo)
         index.add([new_file])
@@ -186,7 +188,7 @@ class TestRemote(TestBase):
         return new_file
 
     def _do_test_fetch(self, remote, rw_repo, remote_repo, **kwargs):
-        # specialized fetch testing to de-clutter the main test
+        """Specialized fetch testing to de-clutter the main test."""
         self._do_test_fetch_info(rw_repo)
 
         def fetch_and_test(remote, **kwargs):
@@ -202,16 +204,16 @@ class TestRemote(TestBase):
         def get_info(res, remote, name):
             return res["%s/%s" % (remote, name)]
 
-        # put remote head to master as it is guaranteed to exist
+        # Put remote head to master as it is guaranteed to exist.
         remote_repo.head.reference = remote_repo.heads.master
 
         res = fetch_and_test(remote, **kwargs)
-        # all up to date
+        # All up to date.
         for info in res:
             self.assertTrue(info.flags & info.HEAD_UPTODATE)
 
-        # rewind remote head to trigger rejection
-        # index must be false as remote is a bare repo
+        # Rewind remote head to trigger rejection.
+        # index must be false as remote is a bare repo.
         rhead = remote_repo.head
         remote_commit = rhead.commit
         rhead.reset("HEAD~2", index=False)
@@ -221,50 +223,50 @@ class TestRemote(TestBase):
         self.assertTrue(master_info.flags & FetchInfo.FORCED_UPDATE)
         self.assertIsNotNone(master_info.note)
 
-        # normal fast forward - set head back to previous one
+        # Normal fast forward - set head back to previous one.
         rhead.commit = remote_commit
         res = fetch_and_test(remote)
         self.assertTrue(res[mkey].flags & FetchInfo.FAST_FORWARD)
 
-        # new remote branch
+        # New remote branch.
         new_remote_branch = Head.create(remote_repo, "new_branch")
         res = fetch_and_test(remote)
         new_branch_info = get_info(res, remote, new_remote_branch)
         self.assertTrue(new_branch_info.flags & FetchInfo.NEW_HEAD)
 
-        # remote branch rename ( causes creation of a new one locally )
+        # Remote branch rename (causes creation of a new one locally).
         new_remote_branch.rename("other_branch_name")
         res = fetch_and_test(remote)
         other_branch_info = get_info(res, remote, new_remote_branch)
         self.assertEqual(other_branch_info.ref.commit, new_branch_info.ref.commit)
 
-        # remove new branch
+        # Remove new branch.
         Head.delete(new_remote_branch.repo, new_remote_branch)
         res = fetch_and_test(remote)
-        # deleted remote will not be fetched
+        # Deleted remote will not be fetched.
         self.assertRaises(IndexError, get_info, res, remote, new_remote_branch)
 
-        # prune stale tracking branches
+        # Prune stale tracking branches.
         stale_refs = remote.stale_refs
         self.assertEqual(len(stale_refs), 2)
         self.assertIsInstance(stale_refs[0], RemoteReference)
         RemoteReference.delete(rw_repo, *stale_refs)
 
-        # test single branch fetch with refspec including target remote
+        # Test single branch fetch with refspec including target remote.
         res = fetch_and_test(remote, refspec="master:refs/remotes/%s/master" % remote)
         self.assertEqual(len(res), 1)
         self.assertTrue(get_info(res, remote, "master"))
 
-        # ... with respec and no target
+        # ...with respec and no target.
         res = fetch_and_test(remote, refspec="master")
         self.assertEqual(len(res), 1)
 
-        # ... multiple refspecs ... works, but git command returns with error if one ref is wrong without
-        # doing anything. This is new in  later binaries
+        # ...multiple refspecs...works, but git command returns with error if one ref is
+        # wrong without doing anything. This is new in later binaries.
         # res = fetch_and_test(remote, refspec=['master', 'fred'])
         # self.assertEqual(len(res), 1)
 
-        # add new tag reference
+        # Add new tag reference.
         rtag = TagReference.create(remote_repo, "1.0-RV_hello.there")
         res = fetch_and_test(remote, tags=True)
         tinfo = res[str(rtag)]
@@ -272,10 +274,10 @@ class TestRemote(TestBase):
         self.assertEqual(tinfo.ref.commit, rtag.commit)
         self.assertTrue(tinfo.flags & tinfo.NEW_TAG)
 
-        # adjust the local tag commit
+        # Adjust the local tag commit.
         Reference.set_object(rtag, rhead.commit.parents[0].parents[0])
 
-        # as of git 2.20 one cannot clobber local tags that have changed without
+        # As of git 2.20 one cannot clobber local tags that have changed without
         # specifying --force, and the test assumes you can clobber, so...
         force = None
         if rw_repo.git.version_info[:2] >= (2, 20):
@@ -285,63 +287,63 @@ class TestRemote(TestBase):
         self.assertEqual(tinfo.commit, rtag.commit)
         self.assertTrue(tinfo.flags & tinfo.TAG_UPDATE)
 
-        # delete remote tag - local one will stay
+        # Delete remote tag - local one will stay.
         TagReference.delete(remote_repo, rtag)
         res = fetch_and_test(remote, tags=True)
         self.assertRaises(IndexError, get_info, res, remote, str(rtag))
 
-        # provoke to receive actual objects to see what kind of output we have to
-        # expect. For that we need a remote transport protocol
+        # Provoke to receive actual objects to see what kind of output we have to
+        # expect. For that we need a remote transport protocol.
         # Create a new UN-shared repo and fetch into it after we pushed a change
-        # to the shared repo
+        # to the shared repo.
         other_repo_dir = tempfile.mktemp("other_repo")
-        # must clone with a local path for the repo implementation not to freak out
-        # as it wants local paths only ( which I can understand )
+        # Must clone with a local path for the repo implementation not to freak out
+        # as it wants local paths only (which I can understand).
         other_repo = remote_repo.clone(other_repo_dir, shared=False)
         remote_repo_url = osp.basename(remote_repo.git_dir)  # git-daemon runs with appropriate `--base-path`.
         remote_repo_url = Git.polish_url("git://localhost:%s/%s" % (GIT_DAEMON_PORT, remote_repo_url))
 
-        # put origin to git-url
+        # Put origin to git-url.
         other_origin = other_repo.remotes.origin
         with other_origin.config_writer as cw:
             cw.set("url", remote_repo_url)
-        # it automatically creates alternates as remote_repo is shared as well.
-        # It will use the transport though and ignore alternates when fetching
+        # It automatically creates alternates as remote_repo is shared as well.
+        # It will use the transport though and ignore alternates when fetching.
         # assert not other_repo.alternates  # this would fail
 
-        # assure we are in the right state
+        # Ensure we are in the right state.
         rw_repo.head.reset(remote.refs.master, working_tree=True)
         try:
             self._commit_random_file(rw_repo)
             remote.push(rw_repo.head.reference)
 
-            # here I would expect to see remote-information about packing
+            # Here I would expect to see remote-information about packing
             # objects and so on. Unfortunately, this does not happen
             # if we are redirecting the output - git explicitly checks for this
-            # and only provides progress information to ttys
+            # and only provides progress information to ttys.
             res = fetch_and_test(other_origin)
         finally:
             rmtree(other_repo_dir)
         # END test and cleanup
 
     def _assert_push_and_pull(self, remote, rw_repo, remote_repo):
-        # push our changes
+        # Push our changes.
         lhead = rw_repo.head
-        # assure we are on master and it is checked out where the remote is
+        # Ensure we are on master and it is checked out where the remote is.
         try:
             lhead.reference = rw_repo.heads.master
         except AttributeError:
-            # if the author is on a non-master branch, the clones might not have
-            # a local master yet. We simply create it
+            # If the author is on a non-master branch, the clones might not have
+            # a local master yet. We simply create it.
             lhead.reference = rw_repo.create_head("master")
         # END master handling
         lhead.reset(remote.refs.master, working_tree=True)
 
-        # push without spec should fail ( without further configuration )
+        # Push without spec should fail (without further configuration)
         # well, works nicely
         # self.assertRaises(GitCommandError, remote.push)
 
-        # simple file push
+        # Simple file push.
         self._commit_random_file(rw_repo)
         progress = TestRemoteProgress()
         res = remote.push(lhead.reference, progress)
@@ -349,23 +351,23 @@ class TestRemote(TestBase):
         self._do_test_push_result(res, remote)
         progress.make_assertion()
 
-        # rejected - undo last commit
+        # Rejected - undo last commit.
         lhead.reset("HEAD~1")
         res = remote.push(lhead.reference)
         self.assertTrue(res[0].flags & PushInfo.ERROR)
         self.assertTrue(res[0].flags & PushInfo.REJECTED)
         self._do_test_push_result(res, remote)
 
-        # force rejected pull
+        # Force rejected pull.
         res = remote.push("+%s" % lhead.reference)
         self.assertEqual(res[0].flags & PushInfo.ERROR, 0)
         self.assertTrue(res[0].flags & PushInfo.FORCED_UPDATE)
         self._do_test_push_result(res, remote)
 
-        # invalid refspec
+        # Invalid refspec.
         self.assertRaises(GitCommandError, remote.push, "hellothere")
 
-        # push new tags
+        # Push new tags.
         progress = TestRemoteProgress()
         to_be_updated = "my_tag.1.0RV"
         new_tag = TagReference.create(rw_repo, to_be_updated)  # @UnusedVariable
@@ -375,28 +377,28 @@ class TestRemote(TestBase):
         progress.make_assertion()
         self._do_test_push_result(res, remote)
 
-        # update push new tags
-        # Rejection is default
+        # Update push new tags.
+        # Rejection is default.
         new_tag = TagReference.create(rw_repo, to_be_updated, reference="HEAD~1", force=True)
         res = remote.push(tags=True)
         self._do_test_push_result(res, remote)
         self.assertTrue(res[-1].flags & PushInfo.REJECTED)
         self.assertTrue(res[-1].flags & PushInfo.ERROR)
 
-        # push force this tag
+        # Force push this tag.
         res = remote.push("+%s" % new_tag.path)
         self.assertEqual(res[-1].flags & PushInfo.ERROR, 0)
         self.assertTrue(res[-1].flags & PushInfo.FORCED_UPDATE)
 
-        # delete tag - have to do it using refspec
+        # Delete tag - have to do it using refspec.
         res = remote.push(":%s" % new_tag.path)
         self._do_test_push_result(res, remote)
         self.assertTrue(res[0].flags & PushInfo.DELETED)
         # Currently progress is not properly transferred, especially not using
-        # the git daemon
+        # the git daemon.
         # progress.assert_received_message()
 
-        # push new branch
+        # Push new branch.
         new_head = Head.create(rw_repo, "my_new_branch")
         progress = TestRemoteProgress()
         res = remote.push(new_head, progress)
@@ -405,7 +407,7 @@ class TestRemote(TestBase):
         progress.make_assertion()
         self._do_test_push_result(res, remote)
 
-        # rejected stale delete
+        # Rejected stale delete.
         force_with_lease = "%s:0000000000000000000000000000000000000000" % new_head.path
         res = remote.push(":%s" % new_head.path, force_with_lease=force_with_lease)
         self.assertTrue(res[0].flags & PushInfo.ERROR)
@@ -413,7 +415,7 @@ class TestRemote(TestBase):
         self.assertIsNone(res[0].local_ref)
         self._do_test_push_result(res, remote)
 
-        # delete new branch on the remote end and locally
+        # Delete new branch on the remote end and locally.
         res = remote.push(":%s" % new_head.path)
         self._do_test_push_result(res, remote)
         Head.delete(rw_repo, new_head)
@@ -425,8 +427,8 @@ class TestRemote(TestBase):
 
         remote.pull("master", kill_after_timeout=10.0)
 
-        # cleanup - delete created tags and branches as we are in an innerloop on
-        # the same repository
+        # Cleanup - delete created tags and branches as we are in an inner loop on
+        # the same repository.
         TagReference.delete(rw_repo, new_tag, other_tag)
         remote.push(":%s" % other_tag.path, kill_after_timeout=10.0)
 
@@ -442,7 +444,7 @@ class TestRemote(TestBase):
             self.assertEqual(remote, remote)
             self.assertNotEqual(str(remote), repr(remote))
             remote_set.add(remote)
-            remote_set.add(remote)  # should already exist
+            remote_set.add(remote)  # Should already exist.
             # REFS
             refs = remote.refs
             self.assertTrue(refs)
@@ -452,17 +454,17 @@ class TestRemote(TestBase):
             # END for each ref
 
             # OPTIONS
-            # cannot use 'fetch' key anymore as it is now a method
+            # Cannot use 'fetch' key anymore as it is now a method.
             for opt in ("url",):
                 val = getattr(remote, opt)
                 reader = remote.config_reader
                 assert reader.get(opt) == val
                 assert reader.get_value(opt, None) == val
 
-                # unable to write with a reader
+                # Unable to write with a reader.
                 self.assertRaises(IOError, reader.set, opt, "test")
 
-                # change value
+                # Change value.
                 with remote.config_writer as writer:
                     new_val = "myval"
                     writer.set(opt, new_val)
@@ -477,7 +479,7 @@ class TestRemote(TestBase):
             prev_name = remote.name
             self.assertEqual(remote.rename(other_name), remote)
             self.assertNotEqual(prev_name, remote.name)
-            # multiple times
+            # Multiple times.
             for _ in range(2):
                 self.assertEqual(remote.rename(prev_name).name, prev_name)
             # END for each rename ( back to prev_name )
@@ -487,7 +489,7 @@ class TestRemote(TestBase):
 
             # FETCH TESTING
             # Only for remotes - local cases are the same or less complicated
-            # as additional progress information will never be emitted
+            # as additional progress information will never be emitted.
             if remote.name == "daemon_origin":
                 self._do_test_fetch(remote, rw_repo, remote_repo, kill_after_timeout=10.0)
                 ran_fetch_test = True
@@ -503,10 +505,10 @@ class TestRemote(TestBase):
         origin = rw_repo.remote("origin")
         assert origin == rw_repo.remotes.origin
 
-        # Verify we can handle prunes when fetching
+        # Verify we can handle prunes when fetching.
         # stderr lines look like this:  x [deleted]         (none)     -> origin/experiment-2012
-        # These should just be skipped
-        # If we don't have a manual checkout, we can't actually assume there are any non-master branches
+        # These should just be skipped.
+        # If we don't have a manual checkout, we can't actually assume there are any non-master branches.
         remote_repo.create_head("myone_for_deletion")
         # Get the branch - to be pruned later
         origin.fetch()
@@ -534,13 +536,13 @@ class TestRemote(TestBase):
         self.assertIn(remote, bare_rw_repo.remotes)
         self.assertTrue(remote.exists())
 
-        # create same one again
+        # Create same one again.
         self.assertRaises(GitCommandError, Remote.create, bare_rw_repo, *arg_list)
 
         Remote.remove(bare_rw_repo, new_name)
-        self.assertTrue(remote.exists())  # We still have a cache that doesn't know we were deleted by name
+        self.assertTrue(remote.exists())  # We still have a cache that doesn't know we were deleted by name.
         remote._clear_cache()
-        assert not remote.exists()  # Cache should be renewed now. This is an issue ...
+        assert not remote.exists()  # Cache should be renewed now. This is an issue...
 
         for remote in bare_rw_repo.remotes:
             if remote.name == new_name:
@@ -548,11 +550,11 @@ class TestRemote(TestBase):
             # END if deleted remote matches existing remote's name
         # END for each remote
 
-        # Issue #262 - the next call would fail if bug wasn't fixed
+        # Issue #262 - the next call would fail if bug wasn't fixed.
         bare_rw_repo.create_remote("bogus", "/bogus/path", mirror="push")
 
     def test_fetch_info(self):
-        # assure we can handle remote-tracking branches
+        # Ensure we can handle remote-tracking branches.
         fetch_info_line_fmt = "c437ee5deb8d00cf02f03720693e4c802e99f390	not-for-merge	%s '0.3' of "
         fetch_info_line_fmt += "git://github.com/gitpython-developers/GitPython"
         remote_info_line_fmt = "* [new branch]      nomatter     -> %s"
@@ -573,8 +575,8 @@ class TestRemote(TestBase):
         assert not fi.ref.is_valid()
         self.assertEqual(fi.ref.name, "local/master")
 
-        # handles non-default refspecs: One can specify a different path in refs/remotes
-        # or a special path just in refs/something for instance
+        # Handles non-default refspecs: One can specify a different path in refs/remotes
+        # or a special path just in refs/something for instance.
 
         fi = FetchInfo._from_line(
             self.rorepo,
@@ -585,7 +587,7 @@ class TestRemote(TestBase):
         self.assertIsInstance(fi.ref, TagReference)
         assert fi.ref.path.startswith("refs/tags"), fi.ref.path
 
-        # it could be in a remote direcftory though
+        # It could be in a remote directory though.
         fi = FetchInfo._from_line(
             self.rorepo,
             remote_info_line_fmt % "remotename/tags/tagname",
@@ -595,14 +597,14 @@ class TestRemote(TestBase):
         self.assertIsInstance(fi.ref, TagReference)
         assert fi.ref.path.startswith("refs/remotes/"), fi.ref.path
 
-        # it can also be anywhere !
+        # It can also be anywhere!
         tag_path = "refs/something/remotename/tags/tagname"
         fi = FetchInfo._from_line(self.rorepo, remote_info_line_fmt % tag_path, fetch_info_line_fmt % "tag")
 
         self.assertIsInstance(fi.ref, TagReference)
         self.assertEqual(fi.ref.path, tag_path)
 
-        # branches default to refs/remotes
+        # Branches default to refs/remotes.
         fi = FetchInfo._from_line(
             self.rorepo,
             remote_info_line_fmt % "remotename/branch",
@@ -612,7 +614,7 @@ class TestRemote(TestBase):
         self.assertIsInstance(fi.ref, RemoteReference)
         self.assertEqual(fi.ref.remote_name, "remotename")
 
-        # but you can force it anywhere, in which case we only have a references
+        # But you can force it anywhere, in which case we only have a references.
         fi = FetchInfo._from_line(
             self.rorepo,
             remote_info_line_fmt % "refs/something/branch",
@@ -639,46 +641,46 @@ class TestRemote(TestBase):
 
     @with_rw_repo("HEAD", bare=False)
     def test_multiple_urls(self, rw_repo):
-        # test addresses
+        # Test addresses.
         test1 = "https://github.com/gitpython-developers/GitPython"
         test2 = "https://github.com/gitpython-developers/gitdb"
         test3 = "https://github.com/gitpython-developers/smmap"
 
         remote = rw_repo.remotes[0]
-        # Testing setting a single URL
+        # Test setting a single URL.
         remote.set_url(test1)
         self.assertEqual(list(remote.urls), [test1])
 
-        # Testing replacing that single URL
+        # Test replacing that single URL.
         remote.set_url(test1)
         self.assertEqual(list(remote.urls), [test1])
-        # Testing adding new URLs
+        # Test adding new URLs.
         remote.set_url(test2, add=True)
         self.assertEqual(list(remote.urls), [test1, test2])
         remote.set_url(test3, add=True)
         self.assertEqual(list(remote.urls), [test1, test2, test3])
-        # Testing removing an URL
+        # Test removing a URL.
         remote.set_url(test2, delete=True)
         self.assertEqual(list(remote.urls), [test1, test3])
-        # Testing changing an URL
+        # Test changing a URL.
         remote.set_url(test2, test3)
         self.assertEqual(list(remote.urls), [test1, test2])
 
         # will raise: fatal: --add --delete doesn't make sense
         self.assertRaises(GitCommandError, remote.set_url, test2, add=True, delete=True)
 
-        # Testing on another remote, with the add/delete URL
+        # Test on another remote, with the add/delete URL.
         remote = rw_repo.create_remote("another", url=test1)
         remote.add_url(test2)
         self.assertEqual(list(remote.urls), [test1, test2])
         remote.add_url(test3)
         self.assertEqual(list(remote.urls), [test1, test2, test3])
-        # Testing removing all the URLs
+        # Test removing all the URLs.
         remote.delete_url(test2)
         self.assertEqual(list(remote.urls), [test1, test3])
         remote.delete_url(test1)
         self.assertEqual(list(remote.urls), [test3])
-        # will raise fatal: Will not delete all non-push URLs
+        # Will raise fatal: Will not delete all non-push URLs.
         self.assertRaises(GitCommandError, remote.delete_url, test3)
 
     def test_fetch_error(self):
@@ -972,14 +974,13 @@ class TestRemote(TestBase):
 class TestTimeouts(TestBase):
     @with_rw_repo("HEAD", bare=False)
     def test_timeout_funcs(self, repo):
-        # Force error code to prevent a race condition if the python thread is
-        # slow
+        # Force error code to prevent a race condition if the python thread is slow.
         default = Git.AutoInterrupt._status_code_if_terminate
         Git.AutoInterrupt._status_code_if_terminate = -15
-        for function in ["pull", "fetch"]:  # can't get push to timeout
+        for function in ["pull", "fetch"]:  # Can't get push to time out.
             f = getattr(repo.remotes.origin, function)
-            assert f is not None  # Make sure these functions exist
-            _ = f()  # Make sure the function runs
+            assert f is not None  # Make sure these functions exist.
+            _ = f()  # Make sure the function runs.
             with pytest.raises(GitCommandError, match="kill_after_timeout=0 s"):
                 f(kill_after_timeout=0)
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -790,7 +790,7 @@ class TestRepo(TestBase):
 
             repo_add(untracked_files)
             self.assertEqual(len(rwrepo.untracked_files), (num_recently_untracked - len(files)))
-        # end for each run
+        # END for each run
 
     def test_config_reader(self):
         reader = self.rorepo.config_reader()  # All config files.
@@ -1165,8 +1165,8 @@ class TestRepo(TestBase):
             for repo_type in (GitCmdObjectDB, GitDB):
                 repo = Repo(self.rorepo.working_tree_dir, odbt=repo_type)
                 last_commit(repo, "master", "test/test_base.py")
-            # end for each repository type
-        # end for each iteration
+            # END for each repository type
+        # END for each iteration
 
     def test_remote_method(self):
         self.assertRaises(ValueError, self.rorepo.remote, "foo-blue")
@@ -1227,7 +1227,7 @@ class TestRepo(TestBase):
             res = repo.merge_base(c1, c2, c3, **{kw: True})
             self.assertIsInstance(res, list)
             self.assertEqual(len(res), 1)
-        # end for each keyword signalling all merge-bases to be returned
+        # END for each keyword signalling all merge-bases to be returned
 
         # Test for no merge base - can't do as we have.
         self.assertRaises(GitCommandError, repo.merge_base, c1, "ffffff")

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # test_repo.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -4,6 +4,7 @@
 #
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import glob
 import io
 from io import BytesIO
@@ -163,28 +164,29 @@ class TestRepo(TestBase):
         self.assertEqual(num_trees, mc)
 
     def _assert_empty_repo(self, repo):
-        # test all kinds of things with an empty, freshly initialized repo.
-        # It should throw good errors
+        """Test all kinds of things with an empty, freshly initialized repo.
 
-        # entries should be empty
+        It should throw good errors.
+        """
+        # Entries should be empty.
         self.assertEqual(len(repo.index.entries), 0)
 
-        # head is accessible
+        # head is accessible.
         assert repo.head
         assert repo.head.ref
         assert not repo.head.is_valid()
 
-        # we can change the head to some other ref
+        # We can change the head to some other ref.
         head_ref = Head.from_path(repo, Head.to_full_path("some_head"))
         assert not head_ref.is_valid()
         repo.head.ref = head_ref
 
-        # is_dirty can handle all kwargs
+        # is_dirty can handle all kwargs.
         for args in ((1, 0, 0), (0, 1, 0), (0, 0, 1)):
             assert not repo.is_dirty(*args)
         # END for each arg
 
-        # we can add a file to the index ( if we are not bare )
+        # We can add a file to the index (if we are not bare).
         if not repo.bare:
             pass
         # END test repos with working tree
@@ -201,7 +203,7 @@ class TestRepo(TestBase):
     @with_rw_directory
     def test_date_format(self, rw_dir):
         repo = Repo.init(osp.join(rw_dir, "repo"))
-        # @-timestamp is the format used by git commit hooks
+        # @-timestamp is the format used by git commit hooks.
         repo.index.commit("Commit messages", commit_date="@1400000000 +0000")
 
     @with_rw_directory
@@ -262,7 +264,7 @@ class TestRepo(TestBase):
             )
         except GitCommandError as err:
             assert password not in str(err), "The error message '%s' should not contain the password" % err
-        # Working example from a blank private project
+        # Working example from a blank private project.
         Repo.clone_from(
             url="https://gitlab+deploy-token-392045:mLWhVus7bjLsy8xj8q2V@gitlab.com/mercierm/test_git_python",
             to_path=rw_dir,
@@ -514,12 +516,12 @@ class TestRepo(TestBase):
                 try:
                     rmtree(clone_path)
                 except OSError:
-                    # when relative paths are used, the clone may actually be inside
-                    # of the parent directory
+                    # When relative paths are used, the clone may actually be inside
+                    # of the parent directory.
                     pass
                 # END exception handling
 
-                # try again, this time with the absolute version
+                # Try again, this time with the absolute version.
                 rc = Repo.clone_from(r.git_dir, clone_path)
                 self._assert_empty_repo(rc)
 
@@ -527,8 +529,8 @@ class TestRepo(TestBase):
                 try:
                     rmtree(clone_path)
                 except OSError:
-                    # when relative paths are used, the clone may actually be inside
-                    # of the parent directory
+                    # When relative paths are used, the clone may actually be inside
+                    # of the parent directory.
                     pass
                 # END exception handling
 
@@ -675,11 +677,11 @@ class TestRepo(TestBase):
             lambda: c.message,
         )
 
-        # test the 'lines per commit' entries
+        # Test the 'lines per commit' entries.
         tlist = b[0][1]
         self.assertTrue(tlist)
         self.assertTrue(isinstance(tlist[0], str))
-        self.assertTrue(len(tlist) < sum(len(t) for t in tlist))  # test for single-char bug
+        self.assertTrue(len(tlist) < sum(len(t) for t in tlist))  # Test for single-char bug.
 
         # BINARY BLAME
         git.return_value = fixture("blame_binary")
@@ -688,7 +690,7 @@ class TestRepo(TestBase):
 
     def test_blame_real(self):
         c = 0
-        nml = 0  # amount of multi-lines per blame
+        nml = 0  # Amount of multi-lines per blame.
         for item in self.rorepo.head.commit.tree.traverse(
             predicate=lambda i, d: i.type == "blob" and i.path.endswith(".py")
         ):
@@ -702,14 +704,14 @@ class TestRepo(TestBase):
 
     @mock.patch.object(Git, "_call_process")
     def test_blame_incremental(self, git):
-        # loop over two fixtures, create a test fixture for 2.11.1+ syntax
+        # Loop over two fixtures, create a test fixture for 2.11.1+ syntax.
         for git_fixture in ("blame_incremental", "blame_incremental_2.11.1_plus"):
             git.return_value = fixture(git_fixture)
             blame_output = self.rorepo.blame_incremental("9debf6b0aafb6f7781ea9d1383c86939a1aacde3", "AUTHORS")
             blame_output = list(blame_output)
             self.assertEqual(len(blame_output), 5)
 
-            # Check all outputted line numbers
+            # Check all outputted line numbers.
             ranges = flatten([entry.linenos for entry in blame_output])
             self.assertEqual(
                 ranges,
@@ -727,13 +729,13 @@ class TestRepo(TestBase):
             commits = [entry.commit.hexsha[:7] for entry in blame_output]
             self.assertEqual(commits, ["82b8902", "82b8902", "c76852d", "c76852d", "c76852d"])
 
-            # Original filenames
+            # Original filenames.
             self.assertSequenceEqual(
                 [entry.orig_path for entry in blame_output],
                 ["AUTHORS"] * len(blame_output),
             )
 
-            # Original line numbers
+            # Original line numbers.
             orig_ranges = flatten([entry.orig_linenos for entry in blame_output])
             self.assertEqual(
                 orig_ranges,
@@ -780,7 +782,7 @@ class TestRepo(TestBase):
             untracked_files = rwrepo.untracked_files
             num_recently_untracked = len(untracked_files)
 
-            # assure we have all names - they are relative to the git-dir
+            # Ensure we have all names - they are relative to the git-dir.
             num_test_untracked = 0
             for utfile in untracked_files:
                 num_test_untracked += join_path_native(base, utfile) in files
@@ -791,9 +793,9 @@ class TestRepo(TestBase):
         # end for each run
 
     def test_config_reader(self):
-        reader = self.rorepo.config_reader()  # all config files
+        reader = self.rorepo.config_reader()  # All config files.
         assert reader.read_only
-        reader = self.rorepo.config_reader("repository")  # single config file
+        reader = self.rorepo.config_reader("repository")  # Single config file.
         assert reader.read_only
 
     def test_config_writer(self):
@@ -802,8 +804,8 @@ class TestRepo(TestBase):
                 with self.rorepo.config_writer(config_level) as writer:
                     self.assertFalse(writer.read_only)
             except IOError:
-                # its okay not to get a writer for some configuration files if we
-                # have no permissions
+                # It's okay not to get a writer for some configuration files if we
+                # have no permissions.
                 pass
 
     def test_config_level_paths(self):
@@ -811,8 +813,8 @@ class TestRepo(TestBase):
             assert self.rorepo._get_config_path(config_level)
 
     def test_creation_deletion(self):
-        # just a very quick test to assure it generally works. There are
-        # specialized cases in the test_refs module
+        # Just a very quick test to assure it generally works. There are
+        # specialized cases in the test_refs module.
         head = self.rorepo.create_head("new_head", "HEAD~1")
         self.rorepo.delete_head(head)
 
@@ -828,7 +830,7 @@ class TestRepo(TestBase):
             self.rorepo.delete_remote(remote)
 
     def test_comparison_and_hash(self):
-        # this is only a preliminary test, more testing done in test_index
+        # This is only a preliminary test, more testing done in test_index.
         self.assertEqual(self.rorepo, self.rorepo)
         self.assertFalse(self.rorepo != self.rorepo)
         self.assertEqual(len({self.rorepo, self.rorepo}), 1)
@@ -844,8 +846,8 @@ class TestRepo(TestBase):
             Repo.init(osp.join("$FOO", "test.git"), bare=True)
 
     def test_git_cmd(self):
-        # test CatFileContentStream, just to be very sure we have no fencepost errors
-        # last \n is the terminating newline that it expects
+        # Test CatFileContentStream, just to be very sure we have no fencepost errors.
+        # The last \n is the terminating newline that it expects.
         l1 = b"0123456789\n"
         l2 = b"abcdefghijklmnopqrstxy\n"
         l3 = b"z\n"
@@ -853,8 +855,8 @@ class TestRepo(TestBase):
 
         l1p = l1[:5]
 
-        # full size
-        # size is without terminating newline
+        # Full size.
+        # Size is without terminating newline.
         def mkfull():
             return Git.CatFileContentStream(len(d) - 1, BytesIO(d))
 
@@ -868,7 +870,7 @@ class TestRepo(TestBase):
         lines = s.readlines()
         self.assertEqual(len(lines), 3)
         self.assertTrue(lines[-1].endswith(b"\n"), lines[-1])
-        self.assertEqual(s._stream.tell(), len(d))  # must have scrubbed to the end
+        self.assertEqual(s._stream.tell(), len(d))  # Must have scrubbed to the end.
 
         # realines line limit
         s = mkfull()
@@ -911,7 +913,7 @@ class TestRepo(TestBase):
         s = mkfull()
         self.assertEqual(s.read(5), l1p)
         self.assertEqual(s.read(6), l1[5:])
-        self.assertEqual(s._stream.tell(), 5 + 6)  # its not yet done
+        self.assertEqual(s._stream.tell(), 5 + 6)  # It's not yet done.
 
         # read tiny
         s = mktiny()
@@ -926,7 +928,7 @@ class TestRepo(TestBase):
         if rev_obj.type == "tag":
             rev_obj = rev_obj.object
 
-        # tree and blob type
+        # Tree and blob type.
         obj = rev_parse(name + "^{tree}")
         self.assertEqual(obj, rev_obj.tree)
 
@@ -946,13 +948,13 @@ class TestRepo(TestBase):
             obj = orig_obj
         # END deref tags by default
 
-        # try history
+        # Try history
         rev = name + "~"
         obj2 = rev_parse(rev)
         self.assertEqual(obj2, obj.parents[0])
         self._assert_rev_parse_types(rev, obj2)
 
-        # history with number
+        # History with number
         ni = 11
         history = [obj.parents[0]]
         for _ in range(ni):
@@ -966,13 +968,13 @@ class TestRepo(TestBase):
             self._assert_rev_parse_types(rev, obj2)
         # END history check
 
-        # parent ( default )
+        # Parent (default)
         rev = name + "^"
         obj2 = rev_parse(rev)
         self.assertEqual(obj2, obj.parents[0])
         self._assert_rev_parse_types(rev, obj2)
 
-        # parent with number
+        # Parent with number
         for pn, parent in enumerate(obj.parents):
             rev = name + "^%i" % (pn + 1)
             self.assertEqual(rev_parse(rev), parent)
@@ -983,17 +985,17 @@ class TestRepo(TestBase):
 
     @with_rw_repo("HEAD", bare=False)
     def test_rw_rev_parse(self, rwrepo):
-        # verify it does not confuse branches with hexsha ids
+        # Verify it does not confuse branches with hexsha ids.
         ahead = rwrepo.create_head("aaaaaaaa")
         assert rwrepo.rev_parse(str(ahead)) == ahead.commit
 
     def test_rev_parse(self):
         rev_parse = self.rorepo.rev_parse
 
-        # try special case: This one failed at some point, make sure its fixed
+        # Try special case: This one failed at some point, make sure its fixed.
         self.assertEqual(rev_parse("33ebe").hexsha, "33ebe7acec14b25c5f84f35a664803fcab2f7781")
 
-        # start from reference
+        # Start from reference.
         num_resolved = 0
 
         for ref_no, ref in enumerate(Reference.iter_items(self.rorepo)):
@@ -1006,7 +1008,7 @@ class TestRepo(TestBase):
                     num_resolved += 1
                 except (BadName, BadObject):
                     print("failed on %s" % path_section)
-                    # is fine, in case we have something like 112, which belongs to remotes/rname/merge-requests/112
+                    # This is fine if we have something like 112, which belongs to remotes/rname/merge-requests/112.
                 # END exception handling
             # END for each token
             if ref_no == 3 - 1:
@@ -1014,21 +1016,21 @@ class TestRepo(TestBase):
         # END for each reference
         assert num_resolved
 
-        # it works with tags !
+        # It works with tags!
         tag = self._assert_rev_parse("0.1.4")
         self.assertEqual(tag.type, "tag")
 
-        # try full sha directly ( including type conversion )
+        # try full sha directly (including type conversion).
         self.assertEqual(tag.object, rev_parse(tag.object.hexsha))
         self._assert_rev_parse_types(tag.object.hexsha, tag.object)
 
-        # multiple tree types result in the same tree: HEAD^{tree}^{tree}:CHANGES
+        # Multiple tree types result in the same tree: HEAD^{tree}^{tree}:CHANGES
         rev = "0.1.4^{tree}^{tree}"
         self.assertEqual(rev_parse(rev), tag.object.tree)
         self.assertEqual(rev_parse(rev + ":CHANGES"), tag.object.tree["CHANGES"])
 
-        # try to get parents from first revision - it should fail as no such revision
-        # exists
+        # Try to get parents from first revision - it should fail as no such revision
+        # exists.
         first_rev = "33ebe7acec14b25c5f84f35a664803fcab2f7781"
         commit = rev_parse(first_rev)
         self.assertEqual(len(commit.parents), 0)
@@ -1036,14 +1038,14 @@ class TestRepo(TestBase):
         self.assertRaises(BadName, rev_parse, first_rev + "~")
         self.assertRaises(BadName, rev_parse, first_rev + "^")
 
-        # short SHA1
+        # Short SHA1.
         commit2 = rev_parse(first_rev[:20])
         self.assertEqual(commit2, commit)
         commit2 = rev_parse(first_rev[:5])
         self.assertEqual(commit2, commit)
 
-        # todo: dereference tag into a blob 0.1.7^{blob} - quite a special one
-        # needs a tag which points to a blob
+        # TODO: Dereference tag into a blob 0.1.7^{blob} - quite a special one.
+        # Needs a tag which points to a blob.
 
         # ref^0 returns commit being pointed to, same with ref~0, and ^{}
         tag = rev_parse("0.1.4")
@@ -1051,7 +1053,7 @@ class TestRepo(TestBase):
             self.assertEqual(tag.object, rev_parse("0.1.4%s" % token))
         # END handle multiple tokens
 
-        # try partial parsing
+        # Try partial parsing.
         max_items = 40
         for i, binsha in enumerate(self.rorepo.odb.sha_iter()):
             self.assertEqual(
@@ -1059,41 +1061,41 @@ class TestRepo(TestBase):
                 binsha,
             )
             if i > max_items:
-                # this is rather slow currently, as rev_parse returns an object
-                # which requires accessing packs, it has some additional overhead
+                # This is rather slow currently, as rev_parse returns an object that
+                # requires accessing packs, so it has some additional overhead.
                 break
         # END for each binsha in repo
 
-        # missing closing brace commit^{tree
+        # Missing closing brace: commit^{tree
         self.assertRaises(ValueError, rev_parse, "0.1.4^{tree")
 
-        # missing starting brace
+        # Missing starting brace.
         self.assertRaises(ValueError, rev_parse, "0.1.4^tree}")
 
         # REVLOG
         #######
         head = self.rorepo.head
 
-        # need to specify a ref when using the @ syntax
+        # Need to specify a ref when using the @ syntax.
         self.assertRaises(BadObject, rev_parse, "%s@{0}" % head.commit.hexsha)
 
-        # uses HEAD.ref by default
+        # Uses HEAD.ref by default.
         self.assertEqual(rev_parse("@{0}"), head.commit)
         if not head.is_detached:
             refspec = "%s@{0}" % head.ref.name
             self.assertEqual(rev_parse(refspec), head.ref.commit)
-            # all additional specs work as well
+            # All additional specs work as well.
             self.assertEqual(rev_parse(refspec + "^{tree}"), head.commit.tree)
             self.assertEqual(rev_parse(refspec + ":CHANGES").type, "blob")
         # END operate on non-detached head
 
-        # position doesn't exist
+        # Position doesn't exist.
         self.assertRaises(IndexError, rev_parse, "@{10000}")
 
-        # currently, nothing more is supported
+        # Currently, nothing more is supported.
         self.assertRaises(NotImplementedError, rev_parse, "@{1 week ago}")
 
-        # the last position
+        # The last position.
         assert rev_parse("@{1}") != head.commit
 
     def test_repo_odbtype(self):
@@ -1114,12 +1116,12 @@ class TestRepo(TestBase):
 
     @with_rw_repo("HEAD", bare=False)
     def test_submodule_update(self, rwrepo):
-        # fails in bare mode
+        # Fails in bare mode.
         rwrepo._bare = True
         self.assertRaises(InvalidGitRepositoryError, rwrepo.submodule_update)
         rwrepo._bare = False
 
-        # test create submodule
+        # Test submodule creation.
         sm = rwrepo.submodules[0]
         sm = rwrepo.create_submodule(
             "my_new_sub",
@@ -1128,7 +1130,7 @@ class TestRepo(TestBase):
         )
         self.assertIsInstance(sm, Submodule)
 
-        # note: the rest of this functionality is tested in test_submodule
+        # NOTE: the rest of this functionality is tested in test_submodule.
 
     @with_rw_repo("HEAD")
     def test_git_file(self, rwrepo):
@@ -1154,11 +1156,11 @@ class TestRepo(TestBase):
             commit = next(repo.iter_commits(rev, path, max_count=1))
             commit.tree[path]
 
-        # This is based on this comment
+        # This is based on this comment:
         # https://github.com/gitpython-developers/GitPython/issues/60#issuecomment-23558741
-        # And we expect to set max handles to a low value, like 64
+        # And we expect to set max handles to a low value, like 64.
         # You should set ulimit -n X, see .travis.yml
-        # The loops below would easily create 500 handles if these would leak (4 pipes + multiple mapped files)
+        # The loops below would easily create 500 handles if these would leak (4 pipes + multiple mapped files).
         for _ in range(64):
             for repo_type in (GitCmdObjectDB, GitDB):
                 repo = Repo(self.rorepo.working_tree_dir, odbt=repo_type)
@@ -1174,13 +1176,13 @@ class TestRepo(TestBase):
     def test_empty_repo(self, rw_dir):
         """Assure we can handle empty repositories"""
         r = Repo.init(rw_dir, mkdir=False)
-        # It's ok not to be able to iterate a commit, as there is none
+        # It's ok not to be able to iterate a commit, as there is none.
         self.assertRaises(ValueError, r.iter_commits)
         self.assertEqual(r.active_branch.name, "master")
         assert not r.active_branch.is_valid(), "Branch is yet to be born"
 
-        # actually, when trying to create a new branch without a commit, git itself fails
-        # We should, however, not fail ungracefully
+        # Actually, when trying to create a new branch without a commit, git itself fails.
+        # We should, however, not fail ungracefully.
         self.assertRaises(BadName, r.create_head, "foo")
         self.assertRaises(BadName, r.create_head, "master")
         # It's expected to not be able to access a tree
@@ -1191,7 +1193,7 @@ class TestRepo(TestBase):
         r.index.add([new_file_path])
         r.index.commit("initial commit\nBAD MESSAGE 1\n")
 
-        # Now a branch should be creatable
+        # Now a branch should be creatable.
         nb = r.create_head("foo")
         assert nb.is_valid()
 
@@ -1214,7 +1216,7 @@ class TestRepo(TestBase):
         self.assertRaises(ValueError, repo.merge_base)
         self.assertRaises(ValueError, repo.merge_base, "foo")
 
-        # two commit merge-base
+        # Two commit merge-base.
         res = repo.merge_base(c1, c2)
         self.assertIsInstance(res, list)
         self.assertEqual(len(res), 1)
@@ -1227,7 +1229,7 @@ class TestRepo(TestBase):
             self.assertEqual(len(res), 1)
         # end for each keyword signalling all merge-bases to be returned
 
-        # Test for no merge base - can't do as we have
+        # Test for no merge base - can't do as we have.
         self.assertRaises(GitCommandError, repo.merge_base, c1, "ffffff")
 
     def test_is_ancestor(self):
@@ -1254,22 +1256,22 @@ class TestRepo(TestBase):
         tree_sha = "960b40fe36"
         tag_sha = "42c2f60c43"
 
-        # Check for valid objects
+        # Check for valid objects.
         self.assertTrue(repo.is_valid_object(commit_sha))
         self.assertTrue(repo.is_valid_object(blob_sha))
         self.assertTrue(repo.is_valid_object(tree_sha))
         self.assertTrue(repo.is_valid_object(tag_sha))
 
-        # Check for valid objects of specific type
+        # Check for valid objects of specific type.
         self.assertTrue(repo.is_valid_object(commit_sha, "commit"))
         self.assertTrue(repo.is_valid_object(blob_sha, "blob"))
         self.assertTrue(repo.is_valid_object(tree_sha, "tree"))
         self.assertTrue(repo.is_valid_object(tag_sha, "tag"))
 
-        # Check for invalid objects
+        # Check for invalid objects.
         self.assertFalse(repo.is_valid_object(b"1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a", "blob"))
 
-        # Check for invalid objects of specific type
+        # Check for invalid objects of specific type.
         self.assertFalse(repo.is_valid_object(commit_sha, "blob"))
         self.assertFalse(repo.is_valid_object(blob_sha, "commit"))
         self.assertFalse(repo.is_valid_object(tree_sha, "commit"))
@@ -1290,16 +1292,16 @@ class TestRepo(TestBase):
             worktree_path = cygpath(worktree_path)
         rw_master.git.worktree("add", worktree_path, branch.name)
 
-        # this ensures that we can read the repo's gitdir correctly
+        # This ensures that we can read the repo's gitdir correctly.
         repo = Repo(worktree_path)
         self.assertIsInstance(repo, Repo)
 
-        # this ensures we're able to actually read the refs in the tree, which
+        # This ensures we're able to actually read the refs in the tree, which
         # means we can read commondir correctly.
         commit = repo.head.commit
         self.assertIsInstance(commit, Object)
 
-        # this ensures we can read the remotes, which confirms we're reading
+        # This ensures we can read the remotes, which confirms we're reading
         # the config correctly.
         origin = repo.remotes.origin
         self.assertIsInstance(origin, Remote)
@@ -1308,11 +1310,11 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     def test_git_work_tree_env(self, rw_dir):
-        """Check that we yield to GIT_WORK_TREE"""
-        # clone a repo
-        # move .git directory to a subdirectory
-        # set GIT_DIR and GIT_WORK_TREE appropriately
-        # check that repo.working_tree_dir == rw_dir
+        """Check that we yield to GIT_WORK_TREE."""
+        # Clone a repo.
+        # Move .git directory to a subdirectory.
+        # Set GIT_DIR and GIT_WORK_TREE appropriately.
+        # Check that: repo.working_tree_dir == rw_dir
 
         self.rorepo.clone(join_path_native(rw_dir, "master_repo"))
 
@@ -1376,7 +1378,7 @@ class TestRepo(TestBase):
             rw_repo.clone(payload)
 
             assert not unexpected_file.exists()
-            # A repo was cloned with the payload as name
+            # A repo was cloned with the payload as name.
             assert pathlib.Path(payload).exists()
 
     @with_rw_repo("HEAD")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -704,7 +704,7 @@ class TestSubmodule(TestBase):
             sm = rwrepo.create_submodule(sm_name, sm_path, rwrepo.git_dir, no_checkout=True)
             assert sm.exists() and sm.module_exists()
             rwrepo.index.commit("Added submodule " + sm_name)
-        # end for each submodule path to add
+        # END for each submodule path to add
 
         self.assertRaises(ValueError, rwrepo.create_submodule, "fail", osp.expanduser("~"))
         self.assertRaises(
@@ -731,7 +731,7 @@ class TestSubmodule(TestBase):
                 url=empty_repo_dir,
                 no_checkout=checkout_mode and True or False,
             )
-        # end for each checkout mode
+        # END for each checkout mode
 
     @with_rw_directory
     @_patch_git_config("protocol.file.allow", "always")
@@ -783,8 +783,8 @@ class TestSubmodule(TestBase):
             for init in (False, True):
                 sm.update(init=init)
                 sm2.update(init=init)
-            # end for each init state
-        # end for each iteration
+            # END for each init state
+        # END for each iteration
 
         sm.move(sm.path + "_moved")
         sm2.move(sm2.path + "_moved")
@@ -839,7 +839,7 @@ class TestSubmodule(TestBase):
             assert sm.exists() == value
             assert sm.module_exists() == value
 
-        # end
+        # END def assert_exists
 
         # As git is backwards compatible itself, it would still recognize what we do here... unless we really
         # muss it up. That's the only reason why the test is still here...
@@ -854,7 +854,7 @@ class TestSubmodule(TestBase):
             assert osp.isfile(module_repo_path)
             assert sm.module().has_separate_working_tree()
             assert find_submodule_git_dir(module_repo_path) is not None, "module pointed to by .git file must be valid"
-        # end verify submodule 'style'
+        # END verify submodule 'style'
 
         # Test move.
         new_sm_path = join_path_native("submodules", "one")
@@ -911,7 +911,7 @@ class TestSubmodule(TestBase):
             sm.remove(dry_run=dry_run, force=True)
             assert_exists(sm, value=dry_run)
             assert osp.isdir(sm_module_path) == dry_run
-        # end for each dry-run mode
+        # END for each dry-run mode
 
     @with_rw_directory
     def test_ignore_non_submodule_file(self, rwdir):
@@ -974,7 +974,6 @@ class TestSubmodule(TestBase):
         sm_mod = sm.module()
         if osp.isfile(osp.join(sm_mod.working_tree_dir, ".git")) == sm._need_gitfile_submodules(parent.git):
             assert sm_mod.git_dir.endswith(join_path_native(".git", "modules", new_sm_name))
-        # end
 
     @with_rw_directory
     def test_branch_renames(self, rw_dir):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1044,7 +1044,7 @@ class TestSubmodule(TestBase):
 
     @skipUnless(is_win, "Specifically for Windows.")
     def test_to_relative_path_with_super_at_root_drive(self):
-        class Repo(object):
+        class Repo:
             working_tree_dir = "D:\\"
 
         super_repo = Repo()

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
+
 import contextlib
 import os
 import shutil
@@ -74,48 +75,48 @@ class TestSubmodule(TestBase):
 
     def _do_base_tests(self, rwrepo):
         """Perform all tests in the given repository, it may be bare or nonbare"""
-        # manual instantiation
+        # Manual instantiation.
         smm = Submodule(rwrepo, "\0" * 20)
-        # name needs to be set in advance
+        # Name needs to be set in advance.
         self.assertRaises(AttributeError, getattr, smm, "name")
 
-        # iterate - 1 submodule
+        # Iterate - 1 submodule.
         sms = Submodule.list_items(rwrepo, self.k_subm_current)
         assert len(sms) == 1
         sm = sms[0]
 
-        # at a different time, there is None
+        # At a different time, there is None.
         assert len(Submodule.list_items(rwrepo, self.k_no_subm_tag)) == 0
 
         assert sm.path == "git/ext/gitdb"
-        assert sm.path != sm.name  # in our case, we have ids there, which don't equal the path
+        assert sm.path != sm.name  # In our case, we have ids there, which don't equal the path.
         assert sm.url.endswith("github.com/gitpython-developers/gitdb.git")
         assert sm.branch_path == "refs/heads/master"  # the default ...
         assert sm.branch_name == "master"
         assert sm.parent_commit == rwrepo.head.commit
-        # size is always 0
+        # Size is always 0.
         assert sm.size == 0
-        # the module is not checked-out yet
+        # The module is not checked-out yet.
         self.assertRaises(InvalidGitRepositoryError, sm.module)
 
-        # which is why we can't get the branch either - it points into the module() repository
+        # ...which is why we can't get the branch either - it points into the module() repository.
         self.assertRaises(InvalidGitRepositoryError, getattr, sm, "branch")
 
-        # branch_path works, as its just a string
+        # branch_path works, as it's just a string.
         assert isinstance(sm.branch_path, str)
 
-        # some commits earlier we still have a submodule, but its at a different commit
+        # Some commits earlier we still have a submodule, but it's at a different commit.
         smold = next(Submodule.iter_items(rwrepo, self.k_subm_changed))
         assert smold.binsha != sm.binsha
         assert smold != sm  # the name changed
 
-        # force it to reread its information
+        # Force it to reread its information.
         del smold._url
         smold.url == sm.url  # noqa: B015  # FIXME: Should this be an assertion?
 
-        # test config_reader/writer methods
+        # Test config_reader/writer methods.
         sm.config_reader()
-        new_smclone_path = None  # keep custom paths for later
+        new_smclone_path = None  # Keep custom paths for later.
         new_csmclone_path = None  #
         if rwrepo.bare:
             with self.assertRaises(InvalidGitRepositoryError):
@@ -123,7 +124,7 @@ class TestSubmodule(TestBase):
                     pass
         else:
             with sm.config_writer() as writer:
-                # for faster checkout, set the url to the local path
+                # For faster checkout, set the url to the local path.
                 new_smclone_path = Git.polish_url(osp.join(self.rorepo.working_tree_dir, sm.path))
                 writer.set_value("url", new_smclone_path)
                 writer.release()
@@ -132,76 +133,76 @@ class TestSubmodule(TestBase):
         # END handle bare repo
         smold.config_reader()
 
-        # cannot get a writer on historical submodules
+        # Cannot get a writer on historical submodules.
         if not rwrepo.bare:
             with self.assertRaises(ValueError):
                 with smold.config_writer():
                     pass
         # END handle bare repo
 
-        # make the old into a new - this doesn't work as the name changed
+        # Make the old into a new - this doesn't work as the name changed.
         self.assertRaises(ValueError, smold.set_parent_commit, self.k_subm_current)
         # the sha is properly updated
         smold.set_parent_commit(self.k_subm_changed + "~1")
         assert smold.binsha != sm.binsha
 
-        # raises if the sm didn't exist in new parent - it keeps its
-        # parent_commit unchanged
+        # Raises if the sm didn't exist in new parent - it keeps its
+        # parent_commit unchanged.
         self.assertRaises(ValueError, smold.set_parent_commit, self.k_no_subm_tag)
 
-        # TEST TODO: if a path in the gitmodules file, but not in the index, it raises
+        # TEST TODO: If a path is in the .gitmodules file, but not in the index, it raises.
 
         # TEST UPDATE
         ##############
-        # module retrieval is not always possible
+        # Module retrieval is not always possible.
         if rwrepo.bare:
             self.assertRaises(InvalidGitRepositoryError, sm.module)
             self.assertRaises(InvalidGitRepositoryError, sm.remove)
             self.assertRaises(InvalidGitRepositoryError, sm.add, rwrepo, "here", "there")
         else:
-            # its not checked out in our case
+            # It's not checked out in our case.
             self.assertRaises(InvalidGitRepositoryError, sm.module)
             assert not sm.module_exists()
 
-            # currently there is only one submodule
+            # Currently there is only one submodule.
             assert len(list(rwrepo.iter_submodules())) == 1
             assert sm.binsha != "\0" * 20
 
             # TEST ADD
             ###########
-            # preliminary tests
-            # adding existing returns exactly the existing
+            # Preliminary tests.
+            # Adding existing returns exactly the existing.
             sma = Submodule.add(rwrepo, sm.name, sm.path)
             assert sma.path == sm.path
 
-            # no url and no module at path fails
+            # No url and no module at path fails.
             self.assertRaises(ValueError, Submodule.add, rwrepo, "newsubm", "pathtorepo", url=None)
 
             # CONTINUE UPDATE
             #################
 
-            # lets update it - its a recursive one too
+            # Let's update it - it's a recursive one too.
             newdir = osp.join(sm.abspath, "dir")
             os.makedirs(newdir)
 
-            # update fails if the path already exists non-empty
+            # Update fails if the path already exists non-empty.
             self.assertRaises(OSError, sm.update)
             os.rmdir(newdir)
 
-            # dry-run does nothing
+            # Dry-run does nothing.
             sm.update(dry_run=True, progress=prog)
             assert not sm.module_exists()
 
             assert sm.update() is sm
-            sm_repopath = sm.path  # cache for later
+            sm_repopath = sm.path  # Cache for later.
             assert sm.module_exists()
             assert isinstance(sm.module(), git.Repo)
             assert sm.module().working_tree_dir == sm.abspath
 
             # INTERLEAVE ADD TEST
             #####################
-            # url must match the one in the existing repository ( if submodule name suggests a new one )
-            # or we raise
+            # url must match the one in the existing repository (if submodule name suggests a new one)
+            # or we raise.
             self.assertRaises(
                 ValueError,
                 Submodule.add,
@@ -213,53 +214,53 @@ class TestSubmodule(TestBase):
 
             # CONTINUE UPDATE
             #################
-            # we should have setup a tracking branch, which is also active
+            # We should have setup a tracking branch, which is also active.
             assert sm.module().head.ref.tracking_branch() is not None
 
-            # delete the whole directory and re-initialize
+            # Delete the whole directory and re-initialize.
             assert len(sm.children()) != 0
             # shutil.rmtree(sm.abspath)
             sm.remove(force=True, configuration=False)
             assert len(sm.children()) == 0
-            # dry-run does nothing
+            # Dry-run does nothing.
             sm.update(dry_run=True, recursive=False, progress=prog)
             assert len(sm.children()) == 0
 
             sm.update(recursive=False)
             assert len(list(rwrepo.iter_submodules())) == 2
-            assert len(sm.children()) == 1  # its not checked out yet
+            assert len(sm.children()) == 1  # It's not checked out yet.
             csm = sm.children()[0]
             assert not csm.module_exists()
             csm_repopath = csm.path
 
-            # adjust the path of the submodules module to point to the local destination
+            # Adjust the path of the submodules module to point to the local destination.
             new_csmclone_path = Git.polish_url(osp.join(self.rorepo.working_tree_dir, sm.path, csm.path))
             with csm.config_writer() as writer:
                 writer.set_value("url", new_csmclone_path)
             assert csm.url == new_csmclone_path
 
-            # dry-run does nothing
+            # Dry-run does nothing.
             assert not csm.module_exists()
             sm.update(recursive=True, dry_run=True, progress=prog)
             assert not csm.module_exists()
 
-            # update recursively again
+            # Update recursively again.
             sm.update(recursive=True)
             assert csm.module_exists()
 
-            # tracking branch once again
+            # Tracking branch once again.
             assert csm.module().head.ref.tracking_branch() is not None
 
-            # this flushed in a sub-submodule
+            # This flushed in a sub-submodule.
             assert len(list(rwrepo.iter_submodules())) == 2
 
-            # reset both heads to the previous version, verify that to_latest_revision works
+            # Reset both heads to the previous version, verify that to_latest_revision works.
             smods = (sm.module(), csm.module())
             for repo in smods:
                 repo.head.reset("HEAD~2", working_tree=1)
             # END for each repo to reset
 
-            # dry run does nothing
+            # Dry-run does nothing.
             self.assertRaises(
                 RepositoryDirtyError,
                 sm.update,
@@ -279,89 +280,89 @@ class TestSubmodule(TestBase):
             # END for each repo to check
             del smods
 
-            # if the head is detached, it still works ( but warns )
+            # If the head is detached, it still works (but warns).
             smref = sm.module().head.ref
             sm.module().head.ref = "HEAD~1"
-            # if there is no tracking branch, we get a warning as well
+            # If there is no tracking branch, we get a warning as well.
             csm_tracking_branch = csm.module().head.ref.tracking_branch()
             csm.module().head.ref.set_tracking_branch(None)
             sm.update(recursive=True, to_latest_revision=True)
 
             # to_latest_revision changes the child submodule's commit, it needs an
-            # update now
+            # update now.
             csm.set_parent_commit(csm.repo.head.commit)
 
-            # undo the changes
+            # Undo the changes.
             sm.module().head.ref = smref
             csm.module().head.ref.set_tracking_branch(csm_tracking_branch)
 
             # REMOVAL OF REPOSITORY
             #######################
-            # must delete something
+            # Must delete something.
             self.assertRaises(ValueError, csm.remove, module=False, configuration=False)
 
             # module() is supposed to point to gitdb, which has a child-submodule whose URL is still pointing
-            # to GitHub. To save time, we will change it to
+            # to GitHub. To save time, we will change it to:
             csm.set_parent_commit(csm.repo.head.commit)
             with csm.config_writer() as cw:
                 cw.set_value("url", self._small_repo_url())
             csm.repo.index.commit("adjusted URL to point to local source, instead of the internet")
 
             # We have modified the configuration, hence the index is dirty, and the
-            # deletion will fail
-            # NOTE: As we did  a few updates in the meanwhile, the indices were reset
-            # Hence we create some changes
+            # deletion will fail.
+            # NOTE: As we did a few updates in the meanwhile, the indices were reset.
+            # Hence we create some changes.
             csm.set_parent_commit(csm.repo.head.commit)
             with sm.config_writer() as writer:
                 writer.set_value("somekey", "somevalue")
             with csm.config_writer() as writer:
                 writer.set_value("okey", "ovalue")
             self.assertRaises(InvalidGitRepositoryError, sm.remove)
-            # if we remove the dirty index, it would work
+            # If we remove the dirty index, it would work.
             sm.module().index.reset()
-            # still, we have the file modified
+            # Still, we have the file modified.
             self.assertRaises(InvalidGitRepositoryError, sm.remove, dry_run=True)
             sm.module().index.reset(working_tree=True)
 
-            # enforce the submodule to be checked out at the right spot as well.
+            # Enforce the submodule to be checked out at the right spot as well.
             csm.update()
             assert csm.module_exists()
             assert csm.exists()
             assert osp.isdir(csm.module().working_tree_dir)
 
-            # this would work
+            # This would work.
             assert sm.remove(force=True, dry_run=True) is sm
             assert sm.module_exists()
             sm.remove(force=True, dry_run=True)
             assert sm.module_exists()
 
-            # but ... we have untracked files in the child submodule
+            # But... we have untracked files in the child submodule.
             fn = join_path_native(csm.module().working_tree_dir, "newfile")
             with open(fn, "w") as fd:
                 fd.write("hi")
             self.assertRaises(InvalidGitRepositoryError, sm.remove)
 
-            # forcibly delete the child repository
+            # Forcibly delete the child repository.
             prev_count = len(sm.children())
             self.assertRaises(ValueError, csm.remove, force=True)
             # We removed sm, which removed all submodules. However, the instance we
-            # have still points to the commit prior to that, where it still existed
+            # have still points to the commit prior to that, where it still existed.
             csm.set_parent_commit(csm.repo.commit(), check=False)
             assert not csm.exists()
             assert not csm.module_exists()
             assert len(sm.children()) == prev_count
-            # now we have a changed index, as configuration was altered.
-            # fix this
+            # Now we have a changed index, as configuration was altered.
+            # Fix this.
             sm.module().index.reset(working_tree=True)
 
-            # now delete only the module of the main submodule
+            # Now delete only the module of the main submodule.
             assert sm.module_exists()
             sm.remove(configuration=False, force=True)
             assert sm.exists()
             assert not sm.module_exists()
             assert sm.config_reader().get_value("url")
 
-            # delete the rest
+            # Delete the rest.
             sm_path = sm.path
             sm.remove()
             assert not sm.exists()
@@ -372,7 +373,7 @@ class TestSubmodule(TestBase):
 
             # ADD NEW SUBMODULE
             ###################
-            # add a simple remote repo - trailing slashes are no problem
+            # Add a simple remote repo - trailing slashes are no problem.
             smid = "newsub"
             osmid = "othersub"
             nsm = Submodule.add(
@@ -386,11 +387,11 @@ class TestSubmodule(TestBase):
             assert nsm.name == smid
             assert nsm.module_exists()
             assert nsm.exists()
-            # its not checked out
+            # It's not checked out.
             assert not osp.isfile(join_path_native(nsm.module().working_tree_dir, Submodule.k_modules_file))
             assert len(rwrepo.submodules) == 1
 
-            # add another submodule, but into the root, not as submodule
+            # Add another submodule, but into the root, not as submodule.
             osm = Submodule.add(rwrepo, osmid, csm_repopath, new_csmclone_path, Submodule.k_head_default)
             assert osm != nsm
             assert osm.module_exists()
@@ -399,28 +400,28 @@ class TestSubmodule(TestBase):
 
             assert len(rwrepo.submodules) == 2
 
-            # commit the changes, just to finalize the operation
+            # Commit the changes, just to finalize the operation.
             rwrepo.index.commit("my submod commit")
             assert len(rwrepo.submodules) == 2
 
-            # needs update as the head changed, it thinks its in the history
-            # of the repo otherwise
+            # Needs update, as the head changed. It thinks it's in the history
+            # of the repo otherwise.
             nsm.set_parent_commit(rwrepo.head.commit)
             osm.set_parent_commit(rwrepo.head.commit)
 
             # MOVE MODULE
             #############
-            # invalid input
+            # Invalid input.
             self.assertRaises(ValueError, nsm.move, "doesntmatter", module=False, configuration=False)
 
-            # renaming to the same path does nothing
+            # Renaming to the same path does nothing.
             assert nsm.move(sm_path) is nsm
 
-            # rename a module
-            nmp = join_path_native("new", "module", "dir") + "/"  # new module path
+            # Rename a module.
+            nmp = join_path_native("new", "module", "dir") + "/"  # New module path.
             pmp = nsm.path
             assert nsm.move(nmp) is nsm
-            nmp = nmp[:-1]  # cut last /
+            nmp = nmp[:-1]  # Cut last /
             nmpl = to_native_path_linux(nmp)
             assert nsm.path == nmpl
             assert rwrepo.submodules[0].path == nmpl
@@ -431,14 +432,14 @@ class TestSubmodule(TestBase):
             self.assertRaises(ValueError, nsm.move, mpath)
             os.remove(absmpath)
 
-            # now it works, as we just move it back
+            # Now it works, as we just move it back.
             nsm.move(pmp)
             assert nsm.path == pmp
             assert rwrepo.submodules[0].path == pmp
 
             # REMOVE 'EM ALL
             ################
-            # if a submodule's repo has no remotes, it can't be added without an explicit url
+            # If a submodule's repo has no remotes, it can't be added without an explicit url.
             osmod = osm.module()
 
             osm.remove(module=False)
@@ -448,7 +449,7 @@ class TestSubmodule(TestBase):
             self.assertRaises(ValueError, Submodule.add, rwrepo, osmid, csm_repopath, url=None)
         # END handle bare mode
 
-        # Error if there is no submodule file here
+        # Error if there is no submodule file here.
         self.assertRaises(
             IOError,
             Submodule._config_parser,
@@ -487,11 +488,11 @@ class TestSubmodule(TestBase):
     )
     @with_rw_repo(k_subm_current, bare=False)
     def test_root_module(self, rwrepo):
-        # Can query everything without problems
+        # Can query everything without problems.
         rm = RootModule(self.rorepo)
         assert rm.module() is self.rorepo
 
-        # try attributes
+        # Try attributes.
         rm.binsha
         rm.mode
         rm.path
@@ -505,110 +506,110 @@ class TestSubmodule(TestBase):
         with rm.config_writer():
             pass
 
-        # deep traversal gitdb / async
+        # Deep traversal gitdb / async.
         rsmsp = [sm.path for sm in rm.traverse()]
-        assert len(rsmsp) >= 2  # gitdb and async [and smmap], async being a child of gitdb
+        assert len(rsmsp) >= 2  # gitdb and async [and smmap], async being a child of gitdb.
 
-        # cannot set the parent commit as root module's path didn't exist
+        # Cannot set the parent commit as root module's path didn't exist.
         self.assertRaises(ValueError, rm.set_parent_commit, "HEAD")
 
         # TEST UPDATE
         #############
-        # setup commit which remove existing, add new and modify existing submodules
+        # Set up a commit that removes existing, adds new and modifies existing submodules.
         rm = RootModule(rwrepo)
         assert len(rm.children()) == 1
 
-        # modify path without modifying the index entry
-        # ( which is what the move method would do properly )
+        # Modify path without modifying the index entry.
+        # (Which is what the move method would do properly.)
         # ==================================================
         sm = rm.children()[0]
         pp = "path/prefix"
         fp = join_path_native(pp, sm.path)
         prep = sm.path
-        assert not sm.module_exists()  # was never updated after rwrepo's clone
+        assert not sm.module_exists()  # It was never updated after rwrepo's clone.
 
-        # assure we clone from a local source
+        # Ensure we clone from a local source.
         with sm.config_writer() as writer:
             writer.set_value("url", Git.polish_url(osp.join(self.rorepo.working_tree_dir, sm.path)))
 
-        # dry-run does nothing
+        # Dry-run does nothing.
         sm.update(recursive=False, dry_run=True, progress=prog)
         assert not sm.module_exists()
 
         sm.update(recursive=False)
         assert sm.module_exists()
         with sm.config_writer() as writer:
-            writer.set_value("path", fp)  # change path to something with prefix AFTER url change
+            writer.set_value("path", fp)  # Change path to something with prefix AFTER url change.
 
-        # update doesn't fail, because list_items ignores the wrong path in such situations.
+        # Update doesn't fail, because list_items ignores the wrong path in such situations.
         rm.update(recursive=False)
 
-        # move it properly - doesn't work as it its path currently points to an indexentry
-        # which doesn't exist ( move it to some path, it doesn't matter here )
+        # Move it properly - doesn't work as it its path currently points to an indexentry
+        # which doesn't exist (move it to some path, it doesn't matter here).
         self.assertRaises(InvalidGitRepositoryError, sm.move, pp)
-        # reset the path(cache) to where it was, now it works
+        # Reset the path(cache) to where it was, now it works.
         sm.path = prep
-        sm.move(fp, module=False)  # leave it at the old location
+        sm.move(fp, module=False)  # Leave it at the old location.
 
         assert not sm.module_exists()
-        cpathchange = rwrepo.index.commit("changed sm path")  # finally we can commit
+        cpathchange = rwrepo.index.commit("changed sm path")  # Finally we can commit.
 
-        # update puts the module into place
+        # Update puts the module into place.
         rm.update(recursive=False, progress=prog)
         sm.set_parent_commit(cpathchange)
         assert sm.module_exists()
 
-        # add submodule
-        # ================
+        # Add submodule.
+        # ==============
         nsmn = "newsubmodule"
         nsmp = "submrepo"
         subrepo_url = Git.polish_url(osp.join(self.rorepo.working_tree_dir, rsmsp[0], rsmsp[1]))
         nsm = Submodule.add(rwrepo, nsmn, nsmp, url=subrepo_url)
-        csmadded = rwrepo.index.commit("Added submodule").hexsha  # make sure we don't keep the repo reference
+        csmadded = rwrepo.index.commit("Added submodule").hexsha  # Make sure we don't keep the repo reference.
         nsm.set_parent_commit(csmadded)
         assert nsm.module_exists()
-        # in our case, the module should not exist, which happens if we update a parent
-        # repo and a new submodule comes into life
+        # In our case, the module should not exist, which happens if we update a parent
+        # repo and a new submodule comes into life.
         nsm.remove(configuration=False, module=True)
         assert not nsm.module_exists() and nsm.exists()
 
-        # dry-run does nothing
+        # Dry-run does nothing.
         rm.update(recursive=False, dry_run=True, progress=prog)
 
-        # otherwise it will work
+        # Otherwise it will work.
         rm.update(recursive=False, progress=prog)
         assert nsm.module_exists()
 
-        # remove submodule - the previous one
+        # Remove submodule - the previous one.
         # ====================================
         sm.set_parent_commit(csmadded)
         smp = sm.abspath
         assert not sm.remove(module=False).exists()
-        assert osp.isdir(smp)  # module still exists
+        assert osp.isdir(smp)  # Module still exists.
         csmremoved = rwrepo.index.commit("Removed submodule")
 
-        # an update will remove the module
-        # not in dry_run
+        # An update will remove the module.
+        # Not in dry_run.
         rm.update(recursive=False, dry_run=True, force_remove=True)
         assert osp.isdir(smp)
 
-        # when removing submodules, we may get new commits as nested submodules are auto-committing changes
+        # When removing submodules, we may get new commits as nested submodules are auto-committing changes
         # to allow deletions without force, as the index would be dirty otherwise.
         # QUESTION: Why does this seem to work in test_git_submodule_compatibility() ?
         self.assertRaises(InvalidGitRepositoryError, rm.update, recursive=False, force_remove=False)
         rm.update(recursive=False, force_remove=True)
         assert not osp.isdir(smp)
 
-        # 'apply work' to the nested submodule and assure this is not removed/altered during updates
-        # Need to commit first, otherwise submodule.update wouldn't have a reason to change the head
+        # 'Apply work' to the nested submodule and ensure this is not removed/altered during updates
+        # Need to commit first, otherwise submodule.update wouldn't have a reason to change the head.
         touch(osp.join(nsm.module().working_tree_dir, "new-file"))
-        # We cannot expect is_dirty to even run as we wouldn't reset a head to the same location
+        # We cannot expect is_dirty to even run as we wouldn't reset a head to the same location.
         assert nsm.module().head.commit.hexsha == nsm.hexsha
         nsm.module().index.add([nsm])
         nsm.module().index.commit("added new file")
-        rm.update(recursive=False, dry_run=True, progress=prog)  # would not change head, and thus doesn't fail
-        # Everything we can do from now on will trigger the 'future' check, so no is_dirty() check will even run
-        # This would only run if our local branch is in the past and we have uncommitted changes
+        rm.update(recursive=False, dry_run=True, progress=prog)  # Would not change head, and thus doesn't fail.
+        # Everything we can do from now on will trigger the 'future' check, so no is_dirty() check will even run.
+        # This would only run if our local branch is in the past and we have uncommitted changes.
 
         prev_commit = nsm.module().head.commit
         rm.update(recursive=False, dry_run=False, progress=prog)
@@ -618,10 +619,10 @@ class TestSubmodule(TestBase):
         rm.update(recursive=True, progress=prog, force_reset=True)
         assert prev_commit != nsm.module().head.commit, "head changed, as the remote url and its commit changed"
 
-        # change url ...
-        # ===============
-        # ... to the first repository, this way we have a fast checkout, and a completely different
-        # repository at the different url
+        # Change url...
+        # =============
+        # ...to the first repository. This way we have a fast checkout, and a completely different
+        # repository at the different url.
         nsm.set_parent_commit(csmremoved)
         nsmurl = Git.polish_url(osp.join(self.rorepo.working_tree_dir, rsmsp[0]))
         with nsm.config_writer() as writer:
@@ -629,7 +630,7 @@ class TestSubmodule(TestBase):
         csmpathchange = rwrepo.index.commit("changed url")
         nsm.set_parent_commit(csmpathchange)
 
-        # Now nsm head is in the future of the tracked remote branch
+        # Now nsm head is in the future of the tracked remote branch.
         prev_commit = nsm.module().head.commit
         # dry-run does nothing
         rm.update(recursive=False, dry_run=True, progress=prog)
@@ -641,16 +642,16 @@ class TestSubmodule(TestBase):
         assert len(rwrepo.submodules) == 1
         assert not rwrepo.submodules[0].children()[0].module_exists(), "nested submodule should not be checked out"
 
-        # add the submodule's changed commit to the index, which is what the
-        # user would do
-        # beforehand, update our instance's binsha with the new one
+        # Add the submodule's changed commit to the index, which is what the
+        # user would do.
+        # Beforehand, update our instance's binsha with the new one.
         nsm.binsha = nsm.module().head.commit.binsha
         rwrepo.index.add([nsm])
 
-        # change branch
-        # =================
-        # we only have one branch, so we switch to a virtual one, and back
-        # to the current one to trigger the difference
+        # Change branch.
+        # ==============
+        # We only have one branch, so we switch to a virtual one, and back
+        # to the current one to trigger the difference.
         cur_branch = nsm.branch
         nsmm = nsm.module()
         prev_commit = nsmm.head.commit
@@ -661,35 +662,35 @@ class TestSubmodule(TestBase):
             nsm.set_parent_commit(csmbranchchange)
         # END for each branch to change
 
-        # Lets remove our tracking branch to simulate some changes
+        # Let's remove our tracking branch to simulate some changes.
         nsmmh = nsmm.head
-        assert nsmmh.ref.tracking_branch() is None  # never set it up until now
+        assert nsmmh.ref.tracking_branch() is None  # Never set it up until now.
         assert not nsmmh.is_detached
 
-        # dry run does nothing
+        # Dry-run does nothing.
         rm.update(recursive=False, dry_run=True, progress=prog)
         assert nsmmh.ref.tracking_branch() is None
 
-        # the real thing does
+        # The real thing does.
         rm.update(recursive=False, progress=prog)
 
         assert nsmmh.ref.tracking_branch() is not None
         assert not nsmmh.is_detached
 
-        # recursive update
+        # Recursive update.
         # =================
-        # finally we recursively update a module, just to run the code at least once
-        # remove the module so that it has more work
-        assert len(nsm.children()) >= 1  # could include smmap
+        # Finally we recursively update a module, just to run the code at least once
+        # remove the module so that it has more work.
+        assert len(nsm.children()) >= 1  # Could include smmap.
         assert nsm.exists() and nsm.module_exists() and len(nsm.children()) >= 1
-        # assure we pull locally only
+        # Ensure we pull locally only.
         nsmc = nsm.children()[0]
         with nsmc.config_writer() as writer:
             writer.set_value("url", subrepo_url)
-        rm.update(recursive=True, progress=prog, dry_run=True)  # just to run the code
+        rm.update(recursive=True, progress=prog, dry_run=True)  # Just to run the code.
         rm.update(recursive=True, progress=prog)
 
-        # gitdb: has either 1 or 2 submodules depending on the version
+        # gitdb: has either 1 or 2 submodules depending on the version.
         assert len(nsm.children()) >= 1 and nsmc.module_exists()
 
     @with_rw_repo(k_no_subm_tag, bare=False)
@@ -742,7 +743,7 @@ class TestSubmodule(TestBase):
 
         assert len(repo.submodules) == 1
 
-        # Delete the directory from submodule
+        # Delete the directory from submodule.
         submodule_path = osp.join(repo_path, "module")
         shutil.rmtree(submodule_path)
         repo.git.add([submodule_path])
@@ -800,13 +801,13 @@ class TestSubmodule(TestBase):
         smm.git.add(Git.polish_url(fp))
         smm.git.commit(m="new file added")
 
-        # submodules are retrieved from the current commit's tree, therefore we can't really get a new submodule
-        # object pointing to the new submodule commit
+        # Submodules are retrieved from the current commit's tree, therefore we can't really get a new submodule
+        # object pointing to the new submodule commit.
         sm_too = parent.submodules["module_moved"]
         assert parent.head.commit.tree[sm.path].binsha == sm.binsha
         assert sm_too.binsha == sm.binsha, "cached submodule should point to the same commit as updated one"
 
-        added_bies = parent.index.add([sm])  # added base-index-entries
+        added_bies = parent.index.add([sm])  # Added base-index-entries.
         assert len(added_bies) == 1
         parent.index.commit("add same submodule entry")
         commit_sm = parent.head.commit.tree[sm.path]
@@ -840,8 +841,8 @@ class TestSubmodule(TestBase):
 
         # end
 
-        # As git is backwards compatible itself, it would still recognize what we do here ... unless we really
-        # muss it up. That's the only reason why the test is still here ... .
+        # As git is backwards compatible itself, it would still recognize what we do here... unless we really
+        # muss it up. That's the only reason why the test is still here...
         assert len(parent.git.submodule().splitlines()) == 1
 
         module_repo_path = osp.join(sm.module().working_tree_dir, ".git")
@@ -855,12 +856,12 @@ class TestSubmodule(TestBase):
             assert find_submodule_git_dir(module_repo_path) is not None, "module pointed to by .git file must be valid"
         # end verify submodule 'style'
 
-        # test move
+        # Test move.
         new_sm_path = join_path_native("submodules", "one")
         sm.move(new_sm_path)
         assert_exists(sm)
 
-        # Add additional submodule level
+        # Add additional submodule level.
         csm = sm.module().create_submodule(
             "nested-submodule",
             join_path_native("nested-submodule", "working-tree"),
@@ -870,21 +871,21 @@ class TestSubmodule(TestBase):
         sm_head_commit = sm.module().commit()
         assert_exists(csm)
 
-        # Fails because there are new commits, compared to the remote we cloned from
+        # Fails because there are new commits, compared to the remote we cloned from.
         self.assertRaises(InvalidGitRepositoryError, sm.remove, dry_run=True)
         assert_exists(sm)
         assert sm.module().commit() == sm_head_commit
         assert_exists(csm)
 
-        # rename nested submodule
-        # This name would move itself one level deeper - needs special handling internally
+        # Rename nested submodule.
+        # This name would move itself one level deeper - needs special handling internally.
         new_name = csm.name + "/mine"
         assert csm.rename(new_name).name == new_name
         assert_exists(csm)
         assert csm.repo.is_dirty(index=True, working_tree=False), "index must contain changed .gitmodules file"
         csm.repo.index.commit("renamed module")
 
-        # keep_going evaluation
+        # keep_going evaluation.
         rsm = parent.submodule_update()
         assert_exists(sm)
         assert_exists(csm)
@@ -944,11 +945,11 @@ class TestSubmodule(TestBase):
         parent.index.commit("Added submodule")
 
         assert sm.repo is parent  # yoh was surprised since expected sm repo!!
-        # so created a new instance for submodule
+        # So created a new instance for submodule.
         smrepo = git.Repo(osp.join(rwdir, "parent", sm.path))
-        # Adding a remote without fetching so would have no references
+        # Adding a remote without fetching so would have no references.
         smrepo.create_remote("special", "git@server-shouldnotmatter:repo.git")
-        # And we should be able to remove it just fine
+        # And we should be able to remove it just fine.
         sm.remove()
         assert not sm.exists()
 
@@ -977,8 +978,8 @@ class TestSubmodule(TestBase):
 
     @with_rw_directory
     def test_branch_renames(self, rw_dir):
-        # Setup initial sandbox:
-        # parent repo has one submodule, which has all the latest changes
+        # Set up initial sandbox:
+        # The parent repo has one submodule, which has all the latest changes.
         source_url = self._small_repo_url()
         sm_source_repo = git.Repo.clone_from(source_url, osp.join(rw_dir, "sm-source"), b="master")
         parent_repo = git.Repo.init(osp.join(rw_dir, "parent"))
@@ -991,20 +992,20 @@ class TestSubmodule(TestBase):
         parent_repo.index.commit("added submodule")
         assert sm.exists()
 
-        # Create feature branch with one new commit in submodule source
+        # Create feature branch with one new commit in submodule source.
         sm_fb = sm_source_repo.create_head("feature")
         sm_fb.checkout()
         new_file = touch(osp.join(sm_source_repo.working_tree_dir, "new-file"))
         sm_source_repo.index.add([new_file])
         sm.repo.index.commit("added new file")
 
-        # change designated submodule checkout branch to the new upstream feature branch
+        # Change designated submodule checkout branch to the new upstream feature branch.
         with sm.config_writer() as smcw:
             smcw.set_value("branch", sm_fb.name)
         assert sm.repo.is_dirty(index=True, working_tree=False)
         sm.repo.index.commit("changed submodule branch to '%s'" % sm_fb)
 
-        # verify submodule update with feature branch that leaves currently checked out branch in it's past
+        # Verify submodule update with feature branch that leaves currently checked out branch in it's past.
         sm_mod = sm.module()
         prev_commit = sm_mod.commit()
         assert sm_mod.head.ref.name == "master"
@@ -1016,22 +1017,22 @@ class TestSubmodule(TestBase):
         assert sm_mod.head.ref.name == sm_fb.name
         assert sm_mod.commit() == sm_fb.commit
 
-        # Create new branch which is in our past, and thus seemingly unrelated to the currently checked out one
-        # To make it even 'harder', we shall fork and create a new commit
+        # Create new branch which is in our past, and thus seemingly unrelated to the currently checked out one.
+        # To make it even 'harder', we shall fork and create a new commit.
         sm_pfb = sm_source_repo.create_head("past-feature", commit="HEAD~20")
         sm_pfb.checkout()
         sm_source_repo.index.add([touch(osp.join(sm_source_repo.working_tree_dir, "new-file"))])
         sm_source_repo.index.commit("new file added, to past of '%r'" % sm_fb)
 
-        # Change designated submodule checkout branch to a new commit in its own past
+        # Change designated submodule checkout branch to a new commit in its own past.
         with sm.config_writer() as smcw:
             smcw.set_value("branch", sm_pfb.path)
         sm.repo.index.commit("changed submodule branch to '%s'" % sm_pfb)
 
-        # Test submodule updates - must fail if submodule is dirty
+        # Test submodule updates - must fail if submodule is dirty.
         touch(osp.join(sm_mod.working_tree_dir, "unstaged file"))
         # This doesn't fail as our own submodule binsha didn't change, and the reset is only triggered if
-        # to latest revision is True.
+        # to_latest_revision is True.
         parent_repo.submodule_update(to_latest_revision=False)
         assert sm_mod.head.ref.name == sm_pfb.name, "should have been switched to past head"
         assert sm_mod.commit() == sm_fb.commit, "Head wasn't reset"

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -839,7 +839,7 @@ class TestSubmodule(TestBase):
             assert sm.exists() == value
             assert sm.module_exists() == value
 
-        # END def assert_exists
+        # END assert_exists
 
         # As git is backwards compatible itself, it would still recognize what we do here... unless we really
         # muss it up. That's the only reason why the test is still here...

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This module is part of GitPython and is released under
 # the BSD License: https://opensource.org/license/bsd-3-clause/
 

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -14,14 +14,14 @@ import os.path as osp
 
 class TestTree(TestBase):
     def test_serializable(self):
-        # tree at the given commit contains a submodule as well
+        # Tree at the given commit contains a submodule as well.
         roottree = self.rorepo.tree("6c1faef799095f3990e9970bc2cb10aa0221cf9c")
         for item in roottree.traverse(ignore_self=False):
             if item.type != Tree.type:
                 continue
             # END skip non-trees
             tree = item
-            # trees have no dict
+            # Trees have no dict.
             self.assertRaises(AttributeError, setattr, tree, "someattr", 1)
 
             orig_data = tree.data_stream.read()
@@ -36,7 +36,7 @@ class TestTree(TestBase):
             testtree._deserialize(stream)
             assert testtree._cache == orig_cache
 
-            # replaces cache, but we make sure of it
+            # Replaces cache, but we make sure of it.
             del testtree._cache
             testtree._deserialize(stream)
         # END for each item in tree
@@ -54,29 +54,29 @@ class TestTree(TestBase):
         # END for each object
         assert all_items == root.list_traverse()
 
-        # limit recursion level to 0 - should be same as default iteration
+        # Limit recursion level to 0 - should be same as default iteration.
         assert all_items
         assert "CHANGES" in root
         assert len(list(root)) == len(list(root.traverse(depth=1)))
 
-        # only choose trees
+        # Only choose trees.
         trees_only = lambda i, d: i.type == "tree"
         trees = list(root.traverse(predicate=trees_only))
         assert len(trees) == len([i for i in root.traverse() if trees_only(i, 0)])
 
-        # test prune
+        # Test prune.
         lib_folder = lambda t, d: t.path == "lib"
         pruned_trees = list(root.traverse(predicate=trees_only, prune=lib_folder))
         assert len(pruned_trees) < len(trees)
 
-        # trees and blobs
+        # Trees and blobs.
         assert len(set(trees) | set(root.trees)) == len(trees)
         assert len({b for b in root if isinstance(b, Blob)} | set(root.blobs)) == len(root.blobs)
         subitem = trees[0][0]
         assert "/" in subitem.path
         assert subitem.name == osp.basename(subitem.path)
 
-        # assure that at some point the traversed paths have a slash in them
+        # Check that at some point the traversed paths have a slash in them.
         found_slash = False
         for item in root.traverse():
             assert osp.isabs(item.abspath)
@@ -84,8 +84,8 @@ class TestTree(TestBase):
                 found_slash = True
             # END check for slash
 
-            # slashes in paths are supported as well
-            # NOTE: on py3, / doesn't work with strings anymore ...
+            # Slashes in paths are supported as well.
+            # NOTE: On Python 3, / doesn't work with strings anymore...
             assert root[item.path] == item == root / item.path
         # END for each item
         assert found_slash

--- a/test/tstrunner.py
+++ b/test/tstrunner.py
@@ -1,3 +1,5 @@
+"""Hook for MonkeyType (see PR #1188)."""
+
 import unittest
 
 loader = unittest.TestLoader()


### PR DESCRIPTION
This revises comments and docstrings, to improve clarity, readability, stylistic consistency, in some cases accuracy, and (for docstrings) Sphinx formatting and cross-linking. It also contains a few other related changes.

### Short summary of the most notable changes

In both comments and docstrings, my changes included rewording for clarity, as well as changes in capitalization, punctuation, and so forth.

For comments, which were in a variety of styles, I converted them to be sentences (or in some cases fragments formatted as sentences), except in a minority of cases when doing so seemed like it would worsen readability. I did this because, in addition to improving stylistic consistency and being encouraged by PEP-8, this tended to make their structure clearer (especially in cases of comments over multiple lines that were convertible to multiple separate sentences). This comment style was also one of the styles already represented throughout the codebase.

For docstrings, there were a number of places where the formatting looked one way when reading the raw docstring, but very different, and arguably less readable, as rendered by Sphinx. In cases where this was clearly unintended and the effect was significant, such as markup that was intended to represent an unordered list but instead represented a running paragraph with literal asterisks, I fixed the formatting. In cases where the intent was less clear, such as non-wrapping newlines conveying a break more major than that between sentences but less major than that between paragraphs, I preserved the style where possible but did not make changes to cause it to be newly reflected in rendered documentation.

### Kinds of other changes

There are also some other changes, described below, including some *code changes*, mainly for clarity, that I believe to be sufficiently related or where there is otherwise a reason to include them here rather than proposing them separately.

Some specific changes (*not* to code) are described in commit messages but not this PR description, but this is noted below. Specifically, a handful of changes to docstrings are for accuracy, and to allow them to carry specific rationales and to be reviewed individually, they each have individual commits and are not currently relisted here.

### Line length in docstrings

I found that many docstrings were already written, or almost entirely written, with a hard wrap of 88 columns. It makes sense that this would be done, because it is the `black` default, even though `black` does not enforce line length in docstrings, and furthermore the maximum line length this this project has been set at the much higher 120 columns. I think that a width of 120, or even 100, in docstrings, reduces readability when reading the docstrings in the code (of course it does not affect what Sphinx renders), so this is probably another reason a smaller width was used in most cases.

Where width was consistent, as well as where making it consistent didn't seem like it would improve readability, I left it alone. Otherwise, I prioritized consistency within each docstring and with nearby docstrings, but overall (when making changes that would justify it) preferred the prevailing 88 column width. To a *much* lesser extent, I preferred a width of 88 columns for comments, but only where that style was otherwise being used. I did not format code to make it narrower. We may want to reduce the `black` maximum line length from 120 to 100 or even the default of 88, but I definitely would consider that beyond the scope of this PR.

### Documentation generated from tests

This includes changes to comments in portions of the two test modules from which documentation is generated. This is not special, but I wanted to note it here to properly characterize what parts of the generated documentation are and are not affected.

### Other documentation - only one small change

Although most of the the docstring changes affect generated documentation, and the documentation in `doc/` should also be revised and updated (and in some places stands to benefit more from such changes than anything here), the purpose of this pull request is not to revise or update the separate documentation in `doc/`.

This does include one change to the contents of `doc/`, to avoid introducing an inconsistency when rewording a docstring for clarity whose wording was also used in the tutorial. Other that that and a change in `conf.py`, it does not modify any tracked files in `doc/`.

### How the changes are divided into commits

Formatting, rewording, and style changes such as to capitalization and punctuation, as well as the repair and introduction of Sphinx cross-linking changes and code-formatting changes (such as placing every multi-paragraph docstring's closing `"""` on its own line) are done in a small number of commits, most pertaining to organizational sections of the code.

In contrast, accuracy improvements, even though they account for a much smaller volume of change, are each done in their own commit, so they can have **commit messages that explain their rationale** and to make them easier to review.

Although I had considered describing each of those changes here, I have not thought of a way to do so that I think would clearly be more useful than the commit messages themselves. Furthermore, this description is already rather long. So I have not reproduced that information here. However, I would be pleased to expand this PR description on request, either about that or in other ways.

### What is omitted

In areas where accuracy might be improved but it is unclear how, or where reviewing the changes seems like it would be easier done separately, or where the changes should be accompanied by code changes that themselves are not natural to include here, I have omitted such changes entirely from this pull request. (One such area I discovered while working on this but did not include in it was #1712, which I instead fixed in #1714.)

The changes in this PR are probably incomplete, in the sense that I most likely have missed some things.

In some areas, I have avoided making changes that I anticipate would create conflicts, or other confusion, with work I have on other feature branches that I plan to open PRs for soon. In practice, the only major omission that arises due to this is in `test/test_util.py`, which is mostly unrevised since I intend to propose changes there soon, for making `xfail` markings more precise, that will involve reorganizing that code.

### Changes to code

Finally, please note that **this PR does contain some code changes.** They are as follows:

- A few messages, such as exception messages, are revised. I avoided doing this except when I thought it was a clear improvement and would not cause problems. When accuracy was the motivation, such a change has its own commit (as do other accuracy changes).
- Some string literals are changed, so that the use of raw string literals is consistent (for regular expressions and for Windows paths not *ending* in a backslash, and with `r` and `R` respectively). Commit messages contain further information about this. Conceptually, I felt this came along with fixing docstring bugs where `'\'` was intended to represent itself literally but instead represented `''` because a non-raw docstring turned `\'` into `'`. There is also an argument to be made that strings are the core concept of this pull request (hence the branch name).
- Explicit inheritance from `object` is removed. This is a legacy of Python 2, where it was needed to make a new-style class. This project no longer supports (and is already considerably incompatible with) Python 2, and in Python 3 all classes are new-style classes. The reason this is a clarity improvement sufficiently related to documentation that it seemed appropriate to include here is that GitPython has an `Object` class that could be confused with `object`.
- Expressions of the form `x.__class__ == t` are changed to `x.__class__ is t`. In [#1673](https://github.com/gitpython-developers/GitPython/pull/1673), I fixed the corresponding problem for `type(x) == t`, but `flake8` does not detect the `.__class__` variant. The reason this change is *convenient* here is that most of these changes were on the same or an adjacent line to something I was already changing, so making them separately would in most cases have incurred a conflict. But the reason I think it's *reasonable* to include this here is that a number of GitPython's objects have `type` attributes that pertain to Git and GitPython's data model rather than to the Python object model, and that hold strings that are (correctly) compared with `==`. Comparing `x.__class__` with `is`, as the related `type(x)` is compared but as the unrelated `x.type` is not compared, makes the distinction easier to heed, I think.
- Python permits `__slots__ = "slot"` for a single slot `slot`, but it is discouraged in preference for `__slots__ = ("slot",)`, which was already being done in most cases. I fixed the few occurrences of the former to bring them in line with that.

Although readability would be further improved by replacing two-argument `super` calls with zero-argument `super()`--which is also something Python 3 adds that is related to new-style classes and thus arguably beckoned by those last three bullet points--I have omitted this. The reason is that this change would require special attention in review to ensure that it is only done in cases where the meaning of the code is not changed. (That is likely every occurrence of `super` in the whole repository, but they would still have to be checked individually.)