### PR TITLE
Avoid brittle assumptions about preexisting temporary files in tests

### DIFF
--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -71,15 +71,19 @@ class TestRepo(TestBase):
         for lfp in glob.glob(_tc_lock_fpaths):
             if osp.isfile(lfp):
                 raise AssertionError("Previous TC left hanging git-lock file: {}".format(lfp))
+
         import gc
 
         gc.collect()
 
     def test_new_should_raise_on_invalid_repo_location(self):
-        self.assertRaises(InvalidGitRepositoryError, Repo, tempfile.gettempdir())
+        with tempfile.TemporaryDirectory() as tdir:
+            self.assertRaises(InvalidGitRepositoryError, Repo, tdir)
 
     def test_new_should_raise_on_non_existent_path(self):
-        self.assertRaises(NoSuchPathError, Repo, "repos/foobar")
+        with tempfile.TemporaryDirectory() as tdir:
+            nonexistent = osp.join(tdir, "foobar")
+            self.assertRaises(NoSuchPathError, Repo, nonexistent)
 
     @with_rw_repo("0.3.2.1")
     def test_repo_creation_from_different_paths(self, rw_repo):


### PR DESCRIPTION
*This is a draft because I haven't pushed all commits yet.*

*May* fix #1744

Two tests had previously used `tempfile.gettempdir()` directly to get a directory to make assertions about, such as not being a valid git repository. One other test had created a repository at a hard-coded location relative to it, which in effect also assumed the availability of that path, a condition that may not hold, due either to GitPython's own previous test runs, unrelated use of those paths in a location like `/tmp`, or possibly other conditions. This uses newly created directories instead whose contents are known.

The tests this makes more robust include `test_new_should_raise_on_invalid_repo_location`, which is the one reported as failing on OpenIndiana in the build described in #1744. I believe this fully remedies that problem, but I do not believe it with high confidence. I had some trouble getting [oi-userland](https://github.com/OpenIndiana/oi-userland) set up in a way that would enable me to efficiently test this, and I would not be sure I had reproduced the precise conditions of the actual build.

I believe these improvements are worthwhile even separately from that, since the assumptions about `tempfile.gettempdir()` and its preexisting contents are minor test bugs in and of themselves. So I'm opening this PR now, but I want to make clear that while I *believe* this addresses #1744, I cannot be certain.

In part to make the tests more comprehensive, and in part because I think it may be relevant to the situation there, this also adds a related test, `test_new_should_raise_on_invalid_repo_location_within_repo`. This verifies that calling `Repo` on a directory that is not a git repository and that is known to reside *inside* a directory that is a git repository gives the same error as we expect when it is not (known to be) inside a repository.

A few more details are in commit messages, including on one of the tests that, while being made no longer to use a hard-coded path under `tempfile.gettempdir()`, now does its cleanup a little differently and cleanup now succeeds on it. So this turns out to be a small step toward #790.