### PR TITLE
Clarify some Git.execute kill_after_timeout limitations

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -879,11 +879,19 @@ class Git(LazyMixin):
             Specifies a timeout in seconds for the git command, after which the process
             should be killed. This will have no effect if `as_process` is set to True.
             It is set to None by default and will let the process run until the timeout
-            is explicitly specified. This feature is not supported on Windows. It's also
-            worth noting that `kill_after_timeout` uses SIGKILL, which can have negative
-            side effects on a repository. For example, stale locks in case of ``git gc``
-            could render the repository incapable of accepting changes until the lock is
-            manually removed.
+            is explicitly specified. Uses of this feature should be carefully
+            considered, due to the following limitations:
+
+            1. This feature is not supported at all on Windows.
+            2. Effectiveness may vary by operating system. ``ps --ppid`` is used to
+               enumerate child processes, which is available on most GNU/Linux systems
+               but not most others.
+            3. Deeper descendants do not receive signals, though they may sometimes
+               terminate as a consequence of their parent processes being killed.
+            4. `kill_after_timeout` uses ``SIGKILL``, which can have negative side
+               effects on a repository. For example, stale locks in case of ``git gc``
+               could render the repository incapable of accepting changes until the lock
+               is manually removed.
 
         :param with_stdout:
             If True, default True, we open stdout on the created process.


### PR DESCRIPTION
This makes the two preliminary changes discussed as possibly useful in https://github.com/gitpython-developers/GitPython/issues/1756#issuecomment-1848350451:

- **The `Git.execute` docstring is modified to include additional portability information for `kill_after_timeout`.** I've tried to do this in a way that avoids going into too much detail, but still gives enough information to allow developers of software using GitPython to infer what systems may be reasonable to use it on, or what the effects of using it on systems where it is less effective might be. I considered linking in the docstring to #1756 or discussing the race condition issue, but omitted both at this time. I'd be pleased to add such information if it is wanted.

- **The implementation of the local `kill_process` function, which is used as the callback for `kill_after_timeout`, is modified to avoid giving the impression that it could be safely or effectively used in similar form on Windows.** This mostly consists of removing code that was present with the intention of supporting Windows. But one of the changes that is part of this is raising `AssertionError` in the event that it somehow were called on Windows. This should not currently be able to happen because Windows is checked for, and an exception raised, [prior to registering](https://github.com/gitpython-developers/GitPython/blob/a58a6be043f62e6552ef1638ec497f3b805c5480/git/cmd.py#L960-L964) the callback in the first place. But this is an area of the code that is somewhat complicated, and I think this may be justified to express how that code is not portable or safe for Windows as written. The changes to `kill_process` are done in their own commit (and just one), so that they are easier to identify if in the future some of the attempts for it to support Windows are revisited (though this could not be done by calling the `ps` command).

See discussion in #1756. However, I do not assum based on what has been discussed there that these specific changes are necessarily ideal, and I'd be pleased to make changes on request.

I considered adding a test but decided not to, based in part on the point about tests in https://github.com/gitpython-developers/GitPython/issues/1756#issuecomment-1838101270, and in part on the limited nature of the changes. However, I did do the following to check that it still seems to work:

```text
>>> git.Git().execute(['sleep', '10'], kill_after_timeout=5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/GitPython/git/cmd.py", line 1111, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('sleep') failed due to: exit code(-9)
  cmdline: sleep 10
  stderr: 'Timeout: the command "sleep 10" did not complete in 5 secs.'
>>> git.Git().execute(['sleep', '4'], kill_after_timeout=5)
''
```