### PR TITLE
Deprecate Git.USE_SHELL

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -280,13 +280,12 @@ class Git(LazyMixin):
     """Enables debugging of GitPython's git commands."""
 
     USE_SHELL = False
-    """If True, a shell will be used when executing git commands.
+    """Deprecated. If set to True, a shell will be used when executing git commands.
 
-    This exists to avoid breaking old code that may access it, but it is no longer
-    needed and should rarely if ever be used. Prior to GitPython 2.0.8, it had a narrow
-    purpose in suppressing console windows in graphical Windows applications. In 2.0.8
-    and higher, it provides no benefit, as GitPython solves that problem more robustly
-    and safely by using the ``CREATE_NO_WINDOW`` process creation flag on Windows.
+    Prior to GitPython 2.0.8, this had a narrow purpose in suppressing console windows
+    in graphical Windows applications. In 2.0.8 and higher, it provides no benefit, as
+    GitPython solves that problem more robustly and safely by using the
+    ``CREATE_NO_WINDOW`` process creation flag on Windows.
 
     Code that uses ``USE_SHELL = True`` or that passes ``shell=True`` to any GitPython
     functions should be updated to use the default value of ``False`` instead. ``True``
@@ -294,6 +293,7 @@ class Git(LazyMixin):
     for, which is not possible under most circumstances.
 
     See:
+    - :meth:`Git.execute` (on the ``shell`` parameter).
     - https://github.com/gitpython-developers/GitPython/commit/0d9390866f9ce42870d3116094cd49e0019a970a
     - https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
     """
@@ -919,7 +919,15 @@ class Git(LazyMixin):
 
         :param shell:
             Whether to invoke commands through a shell (see `Popen(..., shell=True)`).
-            It overrides :attr:`USE_SHELL` if it is not `None`.
+            If this is not `None`, it overrides :attr:`USE_SHELL`.
+
+            Passing ``shell=True`` to this or any other GitPython function should be
+            avoided, as it is unsafe under most circumstances. This is because it is
+            typically not feasible to fully consider and account for the effect of shell
+            expansions, especially when passing ``shell=True`` to other methods that
+            forward it to :meth:`Git.execute`. Passing ``shell=True`` is also no longer
+            needed (nor useful) to work around any known operating system specific
+            issues.
 
         :param env:
             A dictionary of environment variables to be passed to :class:`subprocess.Popen`.

--- a/git/compat.py
+++ b/git/compat.py
@@ -28,18 +28,41 @@ from typing import (  # noqa: F401
 # ---------------------------------------------------------------------------
 
 
-# DEPRECATED attributes providing shortcuts to operating system checks based on os.name.
-#
-# These are deprecated because it is clearer, and helps avoid bugs, to write out the
-# os.name or sys.platform checks explicitly, especially in cases where it matters which
-# is used. For example, is_win is False on Cygwin, but is often assumed True. To detect
-# Cygwin, use sys.platform == "cygwin". (Also, in the past, is_darwin was unreliable.)
-#
 is_win = os.name == "nt"
+"""Deprecated alias for ``os.name == "nt"`` to check for native Windows.
+
+This is deprecated because it is clearer to write out :attr:`os.name` or
+:attr:`sys.platform` checks explicitly, especially in cases where it matters which is
+used.
+
+:note: ``is_win`` is ``False`` on Cygwin, but is often wrongly assumed ``True``. To
+    detect Cygwin, use ``sys.platform == "cygwin"``.
+"""
+
 is_posix = os.name == "posix"
+"""Deprecated alias for ``os.name == "posix"`` to check for Unix-like ("POSIX") systems.
+
+This is deprecated because it clearer to write out :attr:`os.name` or
+:attr:`sys.platform` checks explicitly, especially in cases where it matters which is
+used.
+
+:note: For POSIX systems, more detailed information is available in
+    :attr:`sys.platform`, while :attr:`os.name` is always ``"posix"`` on such systems,
+    including macOS (Darwin).
+"""
+
 is_darwin = sys.platform == "darwin"
+"""Deprecated alias for ``sys.platform == "darwin"`` to check for macOS (Darwin).
+
+This is deprecated because it clearer to write out :attr:`os.name` or
+:attr:`sys.platform` checks explicitly.
+
+:note: For macOS (Darwin), ``os.name == "posix"`` as in other Unix-like systems, while
+    ``sys.platform == "darwin"`.
+"""
 
 defenc = sys.getfilesystemencoding()
+"""The encoding used to convert between Unicode and bytes filenames."""
 
 
 @overload

--- a/git/diff.py
+++ b/git/diff.py
@@ -4,6 +4,7 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import re
+
 from git.cmd import handle_process_output
 from git.compat import defenc
 from git.util import finalize_process, hex_to_bin
@@ -208,13 +209,15 @@ class DiffIndex(List[T_Diff]):
     The class improves the diff handling convenience.
     """
 
-    # Change type invariant identifying possible ways a blob can have changed:
-    # A = Added
-    # D = Deleted
-    # R = Renamed
-    # M = Modified
-    # T = Changed in the type
     change_type = ("A", "C", "D", "R", "M", "T")
+    """Change type invariant identifying possible ways a blob can have changed:
+
+    * ``A`` = Added
+    * ``D`` = Deleted
+    * ``R`` = Renamed
+    * ``M`` = Modified
+    * ``T`` = Changed in the type
+    """
 
     def iter_change_type(self, change_type: Lit_change_type) -> Iterator[T_Diff]:
         """

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -352,8 +352,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def trailers(self) -> Dict[str, str]:
         """Get the trailers of the message as a dictionary
 
-        :note: This property is deprecated, please use either ``Commit.trailers_list``
-            or ``Commit.trailers_dict``.
+        :note: This property is deprecated, please use either :attr:`trailers_list` or
+            :attr:`trailers_dict``.
 
         :return:
             Dictionary containing whitespace stripped trailer information. Only contains

--- a/git/util.py
+++ b/git/util.py
@@ -1233,10 +1233,10 @@ class IterableClassWatcher(type):
         for base in bases:
             if type(base) is IterableClassWatcher:
                 warnings.warn(
-                    f"GitPython Iterable subclassed by {name}. "
-                    "Iterable is deprecated due to naming clash since v3.1.18"
-                    " and will be removed in 3.1.20, "
-                    "Use IterableObj instead \n",
+                    f"GitPython Iterable subclassed by {name}."
+                    " Iterable is deprecated due to naming clash since v3.1.18"
+                    " and will be removed in 4.0.0."
+                    " Use IterableObj instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
This builds on the changes in #1782, actually deprecating `Git.USE_SHELL` as discussed in comments there, though no `DeprecationWarning` is currently issued on access to it. The `USE_SHELL` docstring is updated to state the deprecation while retaining most of the wording from 106bbe6. The docstring for `Git.execute`, on the `shell` parameter, is also updated to discourage passing `shell=True`, but does not declare that deprecated.

This also revises some existing deprecation notices and updates their predicted removal/breakage version number, converts more comments in docstrings (especially, but not only, those related to existing deprecations), and makes other such changes, building on the changes from 94a85d1.

A few more details are given in the commit messages.