### PR TITLE
Fix if items of Index is of type PathLike

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -940,7 +940,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         for item in items:
             if isinstance(item, (BaseIndexEntry, (Blob, Submodule))):
                 paths.append(self._to_relative_path(item.path))
-            elif isinstance(item, str):
+            elif isinstance(item, (str, os.PathLike)):
                 paths.append(self._to_relative_path(item))
             else:
                 raise TypeError("Invalid item type: %r" % item)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -558,14 +558,16 @@ class TestIndex(TestBase):
         def mixed_iterator():
             count = 0
             for entry in index.entries.values():
-                type_id = count % 4
-                if type_id == 0:  # path
+                type_id = count % 5
+                if type_id == 0:  # path (str)
                     yield entry.path
-                elif type_id == 1:  # blob
+                elif type_id == 1:  # path (PathLike)
+                    yield Path(entry.path)
+                elif type_id == 2:  # blob
                     yield Blob(rw_repo, entry.binsha, entry.mode, entry.path)
-                elif type_id == 2:  # BaseIndexEntry
+                elif type_id == 3:  # BaseIndexEntry
                     yield BaseIndexEntry(entry[:4])
-                elif type_id == 3:  # IndexEntry
+                elif type_id == 4:  # IndexEntry
                     yield entry
                 else:
                     raise AssertionError("Invalid Type")


### PR DESCRIPTION
The `move' and `remove' index operations accept `PathLike` items, but throw a `TypeError' if any of the items are of that type.
Example:

```python
index = repo.index
index.remove(Path("foo")) # should work and not throw TypeError
```