### PR TITLE
Document some minor subtleties in test_util.py

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -140,15 +140,11 @@ class TestRmtree:
         # git.index.util "replaces" git.util and is what "import git.util" gives us.
         mocker.patch.object(sys.modules["git.util"], "HIDE_WINDOWS_KNOWN_ERRORS", hide_windows_known_errors)
 
-        # Disable some chmod functions so the callback can't fix a PermissionError.
+        # Mock out common chmod functions to simulate PermissionError the callback can't
+        # fix. (We leave the corresponding lchmod functions alone. If they're used, it's
+        # more important we detect any failures from inadequate compatibility checks.)
         mocker.patch.object(os, "chmod")
-        if hasattr(os, "lchmod"):
-            # Exists on some operating systems. Mocking out os.chmod doesn't affect it.
-            mocker.patch.object(os, "lchmod")
         mocker.patch.object(pathlib.Path, "chmod")
-        if hasattr(pathlib.Path, "lchmod"):
-            # Exists on some Python versions. Don't rely on it calling a public chmod.
-            mocker.patch.object(pathlib.Path, "lchmod")
 
     @pytest.mark.skipif(
         os.name != "nt",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -140,9 +140,15 @@ class TestRmtree:
         # git.index.util "replaces" git.util and is what "import git.util" gives us.
         mocker.patch.object(sys.modules["git.util"], "HIDE_WINDOWS_KNOWN_ERRORS", hide_windows_known_errors)
 
-        # Disable common chmod functions so the callback can't fix a PermissionError.
+        # Disable some chmod functions so the callback can't fix a PermissionError.
         mocker.patch.object(os, "chmod")
+        if hasattr(os, "lchmod"):
+            # Exists on some operating systems. Mocking out os.chmod doesn't affect it.
+            mocker.patch.object(os, "lchmod")
         mocker.patch.object(pathlib.Path, "chmod")
+        if hasattr(pathlib.Path, "lchmod"):
+            # Exists on some Python versions. Don't rely on it calling a public chmod.
+            mocker.patch.object(pathlib.Path, "lchmod")
 
     @pytest.mark.skipif(
         os.name != "nt",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -258,14 +258,15 @@ _norm_cygpath_pairs = (
     (R"D:/Apps\fOO", "/cygdrive/d/Apps/fOO"),
     (R"D:\Apps/123", "/cygdrive/d/Apps/123"),
 )
+"""Path test cases for cygpath and decygpath, other than extended UNC paths."""
 
 _unc_cygpath_pairs = (
     (R"\\?\a:\com", "/cygdrive/a/com"),
     (R"\\?\a:/com", "/cygdrive/a/com"),
     (R"\\?\UNC\server\D$\Apps", "//server/D$/Apps"),
 )
+"""Extended UNC path test cases for cygpath."""
 
-# Mapping of expected failures for the test_cygpath_ok test.
 _cygpath_ok_xfails = {
     # From _norm_cygpath_pairs:
     (R"C:\Users", "/cygdrive/c/Users"): "/proc/cygdrive/c/Users",
@@ -279,9 +280,9 @@ _cygpath_ok_xfails = {
     (R"\\?\a:\com", "/cygdrive/a/com"): "/proc/cygdrive/a/com",
     (R"\\?\a:/com", "/cygdrive/a/com"): "/proc/cygdrive/a/com",
 }
+"""Mapping of expected failures for the test_cygpath_ok test."""
 
 
-# Parameter sets for the test_cygpath_ok test.
 _cygpath_ok_params = [
     (
         _xfail_param(*case, reason=f"Returns: {_cygpath_ok_xfails[case]!r}", raises=AssertionError)
@@ -290,6 +291,7 @@ _cygpath_ok_params = [
     )
     for case in _norm_cygpath_pairs + _unc_cygpath_pairs
 ]
+"""Parameter sets for the test_cygpath_ok test."""
 
 
 @pytest.mark.skipif(sys.platform != "cygwin", reason="Paths specifically for Cygwin.")


### PR DESCRIPTION
These are a couple of small comment/docstring tweaks in `test_util.py` that didn't quite make it into #1739:

- Some of the tests mock `chmod` functions to better simulate the inability to change permissions on a file, but they don't mock the `lchmod` variants, at least one of which (the `pathlib.Path` method) can exists even when calling it is guaranteed to fail. This comments to explain why they are not mocked (it is so we observe such failures).
- There are a few collections of parameter sets used in the `cygpath` tests, some of which existed before any recent changes, and another of which was introduced in [#1729](https://github.com/gitpython-developers/GitPython/pull/1729) to help with precise xfail markings. This adds ["docstrings"](https://github.com/gitpython-developers/GitPython/discussions/1734) to those that didn't have them, and converts the comment on the one that did into such a docstring.

The impact is minor, but I think this helps with clarity a little bit.

The reason I deferred these changes is that I originally had begun by mocking out the `lchmod` functions. While writing the commit message for that, I realized my reasoning wasn't very good, because it is more important that any exceptions due to platform incompatibility be observed and cause the test to fail, in the event that those functions are ever used (directly or indirectly) in the code under test. That original commit is in the history--it's the first commit here--but the test code changes are undone subsequently. I considered just dropping the commit, but it seems to me that having it in the history may make things a little clearer. (However, I can rebase it out if desired.)