### PR TITLE
Group .gitignore entries by purpose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,49 @@
+# Cached Python bytecode
+__pycache__/
 *.py[co]
+
+# Other caches
+.cache/
+.mypy_cache/
+.pytest_cache/
+
+# Transient editor files
 *.swp
 *~
+
+# Editor configuration
+nbproject
+*.sublime-workspace
+/.vscode/
+.idea/
+
+# Virtual environments
 .env/
 env/
 .venv/
 venv/
-/*.egg-info
+
+# Build output
+/*egg-info
 /lib/GitPython.egg-info
-cover/
-.coverage
-.coverage.*
 /build
 /dist
 /doc/_build
-nbproject
-*.sublime-workspace
-.DS_Store
-/*egg-info
+
+# Tox builds/environments
 /.tox
-/.vscode/
-.idea/
-.cache/
-.mypy_cache/
-.pytest_cache/
+
+# Code coverage output
+cover/
+.coverage
+.coverage.*
+
+# Monkeytype output
 monkeytype.sqlite3
+monkeytype.sqlite3.*
+
+# Manual command output
 output.txt
+
+# Finder metadata
+.DS_Store


### PR DESCRIPTION
It's sort of subjective whether, once `.gitignore` files become long, they should be grouped. The intention seemed roughly to group it, and I think this may be preferred to sorting it or doing neither.

This divides the entries into groups and labels each group with a comment.

I've also included some minor changes, which can be omitted if desired (I can amend and force push or commit again):

- Remove `/*.egg-info` because `/*egg-info` covers it.
- Add `__pycache__/` even though it should *probably* only contain `*.pyc` and `*.pyo`.
- Add `monkeytype.sqlite3.*` for compressed copies of that database. In [#1725](https://github.com/gitpython-developers/GitPython/pull/1725) I was tempted to remove `test/tstrunner.py`, but I'm glad I didn't, because it looks like MonkeyType may still be useful for next time work is done on improving type annotations. Actually, what seems most useful to me about it is that it detects cases where imports rewrite what modules are accessible where, causing [a situation where](https://github.com/gitpython-developers/GitPython/blob/fe082ad5e297119a3073dab74fa604eaf547ecc7/test/test_util.py#L138-L140) `from x.y import z` imports `z` from a different `y` than `import x.y` or `from x import y` imports. Anyway, the sqlite database it outputs is about 2.2 GiB, but compresses down to about 27 MiB (when `xz` is used). So I think it makes sense to ignore such files, too, to make working with them easier.