### PR TITLE
Adding dubious ownership handling

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1322,7 +1322,12 @@ class Git(LazyMixin):
         tokens = header_line.split()
         if len(tokens) != 3:
             if not tokens:
-                raise ValueError("SHA could not be resolved, git returned: %r" % (header_line.strip()))
+                err_msg = (
+                    f"SHA is empty, possible dubious ownership in the repository "
+                    f"""at {self._working_dir}.\n            If this is unintended run:\n\n         """
+                    f"""             "git config --global --add safe.directory {self._working_dir}" """
+                )
+                raise ValueError(err_msg)
             else:
                 raise ValueError("SHA %s could not be resolved, git returned: %r" % (tokens[0], header_line.strip()))
             # END handle actual return value


### PR DESCRIPTION
This is a fix for the ticket -> https://github.com/gitpython-developers/GitPython/issues/1616

This was already validated and catch the dubious ownership from the repo object generation to avoid confusing errors forward.

Validations results:

Catching dubious ownership
```
[root@ilabinfra-dev BlueGen]# python3
Python 3.9.16 (main, Sep 12 2023, 00:00:00) 
[GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import git
>>> repo = git .Repo('/tmp/BlueGen')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/git/repo/base.py", line 303, in __init__
    raise InvalidGitRepositoryError(err_msg) from None
git.exc.InvalidGitRepositoryError: Detected dubious ownership in repository at: /tmp/BlueGen
```

No dubious ownership
```
[mario@ilabinfra-dev BlueGen]$ python3
Python 3.9.16 (main, Sep 12 2023, 00:00:00) 
[GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import git
>>> repo = git .Repo('/tmp/BlueGen')
```