### PR TITLE
Don't install black on Cygwin

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-black
+black ; sys_platform != "cygwin"
 coverage[toml]
 ddt >= 1.1.1, != 1.4.3
 mock ; python_version < "3.8"


### PR DESCRIPTION
This makes the `black` test dependency apply only to systems *other* than Cygwin. It does not block `black` from being separately installed. It does not reconfigure or otherwise affect pre-commit hooks. This is to work around a problem where the newest stable version of `black` fails to install on Cygwin. Pinning `black` to the previous stable version specifically on Cygwin would also work, but this is simpler and it is not obvious that there is much of a benefit to installing `black` (automatically) on Cygwin.

As of black 23.12.0 and [as seen](https://github.com/gitpython-developers/GitPython/actions/runs/7181278013/job/19555344996) in #1765 ([d70ba69](https://github.com/gitpython-developers/GitPython/pull/1765/commits/d70ba6941cf0f005f3f247c70233f51a0cc35969)), installing `black` builds a wheel on Cygwin, downloading dependencies for the "d" extra (i.e., `black[d]`), which provides dependencies for running the `blackd` daemon. This includes dependencies, such as `asyncio`, whose compilation fails on CI as it is currently set up, fails under some common Cygwin setups (since it needs a C compiler, the Python headers, and possibly other dependencies), and even if successful would cause the Cygwin test workflow to take significantly longer to run. This consistently occurs on this project's CI and on my local Cygwin setup.

A better solution may be preferred, especially if some users are actually running black on Cygwin (though it can be installed at a previous version, if acceptable, in the virtual environment). So this may be viewed as a stopgap measure until a better solution is put in place.

I do not know if the problem is due to a bug in Black. Although [some changes have been made](https://github.com/psf/black/compare/23.11.0...23.12.0) in Black's `pyproject.toml` since the previous release, including to its dependencies in the "d" group, it does not look like these changes should cause this to happen. Inspection of the available wheels on PyPI for both versions ([23.11.0](https://pypi.org/project/black/23.11.0/#files), [23.12.0](https://pypi.org/project/black/23.12.0/#files)) also does not point to an obvious explanation, though I could be missing something.

It seems no similar situation occurs on other systems, even with Python 3.9 (the version this project tests with on Cygwin).