### PR TITLE
Run some Windows environment variable tests only on Windows

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -46,7 +46,7 @@ def permission_error_tmpdir(tmp_path):
     """Fixture to test permissions errors in situations where they are not overcome."""
     td = tmp_path / "testdir"
     td.mkdir()
-    (td / "x").write_bytes(b"")
+    (td / "x").touch()
 
     # Set up PermissionError on Windows, where we can't delete read-only files.
     (td / "x").chmod(stat.S_IRUSR)
@@ -73,7 +73,7 @@ class TestRmtree:
             td / "s" / "y",
             td / "s" / "z",
         ):
-            f.write_bytes(b"")
+            f.touch()
 
         try:
             rmtree(td)
@@ -95,7 +95,7 @@ class TestRmtree:
         for d in td, td / "sub":
             d.mkdir()
         for f in td / "x", td / "sub" / "y":
-            f.write_bytes(b"")
+            f.touch()
             f.chmod(0)
 
         try:
@@ -115,7 +115,7 @@ class TestRmtree:
 
         dir1 = tmp_path / "dir1"
         dir1.mkdir()
-        (dir1 / "file").write_bytes(b"")
+        (dir1 / "file").touch()
         (dir1 / "file").chmod(stat.S_IRUSR)
         old_mode = (dir1 / "file").stat().st_mode
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -207,24 +207,28 @@ class TestEnvParsing:
         )
         return ast.literal_eval(output)
 
+    @pytest.mark.skipif(
+        os.name != "nt",
+        reason="These environment variables are only used on Windows.",
+    )
     @pytest.mark.parametrize(
         "env_var_value, expected_truth_value",
         [
-            (None, os.name == "nt"),  # True on Windows when the environment variable is unset.
+            (None, True),  # When the environment variable is unset.
             ("", False),
             (" ", False),
             ("0", False),
-            ("1", os.name == "nt"),
+            ("1", True),
             ("false", False),
-            ("true", os.name == "nt"),
+            ("true", True),
             ("False", False),
-            ("True", os.name == "nt"),
+            ("True", True),
             ("no", False),
-            ("yes", os.name == "nt"),
+            ("yes", True),
             ("NO", False),
-            ("YES", os.name == "nt"),
+            ("YES", True),
             (" no  ", False),
-            (" yes  ", os.name == "nt"),
+            (" yes  ", True),
         ],
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
These are a couple changes to simplify and clarify the tests in `test_util.py`.

- Use `Path.touch` instead of `Path.write_bytes(b"")` in the tests. I guess I had formerly had the idea that `pathlib` gained `Path.touch` recently, but that is not at all the case. (This applies to all operating systems, but it is the more minor of the two changes.)
- Run some tests of Windows-specific environment variables on Windows only, and simplify the tests accordingly. The reason I think this makes sense now, even though it wouldn't have been the best idea when those tests were first introduced, is detailed in the [6a8ed70](https://github.com/gitpython-developers/GitPython/pull/1774/commits/6a8ed70a6003c13800d908ab055038eb61ba4ce9) message.

The latter is one of the changes listed in the "What is *not* done here?" section of #1745. Or it is part of that--perhaps some of the other tests, more directly concerning `rmtree`, can also be simplified, I'm not sure. (Right now I'm thinking that will become clearer if it is considered together with further progress toward #790 rather than beforehand.)