### PR TITLE
Fix IndexFile.from_tree on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,5 +52,6 @@ Contributors are:
 -Joseph Hale <me _at_ jhale.dev>
 -Santos Gallegos <stsewd _at_ proton.me>
 -Wenhan Zhu <wzhu.cosmos _at_ gmail.com>
+-Eliah Kagan <eliah.kagan _at_ gmail.com>
 
 Portions derived from other open source works and are clearly marked.

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -362,6 +362,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         # works - /tmp/ dirs could be on another device.
         with ExitStack() as stack:
             tmp_index = stack.enter_context(tempfile.NamedTemporaryFile(dir=repo.git_dir))
+            if os.name == "nt":
+                tmp_index.close()
             arg_list.append("--index-output=%s" % tmp_index.name)
             arg_list.extend(treeish)
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -97,9 +97,8 @@ __all__ = ("IndexFile", "CheckoutError", "StageType")
 
 
 class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
-    """
-    An Index that can be manipulated using a native implementation in order to save git
-    command function calls wherever possible.
+    """An Index that can be manipulated using a native implementation in order to save
+    git command function calls wherever possible.
 
     This provides custom merging facilities allowing to merge without actually changing
     your index or your working tree. This way you can perform own test-merges based
@@ -380,6 +379,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # END index merge handling
 
     # UTILITIES
+
     @unbare_repo
     def _iter_expand_paths(self: "IndexFile", paths: Sequence[PathLike]) -> Iterator[PathLike]:
         """Expand the directories in list of paths to the corresponding paths accordingly.

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -8,9 +8,10 @@ import sys
 
 import pytest
 
-from git.exc import GitCommandError
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
+
+import os.path
 
 
 class Tutorials(TestBase):
@@ -206,14 +207,6 @@ class Tutorials(TestBase):
         assert sm.module_exists()  # The submodule's working tree was checked out by update.
         # ![14-test_init_repo_object]
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_directory
     def test_references_and_objects(self, rw_dir):
         # [1-test_references_and_objects]

--- a/test/test_fun.py
+++ b/test/test_fun.py
@@ -3,13 +3,10 @@
 
 from io import BytesIO
 from stat import S_IFDIR, S_IFREG, S_IFLNK, S_IXUSR
-import os
+from os import stat
 import os.path as osp
 
-import pytest
-
 from git import Git
-from git.exc import GitCommandError
 from git.index import IndexFile
 from git.index.fun import (
     aggressive_tree_merge,
@@ -37,14 +34,6 @@ class TestFun(TestBase):
             assert (entry.path, entry.stage) in index.entries
         # END assert entry matches fully
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     def test_aggressive_tree_merge(self):
         # Head tree with additions, removals and modification compared to its predecessor.
         odb = self.rorepo.odb
@@ -302,12 +291,12 @@ class TestFun(TestBase):
         rw_master.git.worktree("add", worktree_path, branch.name)
 
         dotgit = osp.join(worktree_path, ".git")
-        statbuf = os.stat(dotgit)
+        statbuf = stat(dotgit)
         self.assertTrue(statbuf.st_mode & S_IFREG)
 
         gitdir = find_worktree_git_dir(dotgit)
         self.assertIsNotNone(gitdir)
-        statbuf = os.stat(gitdir)
+        statbuf = stat(gitdir)
         self.assertTrue(statbuf.st_mode & S_IFDIR)
 
     def test_tree_entries_from_data_with_failing_name_decode_py3(self):

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -284,14 +284,6 @@ class TestIndex(TestBase):
         except Exception as ex:
             assert "index.lock' could not be obtained" not in str(ex)
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("0.1.6")
     def test_index_file_from_tree(self, rw_repo):
         common_ancestor_sha = "5117c9c8a4d3af19a9958677e45cda9269de1541"
@@ -342,14 +334,6 @@ class TestIndex(TestBase):
         # END for each blob
         self.assertEqual(num_blobs, len(three_way_index.entries))
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("0.1.6")
     def test_index_merge_tree(self, rw_repo):
         # A bit out of place, but we need a different repo for this:
@@ -412,14 +396,6 @@ class TestIndex(TestBase):
         self.assertEqual(len(unmerged_blobs), 1)
         self.assertEqual(list(unmerged_blobs.keys())[0], manifest_key[0])
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("0.1.6")
     def test_index_file_diffing(self, rw_repo):
         # Default Index instance points to our index.
@@ -554,14 +530,6 @@ class TestIndex(TestBase):
 
     # END num existing helper
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("0.1.6")
     def test_index_mutation(self, rw_repo):
         index = rw_repo.index
@@ -915,14 +883,6 @@ class TestIndex(TestBase):
         for absfile in absfiles:
             assert osp.isfile(absfile)
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("HEAD")
     def test_compare_write_tree(self, rw_repo):
         """Test writing all trees, comparing them for equality."""

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -4,10 +4,7 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from itertools import chain
-import os
 from pathlib import Path
-
-import pytest
 
 from git import (
     Reference,
@@ -218,14 +215,6 @@ class TestRefs(TestBase):
         assert isinstance(res, SymbolicReference)
         assert res.name == "HEAD"
 
-    @pytest.mark.xfail(
-        os.name == "nt",
-        reason=(
-            "IndexFile.from_tree is broken on Windows (related to NamedTemporaryFile), see #1630.\n"
-            "'git read-tree --index-output=...' fails with 'fatal: unable to write new index file'."
-        ),
-        raises=GitCommandError,
-    )
     @with_rw_repo("0.1.6")
     def test_head_reset(self, rw_repo):
         cur_head = rw_repo.head


### PR DESCRIPTION
Fixes #1630

`IndexFile.from_tree` uses [`NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) to create a temporary file in the repository's `.git` directory to pass to `git read-tree` as the operand of `--index-output`. But on Windows, the command always fails: the `git` subprocess reports it cannot write to that path. `IndexFile.from_tree` and everything that uses it are thus broken on Windows. This is the cause of #1630, as `IndexFile.reset` uses `IndexFile.from_tree`.

`git read-tree` does not actually write to the *file* itself. Instead, it attempts to rename its own separate temporary file to have its name. `git read-tree` does not require that any file exist there already. The reason we create it is to get a filename that was definitely available, and prevent an unintended race condition on the name. As [git-read-tree(1)](https://git-scm.com/docs/git-read-tree#Documentation/git-read-tree.txt---index-outputltfilegt) says:

> **`--index-output=<file>`**\
> Instead of writing the results out to `$GIT_INDEX_FILE`, write the resulting index in the named file. While the command is operating, the original index file is locked with the same mechanism as usual. The file must allow to be rename(2)ed into from a temporary file that is created next to the usual index file; typically this means it needs to be on the same filesystem as the index file itself, and you need write permission to the directories the index file and index output file are located in.

Using `NamedTemporaryFile` for this works on Unix-like systems, but not on Windows, because `git` needs to be able to replace the file by renaming its own temporary file to the same name, which is a form of deletion: it deletes the file being replaced. `NamedTemporaryFile` opens the file, which remains open until the context manager object is exited. But on Windows, one cannot typically delete an open file. (As noted in b12fd4a, `NamedTemporaryFile` is often unsuitable for files shared with other processes on Windows even when they do not attempt to delete the file.)

This fixes the problem on Windows by using [`mkstemp`](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) to create the file, and managing cleanup explicitly. Both `NamedTemporaryFile` and `mkstemp` will create a file by opening it in a way that fails if the file already exists (and retrying other names if that happens). In this way they avoid the problems of [`mktemp`](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) (see also [smmap#41](https://github.com/gitpython-developers/smmap/issues/41)). Immediately after opening the file for creation to get the name, we close it. When we pass its name for `git read-tree` to rename its own temporary file to, `git` is able to do so.

More information about the problem, and how it is solved, appears in the commit messages. Especially:

- b12fd4a describes the problem in detail. It fixes it in a way that is very simple, but unsatisfactory because it introduces a race condition of the same kind one would get with `mktemp`. But this verifies the nature of the bug.
- 12bbace describes why `test_index_mutation` still fails (later than before, and unlike the other seven affected tests that now pass). It adds a conditional `xfail` mark. This is due to a test bug, but I think there are tradeoffs to be considered in deciding how to fix it, so I have not attempted to do so in this PR.
- 9e5d0aa describes the race condition from b12fd4a and how to overcome it. It applies the better fix. (Although the race condition would not be as severe here as in the common case where the file is being created in a shared temporary directory, it should still be avoided.)

---

I have not added any new test cases related to this bug. `IndexFile.from_tree` does not seem to have any of its own tests, and perhaps should. However, as described in the commit messages (and viewable in diffs removing `xfail` markings), eight tests were already failing due to it. Of those, seven now pass, while one, which tests a number of things, gets past the point where it failed before and fails later, differently and for an unrelated reason.

To further confirm specifically that this fixes #1630, I followed the procedure described there, which currently shows the bug on the tip of the main branch, but produces no error and successfully resets the change in the working tree at the tip of this topic branch:

```text
(.venv) C:\Users\ek\source\repos\GitPython [fromtree ≡]> rm pyproject.toml
(.venv) C:\Users\ek\source\repos\GitPython [fromtree ≡ +0 ~0 -1 !]> git status -sb
## fromtree...origin/fromtree
 D pyproject.toml
(.venv) C:\Users\ek\source\repos\GitPython [fromtree ≡ +0 ~0 -1 !]> python
Python 3.12.0 (tags/v3.12.0:0fb18b0, Oct  2 2023, 13:03:39) [MSC v.1935 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from git import Repo
>>> Repo().index.reset(working_tree=True)
<git.index.base.IndexFile object at 0x0000023657EF27F0>
>>> exit()
(.venv) C:\Users\ek\source\repos\GitPython [fromtree ≡]> git status -sb
## fromtree...origin/fromtree
(.venv) C:\Users\ek\source\repos\GitPython [fromtree ≡]>
```