### PR TITLE
Revert "Don't install black on Cygwin"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-black ; sys_platform != "cygwin"
+black
 coverage[toml]
 ddt >= 1.1.1, != 1.4.3
 mock ; python_version < "3.8"


### PR DESCRIPTION
Reverts gitpython-developers/GitPython#1766

Black [23.12.1](https://github.com/psf/black/releases/tag/23.12.1) has been [released](https://pypi.org/project/black/23.12.1/). This has the fix for https://github.com/psf/black/issues/4107.

We could impose a constraint that the previous version with the bug not be selected. But that version is fine on most platforms. The constraint could be made for just Cygwin, but that would make the requirement more complicated rather than less. In addition, it's probably possible, with a compiler and Python headers, to build that version for Cygwin, and if someone has done so, we shouldn't force them onto a newer version. Given that other test dependencies aren't pinned, I suggest not pinning `black` either at this time, but instead simply reverting #1766 as [planned](https://github.com/gitpython-developers/GitPython/pull/1766#issuecomment-1853547041).