### PR TITLE
Replace some uses of the deprecated mktemp function

### DIFF
--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -89,8 +89,7 @@ def with_rw_directory(func):
 
     @wraps(func)
     def wrapper(self):
-        path = tempfile.mktemp(prefix=func.__name__)
-        os.mkdir(path)
+        path = tempfile.mkdtemp(prefix=func.__name__)
         keep = False
         try:
             return func(self, path)

--- a/test/performance/lib.py
+++ b/test/performance/lib.py
@@ -65,8 +65,7 @@ class TestBigRepoRW(TestBigRepoR):
     def setUp(self):
         self.gitrwrepo = None
         super().setUp()
-        dirname = tempfile.mktemp()
-        os.mkdir(dirname)
+        dirname = tempfile.mkdtemp()
         self.gitrwrepo = self.gitrorepo.clone(dirname, shared=True, bare=True, odbt=GitCmdObjectDB)
         self.puregitrwrepo = Repo(dirname, odbt=GitDB)
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -68,12 +68,11 @@ class TestBase(_TestBase):
             data = data_stream.read()
             assert data
 
-            tmpfilename = tempfile.mktemp(suffix="test-stream")
-            with open(tmpfilename, "wb+") as tmpfile:
+            with tempfile.NamedTemporaryFile(suffix="test-stream", delete=False) as tmpfile:
                 self.assertEqual(item, item.stream_data(tmpfile))
                 tmpfile.seek(0)
                 self.assertEqual(tmpfile.read(), data)
-            os.remove(tmpfilename)
+            os.remove(tmpfile.name)  # Do it this way so we can inspect the file on failure.
         # END for each object type to create
 
         # Each has a unique sha.

--- a/test/test_reflog.py
+++ b/test/test_reflog.py
@@ -1,15 +1,13 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-import os
+import os.path as osp
 import tempfile
 
 from git.objects import IndexObject
 from git.refs import RefLogEntry, RefLog
 from test.lib import TestBase, fixture_path
 from git.util import Actor, rmtree, hex_to_bin
-
-import os.path as osp
 
 
 class TestRefLog(TestBase):
@@ -35,8 +33,7 @@ class TestRefLog(TestBase):
     def test_base(self):
         rlp_head = fixture_path("reflog_HEAD")
         rlp_master = fixture_path("reflog_master")
-        tdir = tempfile.mktemp(suffix="test_reflogs")
-        os.mkdir(tdir)
+        tdir = tempfile.mkdtemp(suffix="test_reflogs")
 
         rlp_master_ro = RefLog.path(self.rorepo.head)
         assert osp.isfile(rlp_master_ro)

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -667,11 +667,10 @@ class TestRepo(TestBase):
         self.assertEqual(value_errors, [])
 
     def test_archive(self):
-        tmpfile = tempfile.mktemp(suffix="archive-test")
-        with open(tmpfile, "wb") as stream:
+        with tempfile.NamedTemporaryFile("wb", suffix="archive-test", delete=False) as stream:
             self.rorepo.archive(stream, "0.1.6", path="doc")
             assert stream.tell()
-        os.remove(tmpfile)
+        os.remove(stream.name)  # Do it this way so we can inspect the file on failure.
 
     @mock.patch.object(Git, "_call_process")
     def test_should_display_blame_information(self, git):


### PR DESCRIPTION
`tempfile.mktemp` is deprecated for security reasons and the race condition inherent to its use can have an impact on robustness even in situations where the security impact is small or nonexistent. I do not believe the changes made here are fixing security vulnerabilities; I was not able, at least so far, to think of likely ways they could be exploited. Nonetheless I believe these changes are justified, as detailed in the commit messages.

Only one of the uses of `mktemp` was in the `git` module itself. Others are in the test suite. There are a few more in the test suite where I am unsure what the best approach is to replacing them, though I hope to propose a change to eliminate them in the future. All of these considerations, as well as the general issues surrounding `mktemp` and its deprecation, are detailed in the two commit messages.

- 41fac85 makes changes in the test suite.
- 9e86053 changes code in the `git` module.

See also:

- https://github.com/gitpython-developers/smmap/issues/41, which is also about `mktemp`. (I've [proposed a fix](https://github.com/gitpython-developers/smmap/pull/56).) That looks like the only use of `mktemp` in smmap. There are some in gitdb as well, and (as noted) some in GitPython that this PR does not cover.
- #1769 - If you decide both to enable CodeQL and to merge this PR, and they are done in that order, then the effects of this PR will be reflected as changes to the "Code scanning" alerts.