### PR TITLE
Test native Windows on CI

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -73,7 +73,6 @@ jobs:
         python -c 'import sys; print(sys.platform)'
         python -c 'import os; print(os.name)'
         python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
-        printenv PATH | tr ':' '\n'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -73,6 +73,7 @@ jobs:
         python -c 'import sys; print(sys.platform)'
         python -c 'import os; print(os.name)'
         python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
+        printenv PATH | tr ':' '\n'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -70,9 +70,7 @@ jobs:
         command -v git python
         git version
         python --version
-        python -c 'import sys; print(sys.platform)'
-        python -c 'import os; print(os.name)'
-        python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
+        python -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,6 +35,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
+    - name: Set up WSL (Windows)
+      if: startsWith(matrix.os, 'windows')
+      uses: Vampire/setup-wsl@v2.0.2
+      with:
+        distribution: Debian
+
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,6 +35,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
+    - name: Set up WSL
+      if: startsWith(matrix.os, 'windows')
+      uses: Vampire/setup-wsl@v2.0.2
+      with:
+        distribution: Debian
+
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -65,7 +65,27 @@ jobs:
         python -c 'import sys; print(sys.platform)'
         python -c 'import os; print(os.name)'
         python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
-        printenv PATH | tr ':' '\n'
+
+    # For debugging hook tests on native Windows systems that may have WSL.
+    - name: Show where bash.exe may be found
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        set +e
+        type -a bash.exe
+        python -c 'import shutil; print(shutil.which("bash.exe"))'
+        bash.exe --version
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "--version"]); print(f"result: {p!r}")'
+        bash.exe -c 'echo "$BASH"'
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", """echo "$BASH" """]); print(f"result: {p!r}")'
+        bash.exe -c 'echo "$BASH_VERSION"'
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", """echo "$BASH_VERSION" """]); print(f"result: {p!r}")'
+        bash.exe -c 'printenv WSL_DISTRO_NAME'
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "printenv WSL_DISTRO_NAME"]); print(f"result: {p!r}")'
+        bash.exe -c 'ls -l /proc/sys/fs/binfmt_misc/WSLInterop'
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "ls -l /proc/sys/fs/binfmt_misc/WSLInterop"]); print(f"result: {p!r}")'
+        bash.exe -c 'uname -a'
+        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "uname -a"]); print(f"result: {p!r}")'
+      continue-on-error: true
 
     - name: Check types with mypy
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,12 +35,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
-    - name: Set up WSL
-      if: startsWith(matrix.os, 'windows')
-      uses: Vampire/setup-wsl@v2.0.2
-      with:
-        distribution: Debian
-
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -65,6 +65,7 @@ jobs:
         python -c 'import sys; print(sys.platform)'
         python -c 'import os; print(os.name)'
         python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
+        printenv PATH | tr ':' '\n'
 
     - name: Check types with mypy
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,18 +10,19 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
         - experimental: false
 
+    runs-on: ${{ matrix.os }}
+
     defaults:
       run:
-        shell: /bin/bash --noprofile --norc -exo pipefail {0}
+        shell: bash --noprofile --norc -exo pipefail {0}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,6 +35,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
+    - name: Set up WSL (Windows)
+      if: startsWith(matrix.os, 'windows')
+      uses: Vampire/setup-wsl@v2.0.2
+      with:
+        distribution: Debian
+
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh
@@ -62,29 +68,15 @@ jobs:
         command -v git python
         git version
         python --version
-        python -c 'import sys; print(sys.platform)'
-        python -c 'import os; print(os.name)'
-        python -c 'import git; print(git.compat.is_win)'  # NOTE: Deprecated. Use os.name directly.
+        python -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
     # For debugging hook tests on native Windows systems that may have WSL.
-    - name: Show where bash.exe may be found
+    - name: Show bash.exe candidates (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |
         set +e
-        type -a bash.exe
-        python -c 'import shutil; print(shutil.which("bash.exe"))'
-        bash.exe --version
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "--version"]); print(f"result: {p!r}")'
-        bash.exe -c 'echo "$BASH"'
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", """echo "$BASH" """]); print(f"result: {p!r}")'
-        bash.exe -c 'echo "$BASH_VERSION"'
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", """echo "$BASH_VERSION" """]); print(f"result: {p!r}")'
-        bash.exe -c 'printenv WSL_DISTRO_NAME'
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "printenv WSL_DISTRO_NAME"]); print(f"result: {p!r}")'
-        bash.exe -c 'ls -l /proc/sys/fs/binfmt_misc/WSLInterop'
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "ls -l /proc/sys/fs/binfmt_misc/WSLInterop"]); print(f"result: {p!r}")'
-        bash.exe -c 'uname -a'
-        python -c 'import subprocess; p = subprocess.run(["bash.exe", "-c", "uname -a"]); print(f"result: {p!r}")'
+        bash.exe -c 'printenv WSL_DISTRO_NAME; uname -a'
+        python -c 'import subprocess; subprocess.run(["bash.exe", "-c", "printenv WSL_DISTRO_NAME; uname -a"])'
       continue-on-error: true
 
     - name: Check types with mypy

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,12 +35,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}
 
-    - name: Set up WSL (Windows)
-      if: startsWith(matrix.os, 'windows')
-      uses: Vampire/setup-wsl@v2.0.2
-      with:
-        distribution: Debian
-
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ filterwarnings = "ignore::DeprecationWarning"
 python_files = "test_*.py"
 tmp_path_retention_policy = "failed"
 testpaths = "test"  # Space separated list of paths from root e.g test tests doc/testing.
+xfail_strict = true  # Treat the XPASS status as a test failure (unless strict=False is passed).
 # --cov   coverage
 # --cov-report term  # send report to terminal term-missing -> terminal with line numbers  html  xml
 # --cov-report term-missing # to terminal with line numbers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ filterwarnings = "ignore::DeprecationWarning"
 python_files = "test_*.py"
 tmp_path_retention_policy = "failed"
 testpaths = "test"  # Space separated list of paths from root e.g test tests doc/testing.
-xfail_strict = true  # Treat the XPASS status as a test failure (unless strict=False is passed).
 # --cov   coverage
 # --cov-report term  # send report to terminal term-missing -> terminal with line numbers  html  xml
 # --cov-report term-missing # to terminal with line numbers

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pytest-cov
 pytest-instafail
 pytest-mock
 pytest-sugar
+sumtypes

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,19 +6,15 @@
 import glob
 import io
 import os
+import os.path as osp
 from unittest import mock
+
+import pytest
 
 from git import GitConfigParser
 from git.config import _OMD, cp
-from test.lib import (
-    TestCase,
-    fixture_path,
-    SkipTest,
-)
-from test.lib import with_rw_directory
-
-import os.path as osp
 from git.util import rmfile
+from test.lib import SkipTest, TestCase, fixture_path, with_rw_directory
 
 
 _tc_lock_fpaths = osp.join(osp.dirname(__file__), "fixtures/*.lock")
@@ -239,6 +235,11 @@ class TestBase(TestCase):
         with GitConfigParser(fpa, read_only=True) as cr:
             check_test_value(cr, tv)
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason='Second config._has_includes() assertion fails (for "config is included if path is matching git_dir")',
+        raises=AssertionError,
+    )
     @with_rw_directory
     def test_conditional_includes_from_git_dir(self, rw_dir):
         # Initiate repository path.

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -3,26 +3,17 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-import ddt
+import os
+import os.path as osp
 import shutil
 import tempfile
-from git import (
-    Repo,
-    GitCommandError,
-    Diff,
-    DiffIndex,
-    NULL_TREE,
-    Submodule,
-)
-from git.cmd import Git
-from test.lib import (
-    TestBase,
-    StringProcessAdapter,
-    fixture,
-)
-from test.lib import with_rw_directory
 
-import os.path as osp
+import ddt
+import pytest
+
+from git import NULL_TREE, Diff, DiffIndex, GitCommandError, Repo, Submodule
+from git.cmd import Git
+from test.lib import StringProcessAdapter, TestBase, fixture, with_rw_directory
 
 
 def to_raw(input):
@@ -318,6 +309,11 @@ class TestDiff(TestBase):
         self.assertIsNone(diff_index[0].a_path, repr(diff_index[0].a_path))
         self.assertEqual(diff_index[0].b_path, "file with spaces", repr(diff_index[0].b_path))
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason='"Access is denied" when tearDown calls shutil.rmtree',
+        raises=PermissionError,
+    )
     def test_diff_submodule(self):
         """Test that diff is able to correctly diff commits that cover submodule changes"""
         # Init a temp git repo that will be referenced as a submodule.

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -8,10 +8,9 @@ import sys
 
 import pytest
 
+from git.exc import GitCommandError
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
-
-import os.path
 
 
 class Tutorials(TestBase):
@@ -207,6 +206,14 @@ class Tutorials(TestBase):
         assert sm.module_exists()  # The submodule's working tree was checked out by update.
         # ![14-test_init_repo_object]
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_directory
     def test_references_and_objects(self, rw_dir):
         # [1-test_references_and_objects]

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -96,9 +96,9 @@ class _WinBashStatus(enum.Enum):
             return cls.INAPPLICABLE
 
         try:
-            # Print rather than returning the test command's exit status so that if a
-            # failure occurs before we even get to this point, we will detect it. See
-            # https://superuser.com/a/1749811 for information on ways to check for WSL.
+            # Output rather than forwarding the test command's exit status so that if a
+            # failure occurs before we even get to this point, we will detect it. For
+            # information on ways to check for WSL, see https://superuser.com/a/1749811.
             script = 'test -e /proc/sys/fs/binfmt_misc/WSLInterop; echo "$?"'
             command = ["bash.exe", "-c", script]
             proc = subprocess.run(command, capture_output=True, check=True, text=True)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -139,10 +139,6 @@ class WinBashStatus:
         # uses the ASCII subset, so we can safely guess a wrong code page for it. Errors
         # from such an environment can contain any text, but unlike WSL's own messages,
         # they go to stderr, not stdout. So we can try the system ANSI code page first.
-        # (Console programs often use the OEM code page, but the ACP seems more accurate
-        # here. For example, on en-US Windows with the original system code page but the
-        # display language set to fr-FR, the message, if not UTF-16LE, is windows-1252,
-        # same as the ACP, while the OEMCP is 437, which can't decode its accents.)
         acp = _get_windows_ansi_encoding()
         try:
             return stdout.decode(acp)
@@ -151,10 +147,7 @@ class WinBashStatus:
         except LookupError as error:
             log.warning("%s", str(error))  # Message already says "Unknown encoding:".
 
-        # Assume UTF-8. If invalid, substitute Unicode replacement characters. (For
-        # example, on zh-CN Windows set to display fr-FR, errors from WSL itself, if not
-        # UTF-16LE, are in windows-1252, even though the ANSI and OEM code pages both
-        # default to 936, and decoding as code page 936 or as UTF-8 both have errors.)
+        # Assume UTF-8. If invalid, substitute Unicode replacement characters.
         return stdout.decode("utf-8", errors="replace")
 
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -94,10 +94,11 @@ class _WinBashStatus:
         if os.name != "nt":
             return cls.Inapplicable()
 
-        no_distro_message = "Windows Subsystem for Linux has no installed distributions."
+        # Use bytes because messages for different WSL errors use different encodings.
+        no_distro_message = b"Windows Subsystem for Linux has no installed distributions."
 
         def error_running_bash(error):
-            log.error("Error running bash.exe to check WSL status: %s", error)
+            log.error("Error running bash.exe to check WSL status: %r", error)
             return cls.ErrorWhileChecking(error)
 
         try:
@@ -106,7 +107,7 @@ class _WinBashStatus:
             # information on ways to check for WSL, see https://superuser.com/a/1749811.
             script = 'test -e /proc/sys/fs/binfmt_misc/WSLInterop; echo "$?"'
             command = ["bash.exe", "-c", script]
-            proc = subprocess.run(command, capture_output=True, check=True, text=True)
+            proc = subprocess.run(command, capture_output=True, check=True)
         except FileNotFoundError:
             return cls.Absent()
         except OSError as error:
@@ -117,11 +118,11 @@ class _WinBashStatus:
             return error_running_bash(error)
 
         status = proc.stdout.rstrip()
-        if status == "0":
+        if status == b"0":
             return cls.Wsl()
-        if status == "1":
+        if status == b"1":
             return cls.Native()
-        log.error("Strange output checking WSL status: %s", proc.stdout)
+        log.error("Strange output checking WSL status: %r", proc.stdout)
         return cls.ErrorWhileChecking(proc)
 
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -179,6 +179,14 @@ class TestIndex(TestBase):
         except Exception as ex:
             assert "index.lock' could not be obtained" not in str(ex)
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("0.1.6")
     def test_index_file_from_tree(self, rw_repo):
         common_ancestor_sha = "5117c9c8a4d3af19a9958677e45cda9269de1541"
@@ -229,6 +237,14 @@ class TestIndex(TestBase):
         # END for each blob
         self.assertEqual(num_blobs, len(three_way_index.entries))
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("0.1.6")
     def test_index_merge_tree(self, rw_repo):
         # A bit out of place, but we need a different repo for this:
@@ -291,6 +307,14 @@ class TestIndex(TestBase):
         self.assertEqual(len(unmerged_blobs), 1)
         self.assertEqual(list(unmerged_blobs.keys())[0], manifest_key[0])
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("0.1.6")
     def test_index_file_diffing(self, rw_repo):
         # Default Index instance points to our index.
@@ -425,6 +449,14 @@ class TestIndex(TestBase):
 
     # END num existing helper
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("0.1.6")
     def test_index_mutation(self, rw_repo):
         index = rw_repo.index
@@ -778,6 +810,14 @@ class TestIndex(TestBase):
         for absfile in absfiles:
             assert osp.isfile(absfile)
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("HEAD")
     def test_compare_write_tree(self, rw_repo):
         """Test writing all trees, comparing them for equality."""

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -4,7 +4,10 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from itertools import chain
+import os
 from pathlib import Path
+
+import pytest
 
 from git import (
     Reference,
@@ -215,6 +218,14 @@ class TestRefs(TestBase):
         assert isinstance(res, SymbolicReference)
         assert res.name == "HEAD"
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
+            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
+        ),
+        raises=GitCommandError,
+    )
     @with_rw_repo("0.1.6")
     def test_head_reset(self, rw_repo):
         cur_head = rw_repo.head

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -831,6 +831,15 @@ class TestRemote(TestBase):
                     remote.fetch(**unsafe_option)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "File not created. A separate Windows command may be needed. This and the "
+            "currently passing test test_fetch_unsafe_options must be adjusted in the "
+            "same way. Until then, test_fetch_unsafe_options is unreliable on Windows."
+        ),
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_fetch_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:
@@ -890,6 +899,15 @@ class TestRemote(TestBase):
                     remote.pull(**unsafe_option)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "File not created. A separate Windows command may be needed. This and the "
+            "currently passing test test_pull_unsafe_options must be adjusted in the "
+            "same way. Until then, test_pull_unsafe_options is unreliable on Windows."
+        ),
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_pull_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:
@@ -955,6 +973,15 @@ class TestRemote(TestBase):
                     remote.push(**unsafe_option)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "File not created. A separate Windows command may be needed. This and the "
+            "currently passing test test_push_unsafe_options must be adjusted in the "
+            "same way. Until then, test_push_unsafe_options is unreliable on Windows."
+        ),
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_push_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -3,36 +3,37 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import os.path as osp
+from pathlib import Path
 import random
 import tempfile
-import pytest
 from unittest import skipIf
 
+import pytest
+
 from git import (
-    RemoteProgress,
-    FetchInfo,
-    Reference,
-    SymbolicReference,
-    Head,
     Commit,
-    PushInfo,
-    RemoteReference,
-    TagReference,
-    Remote,
+    FetchInfo,
     GitCommandError,
+    Head,
+    PushInfo,
+    Reference,
+    Remote,
+    RemoteProgress,
+    RemoteReference,
+    SymbolicReference,
+    TagReference,
 )
 from git.cmd import Git
-from pathlib import Path
 from git.exc import UnsafeOptionError, UnsafeProtocolError
-from test.lib import (
-    TestBase,
-    with_rw_repo,
-    with_rw_and_rw_remote_repo,
-    fixture,
-    GIT_DAEMON_PORT,
-)
 from git.util import rmtree, HIDE_WINDOWS_FREEZE_ERRORS, IterableList
-import os.path as osp
+from test.lib import (
+    GIT_DAEMON_PORT,
+    TestBase,
+    fixture,
+    with_rw_and_rw_remote_repo,
+    with_rw_repo,
+)
 
 
 # Make sure we have repeatable results.

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import os
 import os.path as osp
 from pathlib import Path
 import random
@@ -767,6 +768,11 @@ class TestRemote(TestBase):
                     Remote.create(rw_repo, "origin", url)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=R"Multiple '\' instead of '/' in remote.url make it differ from expected value",
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_create_remote_unsafe_url_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1365,6 +1365,11 @@ class TestRepo(TestBase):
         r.git.commit(message="init")
         self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline_in_stdout=False), "hello\n")
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=R"fatal: could not create leading directories of '--upload-pack=touch C:\Users\ek\AppData\Local\Temp\tmpnantqizc\pwn': Invalid argument",  # noqa: E501
+        raises=GitCommandError,
+    )
     @with_rw_repo("HEAD")
     def test_clone_command_injection(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -294,6 +294,15 @@ class TestRepo(TestBase):
                     rw_repo.clone(tmp_dir, **unsafe_option)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "File not created. A separate Windows command may be needed. This and the "
+            "currently passing test test_clone_unsafe_options must be adjusted in the "
+            "same way. Until then, test_clone_unsafe_options is unreliable on Windows."
+        ),
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_clone_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:
@@ -364,6 +373,15 @@ class TestRepo(TestBase):
                     Repo.clone_from(rw_repo.working_dir, tmp_dir, **unsafe_option)
                 assert not tmp_file.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "File not created. A separate Windows command may be needed. This and the "
+            "currently passing test test_clone_from_unsafe_options must be adjusted in the "
+            "same way. Until then, test_clone_from_unsafe_options is unreliable on Windows."
+        ),
+        raises=AssertionError,
+    )
     @with_rw_repo("HEAD")
     def test_clone_from_unsafe_options_allowed(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -8,6 +8,7 @@ import io
 from io import BytesIO
 import itertools
 import os
+import os.path as osp
 import pathlib
 import pickle
 import sys
@@ -17,22 +18,22 @@ from unittest import mock, skip
 import pytest
 
 from git import (
-    InvalidGitRepositoryError,
-    Repo,
-    NoSuchPathError,
-    Head,
-    Commit,
-    Object,
-    Tree,
-    IndexFile,
-    Git,
-    Reference,
-    GitDB,
-    Submodule,
-    GitCmdObjectDB,
-    Remote,
     BadName,
+    Commit,
+    Git,
+    GitCmdObjectDB,
     GitCommandError,
+    GitDB,
+    Head,
+    IndexFile,
+    InvalidGitRepositoryError,
+    NoSuchPathError,
+    Object,
+    Reference,
+    Remote,
+    Repo,
+    Submodule,
+    Tree,
 )
 from git.exc import (
     BadObject,
@@ -42,8 +43,6 @@ from git.exc import (
 from git.repo.fun import touch
 from git.util import bin_to_hex, cygpath, join_path_native, rmfile, rmtree
 from test.lib import TestBase, fixture, with_rw_directory, with_rw_repo
-
-import os.path as osp
 
 
 def iter_flatten(lol):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -950,14 +950,14 @@ class TestSubmodule(TestBase):
         assert not sm.exists()
 
     @pytest.mark.xfail(
-        os.name == "nt" and (3, 12) <= sys.version_info < (3, 13),
+        os.name == "nt" and sys.version_info >= (3, 12),
         reason=(
             "The sm.move call fails. Submodule.move calls os.renames, which raises:\n"
             "PermissionError: [WinError 32] "
             "The process cannot access the file because it is being used by another process: "
             R"'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\mymodules\myname' "
             R"-> 'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\renamed\myname'"
-            "\nThis resembles other Windows errors, but seems only to affect Python 3.12 somehow."
+            "\nThis resembles other Windows errors, but only occurs starting in Python 3.12."
         ),
         raises=PermissionError,
     )

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -950,13 +950,14 @@ class TestSubmodule(TestBase):
         assert not sm.exists()
 
     @pytest.mark.xfail(
-        os.name == "nt",
+        os.name == "nt" and (3, 12) <= sys.version_info < (3, 13),
         reason=(
             "The sm.move call fails. Submodule.move calls os.renames, which raises:\n"
             "PermissionError: [WinError 32] "
             "The process cannot access the file because it is being used by another process: "
             R"'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\mymodules\myname' "
             R"-> 'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\renamed\myname'"
+            "\nThis resembles other Windows errors, but seems only to affect Python 3.12 somehow."
         ),
         raises=PermissionError,
     )

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -949,6 +949,17 @@ class TestSubmodule(TestBase):
         sm.remove()
         assert not sm.exists()
 
+    @pytest.mark.xfail(
+        os.name == "nt",
+        reason=(
+            "The sm.move call fails. Submodule.move calls os.renames, which raises:\n"
+            "PermissionError: [WinError 32] "
+            "The process cannot access the file because it is being used by another process: "
+            R"'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\mymodules\myname' "
+            R"-> 'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\renamed\myname'"
+        ),
+        raises=PermissionError,
+    )
     @with_rw_directory
     def test_rename(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))


### PR DESCRIPTION
This expands the CI test matrix in the main test workflow, `pythonpackage.yml`, so that it is parameterized not only by Python version but also by operating system. Now it tests on both Ubuntu and Windows. It also adds conditional `xfail` markings with precise conditions and brief descriptions of the expected failures.

Most of the detailed information about specific changes in this pull request is in the commit messages. I give general information here, as well as covering, in some detail, a few areas where I think it is not readily apparent (and maybe I am wrong) what the best approach is, or what changes should be included.

### Approach to adding `xfail` markings

A number of tests were known always to fail on Windows, with some others known to fail on Windows on particular versions or other conditions. As discussed in https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717475862, I have not attempted to actually fix the failures. Instead, I have marked each failing test case with a conditional `xfail` marking with a description of the failure and the exception with which the test fails. I have sought to make the conditions precise. Most of them are simply that a test fails on native Windows, so the condition is `os.name == "nt"`, but some of the conditions are more specific. In some cases there are really multiple independent expected causes of failure, so some have multiple `xfail` markings. (`pytest` supports stacking them in this way.)

I have tried to document what is currently known about the failures, including known or suspected information about their causes, in the descriptions, and sometimes in more detail in the commit messages that added them. Sometimes this takes the form of a reference to an existing issue, and for some others there may be an existing issue I did not manage to identify, but it is likely that a few bugs are currently only "reported" in commit messages in this PR. In some cases I anticipate I can fix a bug soon; others might benefit from having an issue opened for them.

(An exception is #1630, for which I added `xfail` marks in 6e477e3, which I did not document as thoroughly as I could have. I hope to open a PR to remedy #1630 as soon as Windows has CI test jobs--which if this PR is approved would be at that point--so I figured the commit message didn't need much information.)

### The `WinBashStatus` class in `test_index`

Some more detailed information about this appears in commit messages.

The original motivation for more precise detection of when `bash.exe` is the WSL wrapper was to fix CI. On the Windows CI runners, running `bash.exe` in a shell (any kind of shell) runs Git Bash, which is not related to WSL. But `Popen` finds the WSL-wrapper `bash.exe` in `System32` instead, because the way searching for executables works on Windows differs significantly between the shell and non-shell case. This is an intentional design choice in Windows, not GitPython nor even Python itself. But I think it's accurate to say GitPython must contend with it and, more importantly, some users of GitPython may be relying on it, perhaps even without knowing they are.

When a program is run without using a shell and a search must be performed because just the name of the executable is given, a few directories, including `System32`, are expected to be (and typically are) searched first, before the `PATH` environment variable is even used. This keeps a `shutil.which`-based technique from working. There are other important differences in search behavior of `shutil.which` and `Popen`, but that's the difference that's relevant here.

There are three related issues:

- One of the tests currently fails on WSL `bash`, while passing on native `bash` (like Git Bash).
- When `bash.exe` is found in `System32`, *and* it is the WSL wrapper, that does not imply the existence of any installed distributions (i.e., GNU/Linux systems to run in WSL). This is a common situation. Even when some Windows components needed for WSL to work are not yet installed, `bash.exe` can exist there, yet it does not always. (This is also the situation on CI when WSL is not set up.) Because the tests are `xfail` when `bash.exe` is altogether absent, I think it makes sense also to `xfail` them in the common situation that `bash.exe` can't run `bash` in a WSL-hosted distribution because no such distribution is present.
- Distinguishing expected and unexpected WSL failures, and failures not related to WSL, is complicated by how, while determining the status of WSL on a machine is usually fairly easy interactively, it seems there is no trivial way to do so programmatically in way that covers all cases, or even all common cases.

But the advantage of doing it seems significant to me: not only does this make it more efficient to interpret and document test failures, it also should be helpful in investigating and debugging possible future design changes that seek to build on [#1399](https://github.com/gitpython-developers/GitPython/pull/1399), in a sufficiently backward-compatible way, to retain its benefits (see [#703](https://github.com/gitpython-developers/GitPython/issues/703), [#971](https://github.com/gitpython-developers/GitPython/issues/971)), while avoiding unexpected behavior. (If it can be done in a way that is non-breaking for current users of hooks on Windows, perhaps in the future Git Bash can be used as the default way to run hooks, with other approaches, including WSL, available as backup strategies or if specified.)

I wrote `WinBashStatus` with the intention that, if necessary, it could be retained for an extended time. However, my hope for it is that it will actually disappear (perhaps with some insights from the process making their way into other code). If, in the future, hooks are run on Windows in a way that works on more systems, and has fewer strange edge cases, then there may be no more need for it or anything like it.

I have tried to make it work properly locally as well as on CI. To work locally, it needs to avoid language and locale related limitations other than those those already present. Because some aspects of the approach I used are not obvious, I've included comments about it. They were originally longer, with parenthesized examples of locale-related situations, but that seemed more detailed than necessary, so I removed them in [e00fffc](https://github.com/gitpython-developers/GitPython/pull/1745/commits/e00fffc918da5cd6c3c749d1d2e59d8ae6835189). (But I can bring those back if desired.)

### Which versions should we test?

This PR currently deviates from the preferences expressed in https://github.com/gitpython-developers/GitPython/pull/1654#issuecomment-1717475862 in one significant way, *which can be changed if you wish.* At the time of that discussion, we both held the view that it would be good to test only the lower and upper bounds of the supported version range for Windows. The process of adding these tests has led me to the view that it may be better, at least for now, to test all six versions on Windows (as is done on Ubuntu).

Initially I had them all enabled for the purpose of developing the changes here and planned to remove some at the end, but the reason I now advocate keeping them all for the time being, are, from most to least significant:

- The native Windows tests are much faster than I had feared, running *much* closer to the speed of the Ubuntu jobs than of the Cygwin job. (This is especially remarkable considering that it holds up even with them installing Debian via WSL in the Windows test runner to run the hook tests in `test_index.py`. I think there is value in running those tests, but their `xfail` marks do consider `bash.exe` being the WSL wrapper, yet no WSL systems being installed, as an expected failure condition. So if necessary, the `setup-wsl` step can be dropped to gain that minute. As detailed below, I don't know if caching works for the runs in an open PR, so you may observe further delay here.)
- The conditions under which tests fail on Windows are weirder than I had expected, in at least one way that specifically benefits from testing more versions: `TestSubmodule.test_rename` newly fails in 3.12 with a "being used by another process" `PermissionError`, possibly due to [GC changes](https://github.com/python/cpython/issues/97922). Because of the role of such errors in [#790](https://github.com/gitpython-developers/GitPython/issues/790) and [#1333](https://github.com/gitpython-developers/GitPython/issues/1333), it seems to me that easily distinguishing what versions have a failure, before and after code changes that potentially affect the test, might be helpful in the near future. To do this would at least require a 3.11 job.
- The lower bound GitPython currently supports is 3.7. There are a number of important changes in 3.8, which so far seem not to have been an issue; most special-casing of 3.7 seems to have been in test suite only. To ensure that changes (including security fixes) are effective on 3.7, it should be tested on Windows. To decide what to do about it when that breaks, 3.8 should be tested as well.
- The latest Python build the Cygwin project currently packages is 3.9; for this reason, it is probably the most used on Cygwin, and it makes sense that it is the version tested in the Cygwin job. I had not until recently considered the benefits of being able to compare 3.9 results between native Windows and Cygwin. I think this would avoid situations where one might worry the problem is with 3.9, though that may only be a small boon. However, the stark difference in performance between native Windows and Cygwin makes me think the Cygwin job could be sped up. (For example, it may be possible to use the GitHub Actions caching feature to do I/O in a faster way for installing Cygwin and/or GitPython's dependencies in the Cygwin system.) This is another area where the ability to compare could be helpful.

Most of the benefit could be gotten by testing 3.7, 3.8, 3.11, and 3.12 (the last point above is less compelling than the others, I think). However, this is still much more than the original idea of testing just a couple versions. It seems to me that the additional resource usage of testing two more versions is worthwhile for the benefit of comprehensively testing all the versions GitPython officially supports. I also think other approaches for decreasing undesired load might be preferable, such as removing `fail-fast: false` (the Ubuntu jobs, if desired, could still be set to continue even if another job has failed), skipping the documentation-building step on some or all Windows jobs, and/or either not installing WSL for the hook tests or switching the distribution to Alpine Linux.

With many pushes over a short time--as for example in this pull request, where I pushed the commits separately with ten second delays in between, to make it easy to inspect intermediate CI results--there can be more jobs queued than immediately available runners. (I believe the number of runners is limited per organization.) It is in that case that the number of tests can be most of an issue. Even *if* you decide to accept this PR without the number of Windows jobs being decreased, it might turn out later that this is annoying. I accept that you may know now that you want fewer Windows test jobs, but also, I understand that if you accept this as it is now, that doesn't mean all the jobs will be kept forever.

### `setup-wsl` and caching

On my fork, the `setup-wsl` step seems usually to take between 30 and 90 seconds, and most often near the low end.

I did not disable GitHub Actions caching on `setup-wsl`. Based on how it works in my fork, I expect it to take up 82 MB. I think this is probably fine, and it can be turned off if desired, but I wanted to mention it just in case. I believe GitHub Actions caching quotas are per-organization. I expect that turning off caching (while still installing WSL) would make things somewhat slower.

I am unsure if caching will actually work on it in the CI jobs run on this repository due to the `pull-request` trigger. My vague recollection is that caching does not happen for open PRs that introduce it. If that is the case, then the amount by which installing WSL slows down each Windows job, *as observed here*, may be more than I have observed.

### What is *not* done here

It seemed to me that the `bash.exe` status classification logic in `test_index` (described above) was easier to do in this PR than separately, because it facilitates precise `xfail` markings. However, other substantial changes that could in principle be part of this PR but can be omitted are omitted. Specifically:

- I have not merged `cygwin-test.yml` into `pythonpackage.yml`. I had hoped to do that while adding native Windows tests, but I now think it is best deferred to a later PR. One reason is for more effective reviewing: if merging them produces conditional logic whose complexity is undesirable, it will be easier to notice the problem after the native Windows tests already exist for comparison. Another reason, though, is that I don't know what it will look like after changes have been made to it to speed it up (see above). If this involves adding caching, including for installing `GitPython`'s dependencies, then that might cause it to diverge sufficiently from `pythonpackage.yml` that they should no longer be merged.
- I have not changed the distribution used for WSL in the tests from Debian to Alpine Linux, even though I suspect this would speed things up (perhaps especially if caching is going to be turned off in the `setup-wsl` step). This requires either a fix for [setup-wsl#50](https://github.com/Vampire/setup-wsl/issues/50) or a workaround.
- I have not added macOS jobs. I think this may be worth doing. I don't currently have the ability to test on Apple hardware. I can virtualize systems I don't regularly use in development, such as OpenIndiana or the Simplified Chinese localized build of Windows Server, on Ubuntu or Windows hosts. But virtualizing macOS is not similarly straightforward. Furthermore, some subtleties of Unix can be revealed by testing regularly on systems that are not GNU/Linux, of which macOS has GitHub Actions runners. (For [#1738](https://github.com/gitpython-developers/GitPython/issues/1738), the way I tested on macOS was to run a GitHub Actions job on a macOS runner with a [tmate debugging](https://github.com/marketplace/actions/debugging-with-tmate) step and SSH into it.) However, omitting that here limits scope and allows it to be evaluated separately. Limited testing indicates that, as on Windows, some different expected timings may have to be given in at least one of the performance tests in order to make macOS jobs pass.
- I have not reduced the complexity of `rmtree` and `HIDE_WINDOWS_KNOWN_ERRORS` tests in `test_util`. With native Windows CI jobs, *some* of the behavior that is specific to Windows (especially since [#1739](https://github.com/gitpython-developers/GitPython/pull/1739)) can probably be tested only on Windows, and skipped otherwise. I think there should be a way to make this change in a way that simplifies the tests. (As one example, every `os.name == "nt"` in a `@pytest.mark.parametrize` parameter set would just become `True`.) But it's not at all necessary to do that to achieve the aims here, and it would delay this PR.
- I have not converted tests that skip due to `unittest.SkipTest` being raised in `git.util.rmtree` into `xfail` tests, made `HIDE_WINDOWS_KNOWN_ERRORS` default to `False`, or decreased its use (though I have made sure not to increase its use). It seems to me that such steps would be good progress toward a solution for [#790](https://github.com/gitpython-developers/GitPython/issues/790), but I think they will be easier to do, as well as to review, if done after, and separately from, the addition of native Windows CI jobs.