### PR TITLE
Overhaul noqa directives

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -3,28 +3,27 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-# flake8: noqa
 # @PydevCodeAnalysisIgnore
-
-from git.exc import *  # @NoMove @IgnorePep8
-from typing import List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
-from git.types import PathLike
 
 __version__ = "git"
 
+from typing import List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+
 from gitdb.util import to_hex_sha
+from git.exc import *  # noqa: F403  # @NoMove @IgnorePep8
+from git.types import PathLike
 
 try:
     from git.compat import safe_decode  # @NoMove @IgnorePep8
     from git.config import GitConfigParser  # @NoMove @IgnorePep8
-    from git.objects import *  # @NoMove @IgnorePep8
-    from git.refs import *  # @NoMove @IgnorePep8
-    from git.diff import *  # @NoMove @IgnorePep8
-    from git.db import *  # @NoMove @IgnorePep8
+    from git.objects import *  # noqa: F403  # @NoMove @IgnorePep8
+    from git.refs import *  # noqa: F403  # @NoMove @IgnorePep8
+    from git.diff import *  # noqa: F403  # @NoMove @IgnorePep8
+    from git.db import *  # noqa: F403  # @NoMove @IgnorePep8
     from git.cmd import Git  # @NoMove @IgnorePep8
     from git.repo import Repo  # @NoMove @IgnorePep8
-    from git.remote import *  # @NoMove @IgnorePep8
-    from git.index import *  # @NoMove @IgnorePep8
+    from git.remote import *  # noqa: F403  # @NoMove @IgnorePep8
+    from git.index import *  # noqa: F403  # @NoMove @IgnorePep8
     from git.util import (  # @NoMove @IgnorePep8
         LockFile,
         BlockingLockFile,
@@ -33,12 +32,12 @@ try:
         remove_password_if_present,
         rmtree,
     )
-except GitError as _exc:
+except GitError as _exc:  # noqa: F405
     raise ImportError("%s: %s" % (_exc.__class__.__name__, _exc)) from _exc
 
 # __all__ must be statically defined by py.typed support
 # __all__ = [name for name, obj in locals().items() if not (name.startswith("_") or inspect.ismodule(obj))]
-__all__ = [
+__all__ = [  # noqa: F405
     "Actor",
     "AmbiguousObjectName",
     "BadName",
@@ -127,7 +126,7 @@ def refresh(path: Optional[PathLike] = None) -> None:
 
     if not Git.refresh(path=path):
         return
-    if not FetchInfo.refresh():
+    if not FetchInfo.refresh():  # noqa: F405
         return  # type: ignore [unreachable]
 
     GIT_OK = True

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -965,7 +965,7 @@ class Git(LazyMixin):
             # Only search PATH, not CWD. This must be in the *caller* environment. The "1" can be any value.
             maybe_patch_caller_env = patch_env("NoDefaultCurrentDirectoryInExePath", "1")
         else:
-            cmd_not_found_exception = FileNotFoundError  # NOQA # exists, flake8 unknown @UndefinedVariable
+            cmd_not_found_exception = FileNotFoundError
             maybe_patch_caller_env = contextlib.nullcontext()
         # END handle
 

--- a/git/compat.py
+++ b/git/compat.py
@@ -5,20 +5,15 @@
 
 """Utilities to help provide compatibility with Python 3."""
 
-# flake8: noqa
-
 import locale
 import os
 import sys
 
-from gitdb.utils.encoding import (
-    force_bytes,  # @UnusedImport
-    force_text,  # @UnusedImport
-)
+from gitdb.utils.encoding import force_bytes, force_text  # noqa: F401  # @UnusedImport
 
 # typing --------------------------------------------------------------------
 
-from typing import (
+from typing import (  # noqa: F401
     Any,
     AnyStr,
     Dict,

--- a/git/index/__init__.py
+++ b/git/index/__init__.py
@@ -3,7 +3,5 @@
 
 """Initialize the index package."""
 
-# flake8: noqa
-
-from .base import *
-from .typ import *
+from .base import *  # noqa: F401 F403
+from .typ import *  # noqa: F401 F403

--- a/git/objects/__init__.py
+++ b/git/objects/__init__.py
@@ -3,23 +3,21 @@
 
 """Import all submodules' main classes into the package space."""
 
-# flake8: noqa
-
 import inspect
 
-from .base import *
-from .blob import *
-from .commit import *
+from .base import *  # noqa: F403
+from .blob import *  # noqa: F403
+from .commit import *  # noqa: F403
 from .submodule import util as smutil
-from .submodule.base import *
-from .submodule.root import *
-from .tag import *
-from .tree import *
+from .submodule.base import *  # noqa: F403
+from .submodule.root import *  # noqa: F403
+from .tag import *  # noqa: F403
+from .tree import *  # noqa: F403
 
 # Fix import dependency - add IndexObject to the util module, so that it can be
 # imported by the submodule.base.
-smutil.IndexObject = IndexObject  # type: ignore[attr-defined]
-smutil.Object = Object  # type: ignore[attr-defined]
+smutil.IndexObject = IndexObject  # type: ignore[attr-defined]  # noqa: F405
+smutil.Object = Object  # type: ignore[attr-defined]  # noqa: F405
 del smutil
 
 # Must come after submodule was made available.

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -958,7 +958,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             raise
         # END handle undo rename
 
-        # Auto-rename submodule if it's name was 'default', that is, the checkout directory.
+        # Auto-rename submodule if its name was 'default', that is, the checkout directory.
         if previous_sm_path == self.name:
             self.rename(module_checkout_path)
 
@@ -976,19 +976,19 @@ class Submodule(IndexObject, TraversableIterableObj):
         from the .gitmodules file and the entry in the .git/config file.
 
         :param module: If True, the checked out module we point to will be deleted as
-            well.If that module is currently on a commit outside any branch in the
+            well. If that module is currently on a commit outside any branch in the
             remote, or if it is ahead of its tracking branch, or if there are modified
-            or untracked files in its working tree, then the removal will fail.
-            In case the removal of the repository fails for these reasons, the
-            submodule status will not have been altered.
+            or untracked files in its working tree, then the removal will fail. In case
+            the removal of the repository fails for these reasons, the submodule status
+            will not have been altered.
             If this submodule has child modules of its own, these will be deleted prior
             to touching the direct submodule.
         :param force: Enforces the deletion of the module even though it contains
             modifications. This basically enforces a brute-force file system based
             deletion.
         :param configuration: If True, the submodule is deleted from the configuration,
-            otherwise it isn't. Although this should be enabled most of the time,
-            this flag enables you to safely delete the repository of your submodule.
+            otherwise it isn't. Although this should be enabled most of the time, this
+            flag enables you to safely delete the repository of your submodule.
         :param dry_run: If True, we will not actually do anything, but throw the errors
             we would usually throw.
         :return: self

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -5,20 +5,16 @@
 
 """General utility functions."""
 
-# flake8: noqa F401
-
-
 from abc import ABC, abstractmethod
-import warnings
-from git.util import IterableList, IterableObj, Actor
-
-import re
-from collections import deque
-
-from string import digits
-import time
 import calendar
+from collections import deque
 from datetime import datetime, timedelta, tzinfo
+from string import digits
+import re
+import time
+import warnings
+
+from git.util import IterableList, IterableObj, Actor
 
 # typing ------------------------------------------------------------
 from typing import (
@@ -26,10 +22,10 @@ from typing import (
     Callable,
     Deque,
     Iterator,
-    Generic,
+    # Generic,
     NamedTuple,
     overload,
-    Sequence,  # NOQA: F401
+    Sequence,
     TYPE_CHECKING,
     Tuple,
     Type,
@@ -38,7 +34,7 @@ from typing import (
     cast,
 )
 
-from git.types import Has_id_attribute, Literal, _T  # NOQA: F401
+from git.types import Has_id_attribute, Literal  # , _T
 
 if TYPE_CHECKING:
     from io import BytesIO, StringIO

--- a/git/refs/__init__.py
+++ b/git/refs/__init__.py
@@ -1,13 +1,12 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-# flake8: noqa
 # Import all modules in order, fix the names they require.
 
-from .symbolic import *
-from .reference import *
-from .head import *
-from .tag import *
-from .remote import *
+from .symbolic import *  # noqa: F401 F403
+from .reference import *  # noqa: F401 F403
+from .head import *  # noqa: F401 F403
+from .tag import *  # noqa: F401 F403
+from .remote import *  # noqa: F401 F403
 
-from .log import *
+from .log import *  # noqa: F401 F403

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -31,9 +31,9 @@ from typing import Iterator, List, Tuple, Union, TYPE_CHECKING
 from git.types import PathLike
 
 if TYPE_CHECKING:
-    from git.refs import SymbolicReference
     from io import BytesIO
-    from git.config import GitConfigParser, SectionConstraint  # NOQA
+    from git.refs import SymbolicReference
+    from git.config import GitConfigParser, SectionConstraint
 
 # ------------------------------------------------------------------------------
 

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -10,8 +10,8 @@ from .symbolic import SymbolicReference, T_References
 
 # typing ------------------------------------------------------------------
 
-from typing import Any, Callable, Iterator, Type, Union, TYPE_CHECKING  # NOQA
-from git.types import Commit_ish, PathLike, _T  # NOQA
+from typing import Any, Callable, Iterator, Type, Union, TYPE_CHECKING
+from git.types import Commit_ish, PathLike, _T
 
 if TYPE_CHECKING:
     from git.repo import Repo

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -1,7 +1,6 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-from git.types import PathLike
 import os
 
 from git.compat import defenc
@@ -31,8 +30,8 @@ from typing import (
     Union,
     TYPE_CHECKING,
     cast,
-)  # NOQA
-from git.types import Commit_ish, PathLike  # NOQA
+)
+from git.types import Commit_ish, PathLike
 
 if TYPE_CHECKING:
     from git.repo import Repo

--- a/git/repo/__init__.py
+++ b/git/repo/__init__.py
@@ -3,6 +3,4 @@
 
 """Initialize the Repo package."""
 
-# flake8: noqa
-
-from .base import Repo as Repo
+from .base import Repo as Repo  # noqa: F401

--- a/git/types.py
+++ b/git/types.py
@@ -1,11 +1,9 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-# flake8: noqa
-
 import os
 import sys
-from typing import (
+from typing import (  # noqa: F401
     Dict,
     NoReturn,
     Sequence as Sequence,
@@ -16,24 +14,24 @@ from typing import (
     Callable,
     TYPE_CHECKING,
     TypeVar,
-)  # noqa: F401
+)
 
 if sys.version_info >= (3, 8):
-    from typing import (
+    from typing import (  # noqa: F401
         Literal,
         TypedDict,
         Protocol,
         SupportsIndex as SupportsIndex,
         runtime_checkable,
-    )  # noqa: F401
+    )
 else:
-    from typing_extensions import (
+    from typing_extensions import (  # noqa: F401
         Literal,
         SupportsIndex as SupportsIndex,
         TypedDict,
         Protocol,
         runtime_checkable,
-    )  # noqa: F401
+    )
 
 # if sys.version_info >= (3, 10):
 #     from typing import TypeGuard  # noqa: F401

--- a/git/util.py
+++ b/git/util.py
@@ -62,12 +62,9 @@ from .types import (
     Has_id_attribute,
 )
 
-T_IterableObj = TypeVar("T_IterableObj", bound=Union["IterableObj", "Has_id_attribute"], covariant=True)
-# So IterableList[Head] is subtype of IterableList[IterableObj]
-
 # ---------------------------------------------------------------------
 
-from gitdb.util import (  # NOQA @IgnorePep8
+from gitdb.util import (  # noqa: F401  # @IgnorePep8
     make_sha,
     LockedFD,  # @UnusedImport
     file_contents_ro,  # @UnusedImport
@@ -78,6 +75,9 @@ from gitdb.util import (  # NOQA @IgnorePep8
     bin_to_hex,  # @UnusedImport
     hex_to_bin,  # @UnusedImport
 )
+
+T_IterableObj = TypeVar("T_IterableObj", bound=Union["IterableObj", "Has_id_attribute"], covariant=True)
+# So IterableList[Head] is subtype of IterableList[IterableObj].
 
 # NOTE:  Some of the unused imports might be used/imported by others.
 # Handle once test-cases are back up and running.

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -3,8 +3,8 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-# flake8: noqa
 import inspect
-from .helper import *
+
+from .helper import *  # noqa: F401 F403
 
 __all__ = [name for name, obj in locals().items() if not (name.startswith("_") or inspect.ismodule(obj))]

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -145,7 +145,7 @@ def with_rw_repo(working_tree_ref, bare=False):
             os.chdir(rw_repo.working_dir)
             try:
                 return func(self, rw_repo)
-            except:  # noqa E722
+            except:  # noqa: E722 B001
                 log.info("Keeping repo after failure: %s", repo_dir)
                 repo_dir = None
                 raise
@@ -305,7 +305,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
                     with cwd(rw_repo.working_dir):
                         try:
                             return func(self, rw_repo, rw_daemon_repo)
-                        except:  # noqa E722
+                        except:  # noqa: E722 B001
                             log.info(
                                 "Keeping repos after failure: \n  rw_repo_dir: %s \n  rw_daemon_repo_dir: %s",
                                 rw_repo_dir,

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -475,7 +475,7 @@ JzJMZDRLQLFvnzqZuCjE
             commit.authored_datetime,
             datetime(2009, 10, 8, 18, 17, 5, tzinfo=tzoffset(-7200)),
             commit.authored_datetime,
-        )  # noqa
+        )
         self.assertEqual(
             commit.authored_datetime,
             datetime(2009, 10, 8, 16, 17, 5, tzinfo=utc),

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -125,7 +125,7 @@ class TestBase(TestCase):
             ev = "ruby -e '\n"
             ev += "		system %(git), %(merge-file), %(--marker-size=%L), %(%A), %(%O), %(%B)\n"
             ev += "		b = File.read(%(%A))\n"
-            ev += "		b.sub!(/^<+ .*\\nActiveRecord::Schema\\.define.:version => (\\d+). do\\n=+\\nActiveRecord::Schema\\."  # noqa E501
+            ev += "		b.sub!(/^<+ .*\\nActiveRecord::Schema\\.define.:version => (\\d+). do\\n=+\\nActiveRecord::Schema\\."  # noqa: E501
             ev += "define.:version => (\\d+). do\\n>+ .*/) do\n"
             ev += "		  %(ActiveRecord::Schema.define(:version => #{[$1, $2].max}) do)\n"
             ev += "		end\n"

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -25,7 +25,7 @@ class Tutorials(TestBase):
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "
-    #         "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx")  # noqa E501
+    #         "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\test_work_tree_unsupportedryfa60di\\master_repo\\.git\\objects\\pack\\pack-bc9e0787aef9f69e1591ef38ea0a6f566ec66fe3.idx")  # noqa: E501
     @with_rw_directory
     def test_init_repo_object(self, rw_dir):
         # [1-test_init_repo_object]

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -40,13 +40,13 @@ _cmd_argvs = (
     ),
 )
 _causes_n_substrings = (
-    (None, None),  # noqa: E241 @IgnorePep8
-    (7, "exit code(7)"),  # noqa: E241 @IgnorePep8
-    ("Some string", "'Some string'"),  # noqa: E241 @IgnorePep8
-    ("παλιο string", "'παλιο string'"),  # noqa: E241 @IgnorePep8
-    (Exception("An exc."), "Exception('An exc.')"),  # noqa: E241 @IgnorePep8
-    (Exception("Κακια exc."), "Exception('Κακια exc.')"),  # noqa: E241 @IgnorePep8
-    (object(), "<object object at "),  # noqa: E241 @IgnorePep8
+    (None, None),
+    (7, "exit code(7)"),
+    ("Some string", "'Some string'"),
+    ("παλιο string", "'παλιο string'"),
+    (Exception("An exc."), "Exception('An exc.')"),
+    (Exception("Κακια exc."), "Exception('Κακια exc.')"),
+    (object(), "<object object at "),
 )
 
 _streams_n_substrings = (

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -207,7 +207,7 @@ class TestRefs(TestBase):
         assert not SymbolicReference(self.rorepo, "hellothere").is_valid()
 
     def test_orig_head(self):
-        assert type(self.rorepo.head.orig_head()) == SymbolicReference
+        assert type(self.rorepo.head.orig_head()) is SymbolicReference
 
     @with_rw_repo("0.1.6")
     def test_head_checkout_detached_head(self, rw_repo):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -769,7 +769,7 @@ class TestRepo(TestBase):
                         range(13, 15),
                     ]
                 ),
-            )  # noqa E501
+            )
 
     @mock.patch.object(Git, "_call_process")
     def test_blame_complex_revision(self, git):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -460,7 +460,7 @@ class TestSubmodule(TestBase):
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: fails with: PermissionError: [WinError 32] The process cannot access the file because"
     #         "it is being used by another process: "
-    #         "'C:\\Users\\ankostis\\AppData\\Local\\Temp\\tmp95c3z83bnon_bare_test_base_rw\\git\\ext\\gitdb\\gitdb\\ext\\smmap'")  # noqa E501
+    #         "'C:\\Users\\ankostis\\AppData\\Local\\Temp\\tmp95c3z83bnon_bare_test_base_rw\\git\\ext\\gitdb\\gitdb\\ext\\smmap'")  # noqa: E501
     @with_rw_repo(k_subm_current)
     def test_base_rw(self, rwrepo):
         self._do_base_tests(rwrepo)


### PR DESCRIPTION
This includes a few small style improvements I had missed in previous PRs, but consist mostly of improvements to how and where `noqa` directives are used, and code changes (intended to be non-breaking and uncontroversial) to go along with that.

The directives are made more precise. They always give specific errors/warnings to suppress, both where that had been intended but idiosyncrasies of the syntax caused them to be broader, and where nothing had been given before. All `noqa` directives are now statement-level rather than file-level. Some of those that were no longer needed are removed with no other associated change. Some others are removed together with minimal changes to the code they complained about or to other `noqa` directives that had been ineffective (such as due to their placement).

The commit messages have some more information about the details of the changes.