### PR TITLE
Improve hooks tests

### DIFF
--- a/test/test_index.py
+++ b/test/test_index.py
@@ -992,8 +992,13 @@ class TestIndex(TestBase):
         self.assertEqual(rel, os.path.relpath(path, root))
 
     @pytest.mark.xfail(
+        type(_win_bash_status) is WinBashStatus.Absent,
+        reason="Can't run a hook on Windows without bash.exe.",
+        rasies=HookExecutionError,
+    )
+    @pytest.mark.xfail(
         type(_win_bash_status) is WinBashStatus.WslNoDistro,
-        reason="Currently uses the bash.exe for WSL even with no WSL distro installed",
+        reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=HookExecutionError,
     )
     @with_rw_repo("HEAD", bare=True)
@@ -1004,7 +1009,7 @@ class TestIndex(TestBase):
 
     @pytest.mark.xfail(
         type(_win_bash_status) is WinBashStatus.WslNoDistro,
-        reason="Currently uses the bash.exe for WSL even with no WSL distro installed",
+        reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=AssertionError,
     )
     @with_rw_repo("HEAD", bare=True)
@@ -1030,13 +1035,18 @@ class TestIndex(TestBase):
             raise AssertionError("Should have caught a HookExecutionError")
 
     @pytest.mark.xfail(
-        type(_win_bash_status) in {WinBashStatus.Absent, WinBashStatus.Wsl},
+        type(_win_bash_status) is WinBashStatus.Absent,
+        reason="Can't run a hook on Windows without bash.exe.",
+        rasies=HookExecutionError,
+    )
+    @pytest.mark.xfail(
+        type(_win_bash_status) is WinBashStatus.Wsl,
         reason="Specifically seems to fail on WSL bash (in spite of #1399)",
         raises=AssertionError,
     )
     @pytest.mark.xfail(
         type(_win_bash_status) is WinBashStatus.WslNoDistro,
-        reason="Currently uses the bash.exe for WSL even with no WSL distro installed",
+        reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=HookExecutionError,
     )
     @with_rw_repo("HEAD", bare=True)
@@ -1054,7 +1064,7 @@ class TestIndex(TestBase):
 
     @pytest.mark.xfail(
         type(_win_bash_status) is WinBashStatus.WslNoDistro,
-        reason="Currently uses the bash.exe for WSL even with no WSL distro installed",
+        reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=AssertionError,
     )
     @with_rw_repo("HEAD", bare=True)


### PR DESCRIPTION
This improves the tests of git hooks in `test_index.py`:

- f664a0b fixes and adds missing `xfail` marks for the `WinBashStatus.Absent` condition. This is a test bug from when I added the `xfail` marks in [#1745](https://github.com/gitpython-developers/GitPython/pull/1745). The `Absent` condition was detected correctly, but not always used, or used properly, in `xfail` markings.
- e148647 adds a direct test of `run_commit_hook` itself. The other tests test specific kinds of hooks. `run_commit_hook` is public so it's reasonable for it to have its own test, plus I anticipate this will help future work.

Their commit messages include some more details, including rationale.

I have made sure to test on a Windows system that truly does not have `bash.exe` (as well testing the `WinBashStatus.Wsl` case, which CI confirms, and the `WinBashStatus.Native` case).

One might worry that I missed this before due to some further bug, but I believe not. Producing a genuine `WslBashStatus.Absent` condition on a Windows system that has a system-provided WSL-related `bash.exe` in `System32` (which is searched regardless of what is in the `PATH` environment variable, as noted in the `WinBashStatus.check` docstring) is a bit tricky because renaming that file requires one to act as the `TrustedInstaller` user (as would the worse option of deleting it). At some point while working on #1745, I did not test this when I should have. I believe that is the only reason it was missed, rather than any underlying technical issue.