### PR TITLE
Replace xfail with gc.collect in TestSubmodule.test_rename

### DIFF
--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -948,18 +948,6 @@ class TestSubmodule(TestBase):
         sm.remove()
         assert not sm.exists()
 
-    @pytest.mark.xfail(
-        os.name == "nt" and sys.version_info >= (3, 12),
-        reason=(
-            "The sm.move call fails. Submodule.move calls os.renames, which raises:\n"
-            "PermissionError: [WinError 32] "
-            "The process cannot access the file because it is being used by another process: "
-            R"'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\mymodules\myname' "
-            R"-> 'C:\Users\ek\AppData\Local\Temp\test_renamekkbznwjp\parent\renamed\myname'"
-            "\nThis resembles other Windows errors, but only occurs starting in Python 3.12."
-        ),
-        raises=PermissionError,
-    )
     @with_rw_directory
     def test_rename(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -958,6 +958,12 @@ class TestSubmodule(TestBase):
         assert sm.rename(sm_name) is sm and sm.name == sm_name
         assert not sm.repo.is_dirty(index=True, working_tree=False, untracked_files=False)
 
+        # This is needed to work around a PermissionError on Windows, resembling others,
+        # except new in Python 3.12. (*Maybe* this could be due to changes in CPython's
+        # garbage collector detailed in https://github.com/python/cpython/issues/97922.)
+        if os.name == "nt" and sys.version_info >= (3, 12):
+            gc.collect()
+
         new_path = "renamed/myname"
         assert sm.move(new_path).name == new_path
 


### PR DESCRIPTION
In various places in the code, a conditional `gc.collect()` is used to allow a test to finish its work (and pass). This adds one more such place. It accordingly removes an xfail marking. `TestSubmodule.test_rename` now passes on all combinations of platform and Python version.

Like the xfail condition, running `gc.collect()` here is conditional, being done only in the specific situation the `PermissionError` occurs. Besides that it does not always run even on Windows (only in 3.12 and later), this resembles various other conditional and non-conditional gc.collect calls.

The situation is a bit odd, but I think that's--albeit by a fairly slight margin--more of a reason to convert the xfail into a `gc.collect()` than to refrain from doing so.

#### Context

#1745 (under "Which versions should we test?"), and also 82c361e, 0b7ee17, and various other less interesting commits, provide further context about this test and the `PermissionError` on Windows that does not occur prior to 3.12.

Because `PermissionError` error message is about another process having the file open, #790 seems relevant. But this does not happen in a call to `git.util.rmtree`.

#### One call is enough, now

It had previously appeared to me that two calls to `gc.collect` were required, but I am unable to reproduce that. It may have been specific to how I was running it on my system at that time. The need for only one call may have been brought about by changes to the code in the mean time, but I have tested that only one call appears required even without the changes in #1765. (Perhaps #1753 contributed? I think most likely not, though.)