### PR TITLE
Fix incompletely revised Iterable/IterableObj docstrings

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -1204,8 +1204,6 @@ class IterableObj(Protocol):
         filtering. However, when the method is called with no additional positional or
         keyword arguments, subclasses are obliged to to yield all items.
 
-        For more information about the arguments, see list_items.
-
         :return: Iterator yielding Items
         """
         raise NotImplementedError("To be implemented by Subclass")
@@ -1214,7 +1212,7 @@ class IterableObj(Protocol):
     def list_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> IterableList[T_IterableObj]:
         """Find (all) items of this type and collect them into a list.
 
-        For more information about the arguments, see :meth:`list_items`.
+        For more information about the arguments, see :meth:`iter_items`.
 
         :note: Favor the :meth:`iter_items` method as it will avoid eagerly collecting
             all items. When there are many items, that can slow performance and increase
@@ -1261,7 +1259,7 @@ class Iterable(metaclass=IterableClassWatcher):
 
         Find (all) items of this type.
 
-        See :meth:`IterableObj.list_items` for details on usage.
+        See :meth:`IterableObj.iter_items` for details on usage.
 
         :return: Iterator yielding Items
         """


### PR DESCRIPTION
Three wrong references in docstrings to `list_items` methods had accidentally remained: one that was meant to be removed altogether, and two that were meant to be references to `iter_items`.

This completes those changes, so the docstrings make sense and references to further information are to places that have that information.

---

I don't know how I missed this, which consisted of incomplete changes both in dfee31f (#1780) and in 2b768c7 (#1785). I distinctly remember anticipating this sort of problem specifically, and deliberately checking for it, *twice*, before opening #1780, and then checking for it *twice again* before #1785.

However, examination of the diffs for those PRs reveals that the unintended/inaccurate references are present, and not a result of anything odd happening in the merges. Given that, taken together with how I was fairly tired yesterday, I think this was purely my error, with no tooling or other issues contributing.