### PR TITLE
Reorganize test_util and make xfail marks precise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,11 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-python_files = 'test_*.py'
-testpaths = 'test'  # space separated list of paths from root e.g test tests doc/testing
-addopts = '--cov=git --cov-report=term --disable-warnings'
-filterwarnings = 'ignore::DeprecationWarning'
+addopts = "--cov=git --cov-report=term --disable-warnings"
+filterwarnings = "ignore::DeprecationWarning"
+python_files = "test_*.py"
+tmp_path_retention_policy = "failed"
+testpaths = "test"  # Space separated list of paths from root e.g test tests doc/testing.
 # --cov   coverage
 # --cov-report term  # send report to terminal term-missing -> terminal with line numbers  html  xml
 # --cov-report term-missing # to terminal with line numbers
@@ -29,7 +30,7 @@ show_error_codes = true
 implicit_reexport = true
 # strict = true
 
-# TODO: remove when 'gitdb' is fully annotated
+# TODO: Remove when 'gitdb' is fully annotated.
 exclude = ["^git/ext/gitdb"]
 [[tool.mypy.overrides]]
 module = "gitdb.*"
@@ -44,5 +45,5 @@ omit = ["*/git/ext/*"]
 
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ["py37"]
 extend-exclude = "git/ext/gitdb"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,5 +8,4 @@ pytest >= 7.3.1
 pytest-cov
 pytest-instafail
 pytest-mock
-pytest-subtests
 pytest-sugar

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,9 @@ ddt >= 1.1.1, != 1.4.3
 mock ; python_version < "3.8"
 mypy
 pre-commit
-pytest
+pytest >= 7.3.1
 pytest-cov
 pytest-instafail
+pytest-mock
 pytest-subtests
 pytest-sugar

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -211,6 +211,11 @@ class TestEnvParsing:
         assert actual_parsed_value is expected_truth_value
 
 
+def _xfail_param(*values, **xfail_kwargs):
+    """Build a pytest.mark.parametrize parameter that carries an xfail mark."""
+    return pytest.param(*values, marks=pytest.mark.xfail(**xfail_kwargs))
+
+
 @pytest.mark.skipif(sys.platform != "cygwin", reason="Paths specifically for Cygwin.")
 class TestCygpath:
     """Tests for :func:`git.util.cygpath` and :func:`git.util.decygpath`."""
@@ -246,15 +251,11 @@ class TestCygpath:
         cwpath = cygpath(wpath)
         assert cwpath == cpath, wpath
 
-    @pytest.mark.xfail(
-        reason=R'2nd example r".\bar" -> "bar" fails, returns "./bar"',
-        raises=AssertionError,
-    )
     @pytest.mark.parametrize(
         "wpath, cpath",
         [
             (R"./bar", "bar"),
-            (R".\bar", "bar"),  # FIXME: Mark only this one xfail (or fix it).
+            _xfail_param(R".\bar", "bar", reason=R'Returns: "./bar"', raises=AssertionError),
             (R"../bar", "../bar"),
             (R"..\bar", "../bar"),
             (R"../bar/.\foo/../chu", "../bar/chu"),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -49,8 +49,13 @@ def permission_error_tmpdir(tmp_path):
     td = tmp_path / "testdir"
     td.mkdir()
     (td / "x").write_bytes(b"")
-    (td / "x").chmod(stat.S_IRUSR)  # Set up PermissionError on Windows.
-    td.chmod(stat.S_IRUSR | stat.S_IXUSR)  # Set up PermissionError on Unix.
+
+    # Set up PermissionError on Windows, where we can't delete read-only files.
+    (td / "x").chmod(stat.S_IRUSR)
+
+    # Set up PermissionError on Unix, where we can't delete files in read-only directories.
+    td.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
     yield td
 
 
@@ -113,7 +118,7 @@ class TestRmtree:
         # git.index.util "replaces" git.util and is what "import git.util" gives us.
         mocker.patch.object(sys.modules["git.util"], "HIDE_WINDOWS_KNOWN_ERRORS", True)
 
-        # Disable common chmod functions so the callback can't fix the problem.
+        # Disable common chmod functions so the callback can never fix the problem.
         mocker.patch.object(os, "chmod")
         mocker.patch.object(pathlib.Path, "chmod")
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -59,12 +59,6 @@ def permission_error_tmpdir(tmp_path):
     yield td
 
 
-@pytest.fixture
-def file_not_found_tmpdir(tmp_path):
-    """Fixture to test errors deleting a directory that are not due to permissions."""
-    yield tmp_path / "testdir"  # It is deliberately never created.
-
-
 class TestRmtree:
     """Tests for :func:`git.util.rmtree`."""
 
@@ -142,7 +136,9 @@ class TestRmtree:
                 pytest.fail(f"rmtree unexpectedly attempts skip: {ex!r}")
 
     @pytest.mark.parametrize("hide_windows_known_errors", [False, True])
-    def test_does_not_wrap_other_errors(self, mocker, file_not_found_tmpdir, hide_windows_known_errors):
+    def test_does_not_wrap_other_errors(self, tmp_path, mocker, hide_windows_known_errors):
+        file_not_found_tmpdir = tmp_path / "testdir"  # It is deliberately never created.
+
         # See comments in test_wraps_perm_error_if_enabled for details about patching.
         mocker.patch.object(sys.modules["git.util"], "HIDE_WINDOWS_KNOWN_ERRORS", hide_windows_known_errors)
         mocker.patch.object(os, "chmod")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -46,11 +46,6 @@ from test.lib import TestBase, with_rw_repo
 @pytest.fixture
 def permission_error_tmpdir(tmp_path):
     """Fixture to test permissions errors situations where they are not overcome."""
-    if sys.platform == "cygwin":
-        raise SkipTest("Cygwin can't set the permissions that make the test meaningful.")
-    if sys.version_info < (3, 8):
-        raise SkipTest("In 3.7, TemporaryDirectory doesn't clean up after weird permissions.")
-
     td = tmp_path / "testdir"
     td.mkdir()
     (td / "x").write_bytes(b"")
@@ -107,6 +102,14 @@ class TestRmtree:
 
         assert not td.exists()
 
+    @pytest.mark.skipif(
+        sys.platform == "cygwin",
+        reason="Cygwin can't set the permissions that make the test meaningful.",
+    )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="In 3.7, TemporaryDirectory doesn't clean up after weird permissions.",
+    )
     def test_wraps_perm_error_if_enabled(self, mocker, permission_error_tmpdir):
         """rmtree wraps PermissionError when HIDE_WINDOWS_KNOWN_ERRORS is true."""
         # Access the module through sys.modules so it is unambiguous which module's
@@ -122,6 +125,14 @@ class TestRmtree:
         with pytest.raises(SkipTest):
             rmtree(permission_error_tmpdir)
 
+    @pytest.mark.skipif(
+        sys.platform == "cygwin",
+        reason="Cygwin can't set the permissions that make the test meaningful.",
+    )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="In 3.7, TemporaryDirectory doesn't clean up after weird permissions.",
+    )
     def test_does_not_wrap_perm_error_unless_enabled(self, mocker, permission_error_tmpdir):
         """rmtree does not wrap PermissionError when HIDE_WINDOWS_KNOWN_ERRORS is false."""
         # See comments in test_wraps_perm_error_if_enabled for details about patching.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -106,10 +106,6 @@ class TestRmtree:
         sys.platform == "cygwin",
         reason="Cygwin can't set the permissions that make the test meaningful.",
     )
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="In 3.7, TemporaryDirectory doesn't clean up after weird permissions.",
-    )
     def test_wraps_perm_error_if_enabled(self, mocker, permission_error_tmpdir):
         """rmtree wraps PermissionError when HIDE_WINDOWS_KNOWN_ERRORS is true."""
         # Access the module through sys.modules so it is unambiguous which module's
@@ -128,10 +124,6 @@ class TestRmtree:
     @pytest.mark.skipif(
         sys.platform == "cygwin",
         reason="Cygwin can't set the permissions that make the test meaningful.",
-    )
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="In 3.7, TemporaryDirectory doesn't clean up after weird permissions.",
     )
     def test_does_not_wrap_perm_error_unless_enabled(self, mocker, permission_error_tmpdir):
         """rmtree does not wrap PermissionError when HIDE_WINDOWS_KNOWN_ERRORS is false."""

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,4 @@
-# test_utils.py
+# test_util.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
 # This module is part of GitPython and is released under
@@ -275,14 +275,14 @@ class TestUtils(TestBase):
         my_file = tempfile.mktemp()
         lock_file = LockFile(my_file)
         assert not lock_file._has_lock()
-        # release lock we don't have  - fine
+        # Release lock we don't have - fine.
         lock_file._release_lock()
 
-        # get lock
+        # Get lock.
         lock_file._obtain_lock_or_raise()
         assert lock_file._has_lock()
 
-        # concurrent access
+        # Concurrent access.
         other_lock_file = LockFile(my_file)
         assert not other_lock_file._has_lock()
         self.assertRaises(IOError, other_lock_file._obtain_lock_or_raise)
@@ -293,7 +293,7 @@ class TestUtils(TestBase):
         other_lock_file._obtain_lock_or_raise()
         self.assertRaises(IOError, lock_file._obtain_lock_or_raise)
 
-        # auto-release on destruction
+        # Auto-release on destruction.
         del other_lock_file
         lock_file._obtain_lock_or_raise()
         lock_file._release_lock()
@@ -303,7 +303,7 @@ class TestUtils(TestBase):
         lock_file = BlockingLockFile(my_file)
         lock_file._obtain_lock()
 
-        # next one waits for the lock
+        # Next one waits for the lock.
         start = time.time()
         wait_time = 0.1
         wait_lock = BlockingLockFile(my_file, 0.05, wait_time)
@@ -318,7 +318,7 @@ class TestUtils(TestBase):
         self.assertIn("@", get_user_id())
 
     def test_parse_date(self):
-        # parse_date(from_timestamp()) must return the tuple unchanged
+        # parse_date(from_timestamp()) must return the tuple unchanged.
         for timestamp, offset in (
             (1522827734, -7200),
             (1522827734, 0),
@@ -326,7 +326,7 @@ class TestUtils(TestBase):
         ):
             self.assertEqual(parse_date(from_timestamp(timestamp, offset)), (timestamp, offset))
 
-        # test all supported formats
+        # Test all supported formats.
         def assert_rval(rval, veri_time, offset=0):
             self.assertEqual(len(rval), 2)
             self.assertIsInstance(rval[0], int)
@@ -334,7 +334,7 @@ class TestUtils(TestBase):
             self.assertEqual(rval[0], veri_time)
             self.assertEqual(rval[1], offset)
 
-            # now that we are here, test our conversion functions as well
+            # Now that we are here, test our conversion functions as well.
             utctz = altz_to_utctz_str(offset)
             self.assertIsInstance(utctz, str)
             self.assertEqual(utctz_to_altz(verify_utctz(utctz)), offset)
@@ -347,13 +347,13 @@ class TestUtils(TestBase):
         iso3 = ("2005.04.07 22:13:11 -0000", 0)
         alt = ("04/07/2005 22:13:11", 0)
         alt2 = ("07.04.2005 22:13:11", 0)
-        veri_time_utc = 1112911991  # the time this represents, in time since epoch, UTC
+        veri_time_utc = 1112911991  # The time this represents, in time since epoch, UTC.
         for date, offset in (rfc, iso, iso2, iso3, alt, alt2):
             assert_rval(parse_date(date), veri_time_utc, offset)
         # END for each date type
 
-        # and failure
-        self.assertRaises(ValueError, parse_date, datetime.now())  # non-aware datetime
+        # ...and failure.
+        self.assertRaises(ValueError, parse_date, datetime.now())  # Non-aware datetime.
         self.assertRaises(ValueError, parse_date, "invalid format")
         self.assertRaises(ValueError, parse_date, "123456789 -02000")
         self.assertRaises(ValueError, parse_date, " 123456789 -0200")
@@ -362,7 +362,7 @@ class TestUtils(TestBase):
         for cr in (None, self.rorepo.config_reader()):
             self.assertIsInstance(Actor.committer(cr), Actor)
             self.assertIsInstance(Actor.author(cr), Actor)
-        # END assure config reader is handled
+        # END ensure config reader is handled
 
     @with_rw_repo("HEAD")
     @mock.patch("getpass.getuser")
@@ -402,7 +402,7 @@ class TestUtils(TestBase):
         mock_get_uid.return_value = "user"
         committer = Actor.committer(None)
         author = Actor.author(None)
-        # We can't test with `self.rorepo.config_reader()` here, as the uuid laziness
+        # We can't test with `self.rorepo.config_reader()` here, as the UUID laziness
         # depends on whether the user running the test has their global user.name config set.
         self.assertEqual(committer.name, "user")
         self.assertTrue(committer.email.startswith("user@"))
@@ -436,30 +436,30 @@ class TestUtils(TestBase):
 
         self.assertEqual(len(ilist), 2)
 
-        # contains works with name and identity
+        # Contains works with name and identity.
         self.assertIn(name1, ilist)
         self.assertIn(name2, ilist)
         self.assertIn(m2, ilist)
         self.assertIn(m2, ilist)
         self.assertNotIn("invalid", ilist)
 
-        # with string index
+        # With string index.
         self.assertIs(ilist[name1], m1)
         self.assertIs(ilist[name2], m2)
 
-        # with int index
+        # With int index.
         self.assertIs(ilist[0], m1)
         self.assertIs(ilist[1], m2)
 
-        # with getattr
+        # With getattr.
         self.assertIs(ilist.one, m1)
         self.assertIs(ilist.two, m2)
 
-        # test exceptions
+        # Test exceptions.
         self.assertRaises(AttributeError, getattr, ilist, "something")
         self.assertRaises(IndexError, ilist.__getitem__, "something")
 
-        # delete by name and index
+        # Delete by name and index.
         self.assertRaises(IndexError, ilist.__delitem__, "something")
         del ilist[name2]
         self.assertEqual(len(ilist), 1)
@@ -494,21 +494,21 @@ class TestUtils(TestBase):
         self.assertEqual(altz_to_utctz_str(-59), "+0000")
 
     def test_from_timestamp(self):
-        # Correct offset: UTC+2, should return datetime + tzoffset(+2)
+        # Correct offset: UTC+2, should return datetime + tzoffset(+2).
         altz = utctz_to_altz("+0200")
         self.assertEqual(
             datetime.fromtimestamp(1522827734, tzoffset(altz)),
             from_timestamp(1522827734, altz),
         )
 
-        # Wrong offset: UTC+58, should return datetime + tzoffset(UTC)
+        # Wrong offset: UTC+58, should return datetime + tzoffset(UTC).
         altz = utctz_to_altz("+5800")
         self.assertEqual(
             datetime.fromtimestamp(1522827734, tzoffset(0)),
             from_timestamp(1522827734, altz),
         )
 
-        # Wrong offset: UTC-9000, should return datetime + tzoffset(UTC)
+        # Wrong offset: UTC-9000, should return datetime + tzoffset(UTC).
         altz = utctz_to_altz("-9000")
         self.assertEqual(
             datetime.fromtimestamp(1522827734, tzoffset(0)),
@@ -538,7 +538,7 @@ class TestUtils(TestBase):
         redacted_cmd_1 = remove_password_if_present(cmd_1)
         assert username not in " ".join(redacted_cmd_1)
         assert password not in " ".join(redacted_cmd_1)
-        # Check that we use a copy
+        # Check that we use a copy.
         assert cmd_1 is not redacted_cmd_1
         assert username in " ".join(cmd_1)
         assert password in " ".join(cmd_1)


### PR DESCRIPTION
Fixes #1728

This makes `xfail` markings precise in the test suite, so that only tests that are expected to fail (and do fail on CI) are marked `xfail`. This addresses both the general problem that spurious XPASS statuses make the information from `xfail`-marked tests less informative, and the specific problem focused on in #1728.

In addition, this also refactors some other recently added tests in `test_util.py`, to achieve the goals described there. I *may* soon propose other changes that build on this in other ways, but that is not included here. Basically, this just:

- Reorganizes the tests in `test_util.py`, making some of them pure `pytest` tests.
- Uses `@pytest.mark.parametrize` with the `marks=` argument to apply `@pytest.mark.xfail` to exactly the cases that currently need it, and no others.
- Refactors some of the other tests' use of ad-hoc fixtures, removing some code reuse that I had added that was making the code harder rather than easier to maintain, and achieving useful code reuse more cleanly with a custom `pytest` fixture.

This includes two changes to the `pytest` plugins that are used. Since those affect development dependencies, I list them here with their rationales:

- Because the `parametrized` mark supports nesting, generating test cases for the Cartesian product of the specified parameters, I removed the use of subtests for now, and thus also the [`pytest-subtests`](https://pypi.org/project/pytest-subtests/) development dependency. Subtests, and that plugin, could be brought back in the future if they prove useful for another reason, but right now there are no longer any subtests in the test suite. This is the change I had anticipated in [#1700 (comment)](https://github.com/gitpython-developers/GitPython/pull/1700#discussion_r1353654395).
- I have added and used [`pytest-mock`](https://pypi.org/project/pytest-mock/) for some of the new pure `pytest` tests that had previously used nested `with`-statements. The `pytest-mock` plugin provides a `mocker` fixture that wraps the functionality of `unittest.mock` but automatically unpatches everything (and in the reverse order in which it was patched) after the test.

Since we do not yet have CI for native Windows, I have manually run the `test_util.py` tests on Windows (on Windows 10, with Python 3.12) to verify that they produce the expected statuses (including no FAIL statuses).