### PR TITLE
Clarify license and make module top comments more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ gpg --edit-key 4C08421980C9
 
 ### LICENSE
 
-[New BSD License](https://opensource.org/license/bsd-3-clause/). See the [LICENSE file][license].
+[3-Clause BSD License](https://opensource.org/license/bsd-3-clause/), also known as the New BSD License. See the [LICENSE file][license].
 
 [contributing]: https://github.com/gitpython-developers/GitPython/blob/main/CONTRIBUTING.md
 [license]: https://github.com/gitpython-developers/GitPython/blob/main/LICENSE

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -1,8 +1,7 @@
-# __init__.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 # flake8: noqa
 # @PydevCodeAnalysisIgnore

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1,8 +1,7 @@
-# cmd.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from __future__ import annotations
 

--- a/git/compat.py
+++ b/git/compat.py
@@ -1,8 +1,7 @@
-# compat.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Utilities to help provide compatibility with Python 3."""
 

--- a/git/config.py
+++ b/git/config.py
@@ -1,8 +1,7 @@
-# config.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Module containing module parser implementation able to properly read and write
 configuration files."""

--- a/git/db.py
+++ b/git/db.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module with our own gitdb implementation - it uses the git command."""
 
 from git.util import bin_to_hex, hex_to_bin

--- a/git/diff.py
+++ b/git/diff.py
@@ -1,8 +1,7 @@
-# diff.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import re
 from git.cmd import handle_process_output

--- a/git/exc.py
+++ b/git/exc.py
@@ -1,8 +1,7 @@
-# exc.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Module containing all exceptions thrown throughout the git package."""
 

--- a/git/index/__init__.py
+++ b/git/index/__init__.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Initialize the index package."""
 
 # flake8: noqa

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1,8 +1,7 @@
-# base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from contextlib import ExitStack
 import datetime

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 # Standalone functions to accompany the index implementation and make it more versatile.
 # NOTE: Autodoc hates it if this is a docstring.
 

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module with additional types used by the index."""
 
 from binascii import b2a_hex

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module containing index utilities."""
 
 from functools import wraps

--- a/git/objects/__init__.py
+++ b/git/objects/__init__.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Import all submodules' main classes into the package space."""
 
 # flake8: noqa

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -1,8 +1,7 @@
-# base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from git.exc import WorkTreeRepositoryUnsupported
 from git.util import LazyMixin, join_path_native, stream_copy, bin_to_hex

--- a/git/objects/blob.py
+++ b/git/objects/blob.py
@@ -1,8 +1,7 @@
-# blob.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from mimetypes import guess_type
 from . import base

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -1,8 +1,7 @@
-# commit.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import datetime
 import re

--- a/git/objects/fun.py
+++ b/git/objects/fun.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module with functions which are supposed to be as fast as possible."""
 
 from stat import S_ISDIR

--- a/git/objects/submodule/__init__.py
+++ b/git/objects/submodule/__init__.py
@@ -1,2 +1,5 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 # NOTE: Cannot import anything here as the top-level __init__ has to handle
 # our dependencies.

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from io import BytesIO
 import logging
 import os

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from .base import Submodule, UpdateProgress
 from .util import find_first_remote_branch
 from git.exc import InvalidGitRepositoryError

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 import git
 from git.exc import InvalidGitRepositoryError
 from git.config import GitConfigParser

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -1,8 +1,7 @@
-# tag.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Module containing all Object-based types."""
 

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -1,8 +1,7 @@
-# tree.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from git.util import IterableList, join_path
 import git.diff as git_diff

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -1,8 +1,7 @@
-# util.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Module for general utility functions."""
 

--- a/git/refs/__init__.py
+++ b/git/refs/__init__.py
@@ -1,5 +1,9 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 # flake8: noqa
 # Import all modules in order, fix the names they require.
+
 from .symbolic import *
 from .reference import *
 from .head import *

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from git.config import GitConfigParser, SectionConstraint
 from git.util import join_path
 from git.exc import GitCommandError

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from mmap import mmap
 import re
 import time as _time

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from git.util import (
     LazyMixin,
     IterableObj,

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 import os
 
 from git.util import join_path

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from git.types import PathLike
 import os
 

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from .reference import Reference
 
 __all__ = ["TagReference", "Tag"]

--- a/git/remote.py
+++ b/git/remote.py
@@ -1,8 +1,7 @@
-# remote.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Module implementing a remote object allowing easy access to git remotes."""
 

--- a/git/repo/__init__.py
+++ b/git/repo/__init__.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Initialize the Repo package."""
 
 # flake8: noqa

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1,8 +1,7 @@
-# base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from __future__ import annotations
 

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Module with general repository-related functions."""
 
 from __future__ import annotations

--- a/git/types.py
+++ b/git/types.py
@@ -1,5 +1,5 @@
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 # flake8: noqa
 

--- a/git/util.py
+++ b/git/util.py
@@ -1,8 +1,7 @@
-# util.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from abc import abstractmethod
 import contextlib

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     description="GitPython is a Python library used to interact with Git repositories",
     author="Sebastian Thiel, Michael Trier",
     author_email="byronimo@gmail.com, mtrier@gmail.com",
-    license="BSD",
+    license="BSD-3-Clause",
     url="https://github.com/gitpython-developers/GitPython",
     packages=find_packages(exclude=["test", "test.*"]),
     include_package_data=True,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,4 @@
-# __init__.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -1,8 +1,7 @@
-# __init__.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 # flake8: noqa
 import inspect

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -1,8 +1,7 @@
-# helper.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import contextlib
 from functools import wraps

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Support library for tests."""
 
 import logging

--- a/test/performance/test_commit.py
+++ b/test/performance/test_commit.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 """Performance tests for commits (iteration, traversal, and serialization)."""
 

--- a/test/performance/test_odb.py
+++ b/test/performance/test_odb.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Performance tests for object store."""
 
 import sys

--- a/test/performance/test_streams.py
+++ b/test/performance/test_streams.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Performance tests for data streaming."""
 
 import os

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -1,8 +1,7 @@
-# test_actor.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase
 from git import Actor

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,8 +1,7 @@
-# test_base.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import os
 import sys

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -1,8 +1,7 @@
-# test_blob.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase
 from git import Blob

--- a/test/test_blob_filter.py
+++ b/test/test_blob_filter.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Test the blob filter."""
 
 from pathlib import Path

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,5 +1,5 @@
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from pathlib import Path
 import re

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -1,8 +1,7 @@
-# test_commit.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import copy
 from datetime import datetime

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,8 +1,7 @@
-# test_config.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import glob
 import io

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,8 +1,7 @@
-# test_db.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from git.db import GitCmdObjectDB
 from git.exc import BadObject

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -1,8 +1,7 @@
-# test_diff.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import ddt
 import shutil

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -1,8 +1,7 @@
-# test_docs.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import os
 import sys

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -1,8 +1,7 @@
-# test_exc.py
 # Copyright (C) 2008, 2009, 2016 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 
 import re

--- a/test/test_fun.py
+++ b/test/test_fun.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from io import BytesIO
 from stat import S_IFDIR, S_IFREG, S_IFLNK, S_IXUSR
 from os import stat

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,8 +1,7 @@
-# test_git.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import inspect
 import logging

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1,8 +1,7 @@
-# test_index.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
 import os

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -1,5 +1,5 @@
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import ast
 import os

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
 

--- a/test/test_reflog.py
+++ b/test/test_reflog.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 import os
 import tempfile
 

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -1,8 +1,7 @@
-# test_refs.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from itertools import chain
 from pathlib import Path

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -1,8 +1,7 @@
-# test_remote.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import random
 import tempfile

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1,9 +1,7 @@
-# test_repo.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
-
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 import glob
 import io
 from io import BytesIO

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -1,8 +1,7 @@
-# test_stats.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from test.lib import TestBase, fixture
 from git import Stats

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1,5 +1,5 @@
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import contextlib
 import os

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -1,8 +1,7 @@
-# test_tree.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,8 +1,7 @@
-# test_util.py
 # Copyright (C) 2008, 2009 Michael Trier (mtrier@gmail.com) and contributors
 #
-# This module is part of GitPython and is released under
-# the BSD License: https://opensource.org/license/bsd-3-clause/
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import ast
 from datetime import datetime

--- a/test/tstrunner.py
+++ b/test/tstrunner.py
@@ -1,3 +1,6 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
 """Hook for MonkeyType (see PR #1188)."""
 
 import unittest


### PR DESCRIPTION
While working on #1725, I noticed that comments at the top of modules might be made clearer and more consistent, but judged that such a change would be easier to review if proposed in a separate PR. So I've proposed those changes here instead, and included closely logically related changes as well.

This does not attempt to change the terms under which the project is licensed, nor does it change the license file. However, the changes here do include a change to some of the metadata used to specify the license, which will result in some license information being displayed differently on PyPI. I believe this change is for the better, of course, or I wouldn't be proposing it--it more specifically identifies the exact BSD license this project uses, the 3-Clause BSD License--but I recognize that this may merit special scrutiny in review.

Changes are presented in more detail in the three commit messages. In brief summary (the first commit covering the first *three* of these points):

- Filenames, which were given only in some modules, are omitted from all top comments, because GitPython contains many modules that have the same filename as others of its modules, so the filenames are in practice less clarifying while working on the code than they would be in some other projects.
- Top comments are now present in all modules one might expect or want them to be, indicating that the module is part of GitPython, and what the license is.
- Both existing and new license information in top comments is made more specific, specifying the 3-Clause BSD License rather than using the ambiguous phrase "BSD License". This change should not be confused with the change in [#1662](https://github.com/gitpython-developers/GitPython/pull/1662), which updated links that had come to point to the wrong license. This doesn't modify any URLs, instead modifying the text near them.
- The README is updated to give both names, emphasizing the more modern license name.
- `setup.py` is modified to pass `"BSD-3-Clause"` for the `license=` keyword argument to `setup`, instead of `"BSD"`. The license-related *classifier* is not changed, since no more specific classifier is available. (The commit message has significant further details about this.)