### PR TITLE
Use zero-argument super()

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -718,7 +718,7 @@ class Git(LazyMixin):
            It is meant to be the working tree directory if available, or the
            ``.git`` directory in case of bare repositories.
         """
-        super(Git, self).__init__()
+        super().__init__()
         self._working_dir = expand_path(working_dir)
         self._git_options: Union[List[str], Tuple[str, ...]] = ()
         self._persistent_git_options: List[str] = []
@@ -765,7 +765,7 @@ class Git(LazyMixin):
                 tuple(int(n) for n in version_numbers.split(".")[:4] if n.isdigit()),
             )
         else:
-            super(Git, self)._set_cache_(attr)
+            super()._set_cache_(attr)
         # END handle version info
 
     @property

--- a/git/config.py
+++ b/git/config.py
@@ -107,7 +107,7 @@ class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
             # END for each base
         # END if mutating methods configuration is set
 
-        new_type = super(MetaParserBuilder, cls).__new__(cls, name, bases, clsdict)
+        new_type = super().__new__(cls, name, bases, clsdict)
         return new_type
 
 
@@ -178,7 +178,7 @@ class SectionConstraint(Generic[T_ConfigParser]):
     def __getattr__(self, attr: str) -> Any:
         if attr in self._valid_attrs_:
             return lambda *args, **kwargs: self._call_config(attr, *args, **kwargs)
-        return super(SectionConstraint, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     def _call_config(self, method: str, *args: Any, **kwargs: Any) -> Any:
         """Call the configuration at the given method which must take a section name
@@ -207,36 +207,36 @@ class _OMD(OrderedDict_OMD):
     """Ordered multi-dict."""
 
     def __setitem__(self, key: str, value: _T) -> None:
-        super(_OMD, self).__setitem__(key, [value])
+        super().__setitem__(key, [value])
 
     def add(self, key: str, value: Any) -> None:
         if key not in self:
-            super(_OMD, self).__setitem__(key, [value])
+            super().__setitem__(key, [value])
             return None
-        super(_OMD, self).__getitem__(key).append(value)
+        super().__getitem__(key).append(value)
 
     def setall(self, key: str, values: List[_T]) -> None:
-        super(_OMD, self).__setitem__(key, values)
+        super().__setitem__(key, values)
 
     def __getitem__(self, key: str) -> Any:
-        return super(_OMD, self).__getitem__(key)[-1]
+        return super().__getitem__(key)[-1]
 
     def getlast(self, key: str) -> Any:
-        return super(_OMD, self).__getitem__(key)[-1]
+        return super().__getitem__(key)[-1]
 
     def setlast(self, key: str, value: Any) -> None:
         if key not in self:
-            super(_OMD, self).__setitem__(key, [value])
+            super().__setitem__(key, [value])
             return
 
-        prior = super(_OMD, self).__getitem__(key)
+        prior = super().__getitem__(key)
         prior[-1] = value
 
     def get(self, key: str, default: Union[_T, None] = None) -> Union[_T, None]:
-        return super(_OMD, self).get(key, [default])[-1]
+        return super().get(key, [default])[-1]
 
     def getall(self, key: str) -> List[_T]:
-        return super(_OMD, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def items(self) -> List[Tuple[str, _T]]:  # type: ignore[override]
         """List of (key, last value for key)."""
@@ -680,7 +680,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def items(self, section_name: str) -> List[Tuple[str, str]]:  # type: ignore[override]
         """:return: list((option, value), ...) pairs of all items in the given section"""
-        return [(k, v) for k, v in super(GitConfigParser, self).items(section_name) if k != "__name__"]
+        return [(k, v) for k, v in super().items(section_name) if k != "__name__"]
 
     def items_all(self, section_name: str) -> List[Tuple[str, List[str]]]:
         """:return: list((option, [values...]), ...) pairs of all items in the given section"""
@@ -748,7 +748,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def add_section(self, section: str) -> None:
         """Assures added options will stay in order"""
-        return super(GitConfigParser, self).add_section(section)
+        return super().add_section(section)
 
     @property
     def read_only(self) -> bool:
@@ -899,7 +899,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         if self.has_section(new_name):
             raise ValueError("Destination section '%s' already exists" % new_name)
 
-        super(GitConfigParser, self).add_section(new_name)
+        super().add_section(new_name)
         new_section = self._sections[new_name]
         for k, vs in self.items_all(section):
             new_section.setall(k, vs)

--- a/git/config.py
+++ b/git/config.py
@@ -150,6 +150,7 @@ class SectionConstraint(Generic[T_ConfigParser]):
     """
 
     __slots__ = ("_config", "_section_name")
+
     _valid_attrs_ = (
         "get_value",
         "set_value",

--- a/git/db.py
+++ b/git/db.py
@@ -34,7 +34,7 @@ class GitCmdObjectDB(LooseObjectDB):
 
     def __init__(self, root_path: PathLike, git: "Git") -> None:
         """Initialize this instance with the root and a git command."""
-        super(GitCmdObjectDB, self).__init__(root_path)
+        super().__init__(root_path)
         self._git = git
 
     def info(self, binsha: bytes) -> OInfo:

--- a/git/exc.py
+++ b/git/exc.py
@@ -137,7 +137,7 @@ class GitCommandNotFound(CommandError):
     the GIT_PYTHON_GIT_EXECUTABLE environment variable."""
 
     def __init__(self, command: Union[List[str], Tuple[str], str], cause: Union[str, Exception]) -> None:
-        super(GitCommandNotFound, self).__init__(command, cause)
+        super().__init__(command, cause)
         self._msg = "Cmd('%s') not found%s"
 
 
@@ -151,7 +151,7 @@ class GitCommandError(CommandError):
         stderr: Union[bytes, str, None] = None,
         stdout: Union[bytes, str, None] = None,
     ) -> None:
-        super(GitCommandError, self).__init__(command, status, stderr, stdout)
+        super().__init__(command, status, stderr, stdout)
 
 
 class CheckoutError(GitError):
@@ -207,7 +207,7 @@ class HookExecutionError(CommandError):
         stderr: Union[bytes, str, None] = None,
         stdout: Union[bytes, str, None] = None,
     ) -> None:
-        super(HookExecutionError, self).__init__(command, status, stderr, stdout)
+        super().__init__(command, status, stderr, stdout)
         self._msg = "Hook('%s') failed%s"
 
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -153,7 +153,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
             self._deserialize(stream)
         else:
-            super(IndexFile, self)._set_cache_(attr)
+            super()._set_cache_(attr)
 
     def _index_path(self) -> PathLike:
         if self.repo.git_dir:
@@ -1425,4 +1425,4 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             raise ValueError("other must be None, Diffable.Index, a Tree or Commit, was %r" % other)
 
         # Diff against working copy - can be handled by superclass natively.
-        return super(IndexFile, self).diff(other, paths, create_patch, **kwargs)
+        return super().diff(other, paths, create_patch, **kwargs)

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -137,7 +137,7 @@ class Object(LazyMixin):
     @property
     def hexsha(self) -> str:
         """:return: 40 byte hex version of our 20 byte binary sha"""
-        # b2a_hex produces bytes
+        # b2a_hex produces bytes.
         return bin_to_hex(self.binsha).decode("ascii")
 
     @property
@@ -206,7 +206,7 @@ class IndexObject(Object):
 
     def _set_cache_(self, attr: str) -> None:
         if attr in IndexObject.__slots__:
-            # they cannot be retrieved lateron ( not without searching for them )
+            # They cannot be retrieved later on (not without searching for them).
             raise AttributeError(
                 "Attribute '%s' unset: path and mode attributes must have been set during %s object creation"
                 % (attr, type(self).__name__)

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -62,7 +62,7 @@ class Object(LazyMixin):
 
         :param binsha: 20 byte SHA1
         """
-        super(Object, self).__init__()
+        super().__init__()
         self.repo = repo
         self.binsha = binsha
         assert len(binsha) == 20, "Require 20 byte binary sha, got %r, len = %i" % (
@@ -108,7 +108,7 @@ class Object(LazyMixin):
             self.size = oinfo.size  # type:  int
             # assert oinfo.type == self.type, _assertion_msg_format % (self.binsha, oinfo.type, self.type)
         else:
-            super(Object, self)._set_cache_(attr)
+            super()._set_cache_(attr)
 
     def __eq__(self, other: Any) -> bool:
         """:return: True if the objects have the same SHA1"""
@@ -190,7 +190,7 @@ class IndexObject(Object):
             Path may not be set if the index object has been created directly, as it
             cannot be retrieved without knowing the parent tree.
         """
-        super(IndexObject, self).__init__(repo, binsha)
+        super().__init__(repo, binsha)
         if mode is not None:
             self.mode = mode
         if path is not None:
@@ -212,7 +212,7 @@ class IndexObject(Object):
                 % (attr, type(self).__name__)
             )
         else:
-            super(IndexObject, self)._set_cache_(attr)
+            super()._set_cache_(attr)
         # END handle slot attribute
 
     @property

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -146,7 +146,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             as what time.altzone returns. The sign is inverted compared to git's
             UTC timezone.
         """
-        super(Commit, self).__init__(repo, binsha)
+        super().__init__(repo, binsha)
         self.binsha = binsha
         if tree is not None:
             assert isinstance(tree, Tree), "Tree needs to be a Tree instance, was %s" % type(tree)
@@ -218,7 +218,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             _binsha, _typename, self.size, stream = self.repo.odb.stream(self.binsha)
             self._deserialize(BytesIO(stream.read()))
         else:
-            super(Commit, self)._set_cache_(attr)
+            super()._set_cache_(attr)
         # END handle attrs
 
     @property

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -124,7 +124,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         :param branch_path: Full (relative) path to ref to checkout when cloning the
             remote repository.
         """
-        super(Submodule, self).__init__(repo, binsha, mode, path)
+        super().__init__(repo, binsha, mode, path)
         self.size = 0
         self._parent_commit = parent_commit
         if url is not None:
@@ -154,7 +154,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         elif attr == "_name":
             raise AttributeError("Cannot retrieve the name of a submodule if it was not set initially")
         else:
-            super(Submodule, self)._set_cache_(attr)
+            super()._set_cache_(attr)
         # END handle attribute name
 
     @classmethod
@@ -174,7 +174,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         """Compare with another submodule."""
         # We may only compare by name as this should be the ID they are hashed with.
         # Otherwise this type wouldn't be hashable.
-        # return self.path == other.path and self.url == other.url and super(Submodule, self).__eq__(other)
+        # return self.path == other.path and self.url == other.url and super().__eq__(other)
         return self._name == other._name
 
     def __ne__(self, other: object) -> bool:

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -55,7 +55,7 @@ class RootModule(Submodule):
 
     def __init__(self, repo: "Repo"):
         # repo, binsha, mode=None, path=None, name = None, parent_commit=None, url=None, ref=None)
-        super(RootModule, self).__init__(
+        super().__init__(
             repo,
             binsha=self.NULL_BIN_SHA,
             mode=self.k_default_mode,

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -79,7 +79,7 @@ class SubmoduleConfigParser(GitConfigParser):
         self._smref: Union["ReferenceType[Submodule]", None] = None
         self._index = None
         self._auto_write = True
-        super(SubmoduleConfigParser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     # { Interface
     def set_submodule(self, submodule: "Submodule") -> None:
@@ -107,7 +107,7 @@ class SubmoduleConfigParser(GitConfigParser):
 
     # { Overridden Methods
     def write(self) -> None:  # type: ignore[override]
-        rval: None = super(SubmoduleConfigParser, self).write()
+        rval: None = super().write()
         self.flush_to_index()
         return rval
 

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -64,7 +64,7 @@ class TagObject(base.Object):
             The timezone that the authored_date is in, in a format similar
             to :attr:`time.altzone`.
         """
-        super(TagObject, self).__init__(repo, binsha)
+        super().__init__(repo, binsha)
         if object is not None:
             self.object: Union["Commit", "Blob", "Tree", "TagObject"] = object
         if tag is not None:
@@ -108,4 +108,4 @@ class TagObject(base.Object):
                 self.message = ""
         # END check our attributes
         else:
-            super(TagObject, self)._set_cache_(attr)
+            super()._set_cache_(attr)

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -237,7 +237,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
         mode: int = tree_id << 12,
         path: Union[PathLike, None] = None,
     ):
-        super(Tree, self).__init__(repo, binsha, mode, path)
+        super().__init__(repo, binsha, mode, path)
 
     @classmethod
     def _get_intermediate_items(
@@ -254,7 +254,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
             ostream = self.repo.odb.stream(self.binsha)
             self._cache: List[TreeCacheTup] = tree_entries_from_data(ostream.read())
         else:
-            super(Tree, self)._set_cache_(attr)
+            super()._set_cache_(attr)
         # END handle attribute
 
     def _iter_convert_to_object(self, iterable: Iterable[TreeCacheTup]) -> Iterator[IndexObjUnion]:
@@ -352,13 +352,13 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
         # def is_tree_traversed(inp: Tuple) -> TypeGuard[Tuple[Iterator[Union['Tree', 'Blob', 'Submodule']]]]:
         #     return all(isinstance(x, (Blob, Tree, Submodule)) for x in inp[1])
 
-        # ret = super(Tree, self).traverse(predicate, prune, depth, branch_first, visit_once, ignore_self)
+        # ret = super().traverse(predicate, prune, depth, branch_first, visit_once, ignore_self)
         # ret_tup = itertools.tee(ret, 2)
         # assert is_tree_traversed(ret_tup), f"Type is {[type(x) for x in list(ret_tup[0])]}"
         # return ret_tup[0]"""
         return cast(
             Union[Iterator[IndexObjUnion], Iterator[TraversedTreeTup]],
-            super(Tree, self)._traverse(
+            super()._traverse(
                 predicate,
                 prune,
                 depth,  # type: ignore
@@ -374,7 +374,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
             traverse()
             Tree -> IterableList[Union['Submodule', 'Tree', 'Blob']]
         """
-        return super(Tree, self)._list_traverse(*args, **kwargs)
+        return super()._list_traverse(*args, **kwargs)
 
     # List protocol
 

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -577,7 +577,7 @@ class TraversableIterableObj(IterableObj, Traversable):
     TIobj_tuple = Tuple[Union[T_TIobj, None], T_TIobj]
 
     def list_traverse(self: T_TIobj, *args: Any, **kwargs: Any) -> IterableList[T_TIobj]:
-        return super(TraversableIterableObj, self)._list_traverse(*args, **kwargs)
+        return super()._list_traverse(*args, **kwargs)
 
     @overload  # type: ignore
     def traverse(self: T_TIobj) -> Iterator[T_TIobj]:
@@ -652,7 +652,5 @@ class TraversableIterableObj(IterableObj, Traversable):
         """
         return cast(
             Union[Iterator[T_TIobj], Iterator[Tuple[Union[None, T_TIobj], T_TIobj]]],
-            super(TraversableIterableObj, self)._traverse(
-                predicate, prune, depth, branch_first, visit_once, ignore_self, as_edge  # type: ignore
-            ),
+            super()._traverse(predicate, prune, depth, branch_first, visit_once, ignore_self, as_edge),  # type: ignore
         )

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -39,7 +39,7 @@ class HEAD(SymbolicReference):
     def __init__(self, repo: "Repo", path: PathLike = _HEAD_NAME):
         if path != self._HEAD_NAME:
             raise ValueError("HEAD instance must point to %r, got %r" % (self._HEAD_NAME, path))
-        super(HEAD, self).__init__(repo, path)
+        super().__init__(repo, path)
         self.commit: "Commit"
 
     def orig_head(self) -> SymbolicReference:

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -155,7 +155,7 @@ class RefLog(List[RefLogEntry], Serializable):
     __slots__ = ("_path",)
 
     def __new__(cls, filepath: Union[PathLike, None] = None) -> "RefLog":
-        inst = super(RefLog, cls).__new__(cls)
+        inst = super().__new__(cls)
         return inst
 
     def __init__(self, filepath: Union[PathLike, None] = None):

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -62,7 +62,7 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
         if check_path and not str(path).startswith(self._common_path_default + "/"):
             raise ValueError(f"Cannot instantiate {self.__class__.__name__!r} from path {path}")
         self.path: str  # SymbolicReference converts to string at the moment.
-        super(Reference, self).__init__(repo, path)
+        super().__init__(repo, path)
 
     def __str__(self) -> str:
         return self.name
@@ -87,7 +87,7 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
             # END handle commit retrieval
         # END handle message is set
 
-        super(Reference, self).set_object(object, logmsg)
+        super().set_object(object, logmsg)
 
         if oldbinsha is not None:
             # From refs/files-backend.c in git-source:

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -40,7 +40,7 @@ class RemoteReference(Head):
             common_path = join_path(common_path, str(remote))
         # END handle remote constraint
         # super is Reference
-        return super(RemoteReference, cls).iter_items(repo, common_path)
+        return super().iter_items(repo, common_path)
 
     # The Head implementation of delete also accepts strs, but this
     # implementation does not.  mypy doesn't have a way of representing

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -215,7 +215,7 @@ class SymbolicReference:
         elif any(component.endswith(".lock") for component in str(ref_path).split("/")):
             raise ValueError(
                 f"Invalid reference '{ref_path}': references cannot have slash-separated components that end with"
-                f" '.lock'"
+                " '.lock'"
             )
 
     @classmethod
@@ -309,8 +309,8 @@ class SymbolicReference:
     ) -> "SymbolicReference":
         """As set_object, but restricts the type of object to be a Commit.
 
-        :raise ValueError: If commit is not a Commit object or doesn't point to
-            a commit
+        :raise ValueError: If commit is not a :class:`~git.objects.commit.Commit` object
+            or doesn't point to a commit
         :return: self
         """
         # Check the type - assume the best if it is a base-string.

--- a/git/remote.py
+++ b/git/remote.py
@@ -573,14 +573,14 @@ class Remote(LazyMixin, IterableObj):
         """Allows to call this instance like
         remote.special( \\*args, \\*\\*kwargs) to call git-remote special self.name."""
         if attr == "_config_reader":
-            return super(Remote, self).__getattr__(attr)
+            return super().__getattr__(attr)
 
         # Sometimes, probably due to a bug in Python itself, we are being called
         # even though a slot of the same name exists.
         try:
             return self._config_reader.get(attr)
         except cp.NoOptionError:
-            return super(Remote, self).__getattr__(attr)
+            return super().__getattr__(attr)
         # END handle exception
 
     def _config_section_name(self) -> str:
@@ -592,7 +592,7 @@ class Remote(LazyMixin, IterableObj):
             # values implicitly, such as in print(r.pushurl).
             self._config_reader = SectionConstraint(self.repo.config_reader("repository"), self._config_section_name())
         else:
-            super(Remote, self)._set_cache_(attr)
+            super()._set_cache_(attr)
 
     def __str__(self) -> str:
         return self.name

--- a/git/util.py
+++ b/git/util.py
@@ -718,7 +718,7 @@ class CallableRemoteProgress(RemoteProgress):
 
     def __init__(self, fn: Callable) -> None:
         self._callable = fn
-        super(CallableRemoteProgress, self).__init__()
+        super().__init__()
 
     def update(self, *args: Any, **kwargs: Any) -> None:
         self._callable(*args, **kwargs)
@@ -1040,7 +1040,7 @@ class BlockingLockFile(LockFile):
 
         :param max_block_time_s: Maximum amount of seconds we may lock.
         """
-        super(BlockingLockFile, self).__init__(file_path)
+        super().__init__(file_path)
         self._check_interval = check_interval_s
         self._max_block_time = max_block_time_s
 
@@ -1054,7 +1054,7 @@ class BlockingLockFile(LockFile):
         maxtime = starttime + float(self._max_block_time)
         while True:
             try:
-                super(BlockingLockFile, self)._obtain_lock()
+                super()._obtain_lock()
             except IOError as e:
                 # synity check: if the directory leading to the lockfile is not
                 # readable anymore, raise an exception
@@ -1103,7 +1103,7 @@ class IterableList(List[T_IterableObj]):
     __slots__ = ("_id_attr", "_prefix")
 
     def __new__(cls, id_attr: str, prefix: str = "") -> "IterableList[T_IterableObj]":
-        return super(IterableList, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, id_attr: str, prefix: str = "") -> None:
         self._id_attr = id_attr

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -33,7 +33,7 @@ class TestBigRepoR(TestBase):
 
     def setUp(self):
         try:
-            super(TestBigRepoR, self).setUp()
+            super().setUp()
         except AttributeError:
             pass
 
@@ -65,7 +65,7 @@ class TestBigRepoRW(TestBigRepoR):
     def setUp(self):
         self.gitrwrepo = None
         try:
-            super(TestBigRepoRW, self).setUp()
+            super().setUp()
         except AttributeError:
             pass
         dirname = tempfile.mktemp()
@@ -74,7 +74,7 @@ class TestBigRepoRW(TestBigRepoR):
         self.puregitrwrepo = Repo(dirname, odbt=GitDB)
 
     def tearDown(self):
-        super(TestBigRepoRW, self).tearDown()
+        super().tearDown()
         if self.gitrwrepo is not None:
             rmtree(self.gitrwrepo.working_dir)
             self.gitrwrepo.git.clear_cache()

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -32,10 +32,7 @@ class TestBigRepoR(TestBase):
     """
 
     def setUp(self):
-        try:
-            super().setUp()
-        except AttributeError:
-            pass
+        super().setUp()
 
         repo_path = os.environ.get(k_env_git_repo)
         if repo_path is None:
@@ -64,10 +61,7 @@ class TestBigRepoRW(TestBigRepoR):
 
     def setUp(self):
         self.gitrwrepo = None
-        try:
-            super().setUp()
-        except AttributeError:
-            pass
+        super().setUp()
         dirname = tempfile.mktemp()
         os.mkdir(dirname)
         self.gitrwrepo = self.gitrorepo.clone(dirname, shared=True, bare=True, odbt=GitCmdObjectDB)

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -275,7 +275,7 @@ class TestCommit(TestCommitSerialization):
 
         class Child(Commit):
             def __init__(self, *args, **kwargs):
-                super(Child, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
 
         child_commits = list(Child.iter_items(self.rorepo, "master", paths=("CHANGES", "AUTHORS")))
         assert type(child_commits[0]) is Child

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -32,7 +32,7 @@ from test.lib import TestBase, fixture_path, with_rw_directory
 class TestGit(TestBase):
     @classmethod
     def setUpClass(cls):
-        super(TestGit, cls).setUpClass()
+        super().setUpClass()
         cls.git = Git(cls.rorepo.working_dir)
 
     def tearDown(self):

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -66,7 +66,7 @@ def _make_hook(git_dir, name, content, make_exec=True):
 
 class TestIndex(TestBase):
     def __init__(self, *args):
-        super(TestIndex, self).__init__(*args)
+        super().__init__(*args)
         self._reset_progress()
 
     def _assert_fprogress(self, entries):

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -44,7 +44,7 @@ class TestRemoteProgress(RemoteProgress):
     __slots__ = ("_seen_lines", "_stages_per_op", "_num_progress_messages")
 
     def __init__(self):
-        super(TestRemoteProgress, self).__init__()
+        super().__init__()
         self._seen_lines = []
         self._stages_per_op = {}
         self._num_progress_messages = 0
@@ -53,7 +53,7 @@ class TestRemoteProgress(RemoteProgress):
         # We may remove the line later if it is dropped.
         # Keep it for debugging.
         self._seen_lines.append(line)
-        rval = super(TestRemoteProgress, self)._parse_progress_line(line)
+        rval = super()._parse_progress_line(line)
         return rval
 
     def line_dropped(self, line):


### PR DESCRIPTION
This replaces 2-argument `super(...)` calls with the zero-argument `super()` form everywhere applicable:

- All uses of two-argument `super` in the *code* are replaced.
- All but one mention of two-argument `super` in *comments* are replaced.

I had omitted this from #1725 because it may require more technical attention to fully check than other code changes there, and that PR was mostly for comments and docstrings.

### Exactly when `super()` can be used

*Since `super` is in practice one of the most confusing features of Python, I've included this section to help in verifying the changes here, and also so that they could be reverified later. However, this section is optional.*

As noted in output of `help(super)` (which is from [this code](https://github.com/python/cpython/blob/f4b5588bde656d8ad048b66a0be4cb5131f0d83f/Objects/typeobject.c#L10581), though [the other documentation](https://docs.python.org/3/library/functions.html#super) can be useful):

```text
super() -> same as super(__class__, <first argument>)
```

`__class__` is [actually literal](https://docs.python.org/3/reference/datamodel.html#creating-the-class-object) there--though the static `__class__` cell should not be confused with the dynamic `__class__` attribute--but it can also be thought of as standing for the name of the enclosing class (or narrowest enclosing class in the case of nested classes), which is actually what one typically writes in the two-argument form of `super`.

When the expression passed in place of `__class__` refers to the (narrowest enclosing) class, and the expression passed in place of `<first argument>` is the name of the first parameter of the method (typically `self` in instance methods, or `cls` in class methods or `__new__`), the zero-argument form `super()` can be used instead with the same meaning.

### The one place I couldn't replace it

The above-described situation applied *everywhere* in GitPython where `super` was actually *used*.

However, there are also comments in some places describing how something else could be done or how what was done could be done differently. In those, *most* showings of multiple-argument `super` were replaceable with `super` without changing what the code would mean and do if used in the place the comment pertained to. But then there is this, in `git.objects.util.TraversableIterableObj`:

https://github.com/gitpython-developers/GitPython/blob/6cef9c054fa15c711aed83cd5dfb19b4520e75f8/git/objects/util.py#L625-L658

The actual `super` call in the code there is replaceable, and I replaced it, with zero-argument `super()`. But the comment--or, more precisely, the string being used as a comment--shows a call with `Commit` as the class name. I'm not sure if that's intended or not. If it is intended, maybe it represents code that would be written somewhere else. So I haven't changed that, though I'm willing to do so if the matter is clarified. It could be changed either in a new commit in this PR, or in a subsequent PR.

### Other changes

There's some proofreading of the kind done in #1725 that I missed there and took care of here.

More significantly, `TestBigRepoR.setUp` contains:

https://github.com/gitpython-developers/GitPython/blob/6cef9c054fa15c711aed83cd5dfb19b4520e75f8/test/performance/lib.py#L35-L38

And `TestBigRepoRW.setUp` analogously contains:

https://github.com/gitpython-developers/GitPython/blob/6cef9c054fa15c711aed83cd5dfb19b4520e75f8/test/performance/lib.py#L67-L70

In addition to replacing those two-argument `super` calls with zero-argument `super()`, I also removed the logic to catch and swallow `AttributeError`. As covered in more detail in the 9113177 commit message, this is unnecessary because `unittest.TestCase` defines an empty `setUp` method to allow this kind of special casing to be avoided, and it may be brittle because `AttributeError` could be raised from the actual code of a `setUp` method, due to the specific way the code to swallow it is written. However, if that latter effect, which would usually be strongly unwanted, is actually the goal, then this should be undone and a suitable comment and/or clarifying refactoring done.

### What isn't included

It's unclear whether `super` calls in test classes' `setUp` and `tearDown` methods are always made in the places they are made because that is where superclass and sibling-class fixture acquisition and release behavior should occur. For example, usually, if `setUp` delegates via `super` to another class's `setUp` method at the beginning, and in a case where the corresponding `tearDown` method needs delegate via `super` to another class's `tearDown` method, then that `tearDown` call should be at the *end*, so that resource acquisition and release more often occurs in a temporally nested way that is easier to reason about and more often correct.

However, sometimes doing it differently is deliberate. Furthermore, `setUp` and `tearDown` methods are inherently weird, because, if a subclass's `setUp` calls a superclass's `setUp` and then fails with an exception, then `tearDown` won't run. (Also, in situations where `tearDown` does run, an exception in one `tearDown` method may still prevent other MRO classes' `tearDown` methods from running. Unlike the first issue, for this there isn't really any perfect thing to do. But I think the framework still makes it somewhat harder than necessary to reason about when the `tearDown` calls are manually written rather than arranged and implied by the `setUp` logic.)

For this reason, I am unsure if it is really worthwhile to try to improve ordering. If improvements are to be made, it might be best to have only `setUp` methods and have them register cleanup logic by calling [`addCleanup`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.addCleanup)--or, perhaps better where applicable, [`enterContext`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.enterContext), though a backport of it for Python <3.11 would be needed. Unlike `tearDown` methods, cleanup scheduled with `addCleanup`, either directly or through `enterContext`, is deterministically performed, in the opposite of the order it was added, even if `setUp` failed with an exception after the `addCleanup` call.