### PR TITLE
Extract all "import gc" to module level

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1,6 +1,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 from io import BytesIO
 import logging
 import os
@@ -1079,8 +1080,6 @@ class Submodule(IndexObject, TraversableIterableObj):
                     self._clear_cache()
                     wtd = mod.working_tree_dir
                     del mod  # Release file-handles (Windows).
-                    import gc
-
                     gc.collect()
                     rmtree(str(wtd))
                 # END delete tree if possible

--- a/test/performance/test_commit.py
+++ b/test/performance/test_commit.py
@@ -5,6 +5,7 @@
 
 """Performance tests for commits (iteration, traversal, and serialization)."""
 
+import gc
 from io import BytesIO
 from time import time
 import sys
@@ -17,8 +18,6 @@ from test.test_commit import TestCommitSerialization
 
 class TestPerformance(TestBigRepoRW, TestCommitSerialization):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     # ref with about 100 commits in its history.

--- a/test/performance/test_streams.py
+++ b/test/performance/test_streams.py
@@ -3,6 +3,7 @@
 
 """Performance tests for data streaming."""
 
+import gc
 import os
 import subprocess
 import sys
@@ -92,8 +93,6 @@ class TestObjDBPerformance(TestBigRepoR):
 
             # del db file so git has something to do.
             ostream = None
-            import gc
-
             gc.collect()
             os.remove(db_file)
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 import os
 import sys
 import tempfile
@@ -20,8 +21,6 @@ import os.path as osp
 
 class TestBase(_TestBase):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     type_tuples = (

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 import os
 import sys
 
@@ -16,8 +17,6 @@ import os.path
 
 class Tutorials(TestBase):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     # ACTUALLY skipped by git.util.rmtree (in local onerror function), from the last call to it via

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 import inspect
 import logging
 import os
@@ -34,8 +35,6 @@ class TestGit(TestBase):
         cls.git = Git(cls.rorepo.working_dir)
 
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     def _assert_logged_for_popen(self, log_watcher, name, value):

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -1,14 +1,14 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
+
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
 
 
 class QuickDoc(TestBase):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     @with_rw_directory

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 import os
 import os.path as osp
 from pathlib import Path
@@ -105,8 +106,6 @@ class TestRemoteProgress(RemoteProgress):
 
 class TestRemote(TestBase):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     def _print_fetchhead(self, repo):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -3,6 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+import gc
 import glob
 import io
 from io import BytesIO
@@ -71,8 +72,6 @@ class TestRepo(TestBase):
         for lfp in glob.glob(_tc_lock_fpaths):
             if osp.isfile(lfp):
                 raise AssertionError("Previous TC left hanging git-lock file: {}".format(lfp))
-
-        import gc
 
         gc.collect()
 

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -2,6 +2,7 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import contextlib
+import gc
 import os
 import os.path as osp
 from pathlib import Path
@@ -61,8 +62,6 @@ prog = TestRootProgress()
 
 class TestSubmodule(TestBase):
     def tearDown(self):
-        import gc
-
         gc.collect()
 
     k_subm_current = "c15a6e1923a14bc760851913858a3942a4193cdb"


### PR DESCRIPTION
The `gc` module [was already imported](https://github.com/gitpython-developers/GitPython/blob/68272aa0028c35bd4bf36ebfd0fb55ac292b163d/git/repo/base.py#L8) at module scope in `git/repo/base.py`. Although it was moved recently, it is not a new addition. It has been present for about seven years, since f1a82e4 (#555). Importing the top-level git module or any submodule of it runs that import statement:

```python
>>> import sys
>>> "gc" in sys.modules
False
>>> import git
>>> "gc" in sys.modules
True
```

Because the `gc` module is already imported, reimporting it is fast.

Imports that there is no specific reason to do locally should be at module scope. Having them local decreased readability, in part because of how black inserts a black line between them and `gc.collect()` calls they are imported to allow.

An alternative to this change would be to remove the preexisting top-level `import gc` (there is also another one in the test suite) and replace it with a local import as well. I am unsure if that would affect performance and, if so, whether the effect would be good or bad, since the small delay of the import might potentially be less desirable to an application if it occurs while the work of the application is already in progress.

If a `gc.collect()` call runs as a consequence of a finally block or `__del__` method being called during interpreter shutdown, then in (very) rare cases the variable may have been set to None. But this does not appear to have been the intent behind making the imports local. More importantly, a local import should not be expected to succeed, or the imported module usable, in such a situation.

---

Conceptually unrelated to this, it looks like the newly released version of `black` fails to install on Cygwin in the `test-cygwin.yml` workflow. I expect failures from that workflow for this reason. Although unrelated, there is of course no rush on this PR, and if that does happen, it would prevent any Cygwin tests from running until a fix or workaround is applied. If that is fixed first, this PR could be rebased. If this problem doesn't happen, then it is resolved or somehow specific to the setup in my fork and on my local machine, in which case probably nothing has to be done about it.