### PR TITLE
Remove obsolete note in _iter_packed_refs

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -149,10 +149,6 @@ class SymbolicReference:
         except OSError:
             return None
         # END no packed-refs file handling
-        # NOTE: Had try-finally block around here to close the fp,
-        # but some python version wouldn't allow yields within that.
-        # I believe files are closing themselves on destruction, so it is
-        # alright.
 
     @classmethod
     def dereference_recursive(cls, repo: "Repo", ref_path: Union[PathLike, None]) -> str:


### PR DESCRIPTION
This removes a comment noting that a `try`-`finally` block had been present (or had been intended), but was removed because some version of Python had imposed a limitation on yield appearing in `try`-`finally`.

That comment was obsolete as of 58c5b99 (#326), which wrapped the relevant code in a `with`-statement, because:

1. Since then, the cleanup is done in a manner equivalent to `try`-`finally`.

2. It turned out, as noted in that PR, that cleanup had not always been done automatically. (This was contrary to the prediction given in the comment.)

3. At some point before that, the limitation that had prevented the use of `try`-`finally` no longer affected any supported version of Python.

   Specifically, it appears the only limitation that this could be was the limitation lifted in Python 2.5, where along with the introduction of `close()`, which is automatically called when a generator object is finalized, it became permitted for `yield` to appear in a `try`-block with an associated `finally`-block, on the grounds that calling `close()` runs the `finally`-block (by raising `GeneratorExit`).

   For details, see: https://docs.python.org/3/whatsnew/2.5.html#pep-342-new-generator-features

This obsolete comment was one of the things I discovered while working on #1725, but I didn't include this change there, having not yet looked into the history of the code enough to be sure.