### PR TITLE
Fix two remaining Windows untrusted search path cases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   hooks:
   - id: shellcheck
     args: [--color]
-    exclude: ^git/ext/
+    exclude: ^test/fixtures/polyglot$|^git/ext/
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -985,23 +985,31 @@ class Git(LazyMixin):
         if inline_env is not None:
             env.update(inline_env)
 
+        if shell is None:
+            shell = self.USE_SHELL
+
+        cmd_not_found_exception = FileNotFoundError
+        maybe_patch_caller_env = contextlib.nullcontext()
+
         if os.name == "nt":
-            cmd_not_found_exception = OSError
             if kill_after_timeout is not None:
                 raise GitCommandError(
                     redacted_command,
                     '"kill_after_timeout" feature is not supported on Windows.',
                 )
-            # Only search PATH, not CWD. This must be in the *caller* environment. The "1" can be any value.
-            maybe_patch_caller_env = patch_env("NoDefaultCurrentDirectoryInExePath", "1")
-        else:
-            cmd_not_found_exception = FileNotFoundError
-            maybe_patch_caller_env = contextlib.nullcontext()
+
+            cmd_not_found_exception = OSError
+
+            # Search PATH, but do not search CWD. The "1" can be any value.
+            if shell:
+                # If the direct subprocess is a shell, this must go in its environment.
+                env["NoDefaultCurrentDirectoryInExePath"] = "1"
+            else:
+                # If we're not using a shell, the variable goes in our own environment.
+                maybe_patch_caller_env = patch_env("NoDefaultCurrentDirectoryInExePath", "1")
         # END handle
 
         stdout_sink = PIPE if with_stdout else getattr(subprocess, "DEVNULL", None) or open(os.devnull, "wb")
-        if shell is None:
-            shell = self.USE_SHELL
         log.debug(
             "Popen(%s, cwd=%s, stdin=%s, shell=%s, universal_newlines=%s)",
             redacted_command,

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -3,7 +3,6 @@
 
 """Standalone functions to accompany the index implementation and make it more versatile."""
 
-import contextlib
 from io import BytesIO
 import os
 import os.path as osp
@@ -19,7 +18,7 @@ from stat import (
 )
 import subprocess
 
-from git.cmd import PROC_CREATIONFLAGS, handle_process_output
+from git.cmd import handle_process_output
 from git.compat import defenc, force_bytes, force_text, safe_decode
 from git.exc import HookExecutionError, UnmergedEntriesError
 from git.objects.fun import (
@@ -27,7 +26,7 @@ from git.objects.fun import (
     traverse_trees_recursive,
     tree_to_stream,
 )
-from git.util import IndexFileSHA1Writer, finalize_process, patch_env
+from git.util import IndexFileSHA1Writer, finalize_process, safer_popen
 from gitdb.base import IStream
 from gitdb.typ import str_tree_type
 
@@ -91,10 +90,6 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
     env = os.environ.copy()
     env["GIT_INDEX_FILE"] = safe_decode(str(index.path))
     env["GIT_EDITOR"] = ":"
-    if os.name == "nt":
-        maybe_patch_caller_env = patch_env("NoDefaultCurrentDirectoryInExePath", "1")
-    else:
-        maybe_patch_caller_env = contextlib.nullcontext()
     cmd = [hp]
     try:
         if os.name == "nt" and not _has_file_extension(hp):
@@ -103,15 +98,13 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
             relative_hp = Path(hp).relative_to(index.repo.working_dir).as_posix()
             cmd = ["bash.exe", relative_hp]
 
-        with maybe_patch_caller_env:
-            process = subprocess.Popen(
-                cmd + list(args),
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                cwd=index.repo.working_dir,
-                creationflags=PROC_CREATIONFLAGS,
-            )
+        process = safer_popen(
+            cmd + list(args),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=index.repo.working_dir,
+        )
     except Exception as ex:
         raise HookExecutionError(hp, ex) from ex
     else:

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -18,7 +18,7 @@ from stat import (
 )
 import subprocess
 
-from git.cmd import handle_process_output
+from git.cmd import handle_process_output, safer_popen
 from git.compat import defenc, force_bytes, force_text, safe_decode
 from git.exc import HookExecutionError, UnmergedEntriesError
 from git.objects.fun import (
@@ -26,7 +26,7 @@ from git.objects.fun import (
     traverse_trees_recursive,
     tree_to_stream,
 )
-from git.util import IndexFileSHA1Writer, finalize_process, safer_popen
+from git.util import IndexFileSHA1Writer, finalize_process
 from gitdb.base import IStream
 from gitdb.typ import str_tree_type
 

--- a/git/util.py
+++ b/git/util.py
@@ -33,7 +33,6 @@ from typing import (
     IO,
     Iterator,
     List,
-    Mapping,
     Optional,
     Pattern,
     Sequence,
@@ -535,67 +534,6 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
             continue
     return new_cmdline
 
-
-def _safer_popen_windows(
-    command: Union[str, Sequence[Any]],
-    *,
-    shell: bool = False,
-    env: Optional[Mapping[str, str]] = None,
-    **kwargs: Any,
-) -> subprocess.Popen:
-    """Call :class:`subprocess.Popen` on Windows but don't include a CWD in the search.
-
-    This avoids an untrusted search path condition where a file like ``git.exe`` in a
-    malicious repository would be run when GitPython operates on the repository. The
-    process using GitPython may have an untrusted repository's working tree as its
-    current working directory. Some operations may temporarily change to that directory
-    before running a subprocess. In addition, while by default GitPython does not run
-    external commands with a shell, it can be made to do so, in which case the CWD of
-    the subprocess, which GitPython usually sets to a repository working tree, can
-    itself be searched automatically by the shell. This wrapper covers all those cases.
-
-    :note: This currently works by setting the ``NoDefaultCurrentDirectoryInExePath``
-        environment variable during subprocess creation. It also takes care of passing
-        Windows-specific process creation flags, but that is unrelated to path search.
-
-    :note: The current implementation contains a race condition on :attr:`os.environ`.
-        GitPython isn't thread-safe, but a program using it on one thread should ideally
-        be able to mutate :attr:`os.environ` on another, without unpredictable results.
-        See comments in https://github.com/gitpython-developers/GitPython/pull/1650.
-    """
-    # CREATE_NEW_PROCESS_GROUP is needed for some ways of killing it afterwards. See:
-    # https://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal
-    # https://docs.python.org/3/library/subprocess.html#subprocess.CREATE_NEW_PROCESS_GROUP
-    creationflags = subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
-
-    # When using a shell, the shell is the direct subprocess, so the variable must be
-    # set in its environment, to affect its search behavior. (The "1" can be any value.)
-    if shell:
-        safer_env = {} if env is None else dict(env)
-        safer_env["NoDefaultCurrentDirectoryInExePath"] = "1"
-    else:
-        safer_env = env
-
-    # When not using a shell, the current process does the search in a CreateProcessW
-    # API call, so the variable must be set in our environment. With a shell, this is
-    # unnecessary, in versions where https://github.com/python/cpython/issues/101283 is
-    # patched. If not, in the rare case the ComSpec environment variable is unset, the
-    # shell is searched for unsafely. Setting NoDefaultCurrentDirectoryInExePath in all
-    # cases, as here, is simpler and protects against that. (The "1" can be any value.)
-    with patch_env("NoDefaultCurrentDirectoryInExePath", "1"):
-        return subprocess.Popen(
-            command,
-            shell=shell,
-            env=safer_env,
-            creationflags=creationflags,
-            **kwargs,
-        )
-
-
-if os.name == "nt":
-    safer_popen = _safer_popen_windows
-else:
-    safer_popen = subprocess.Popen
 
 # } END utilities
 

--- a/test/fixtures/polyglot
+++ b/test/fixtures/polyglot
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# Valid script in both Bash and Python, but with different behavior.
+""":"
+echo 'Ran intended hook.' >output.txt
+exit
+" """
+from pathlib import Path
+Path('payload.txt').write_text('Ran impostor hook!', encoding='utf-8')

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -88,11 +88,11 @@ def with_rw_directory(func):
     test succeeds, but leave it otherwise to aid additional debugging."""
 
     @wraps(func)
-    def wrapper(self):
+    def wrapper(self, *args, **kwargs):
         path = tempfile.mkdtemp(prefix=func.__name__)
         keep = False
         try:
-            return func(self, path)
+            return func(self, path, *args, **kwargs)
         except Exception:
             log.info(
                 "Test %s.%s failed, output is at %r\n",

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -14,6 +14,7 @@ import tempfile
 import textwrap
 import time
 import unittest
+import venv
 
 import gitdb
 
@@ -36,6 +37,7 @@ __all__ = (
     "with_rw_repo",
     "with_rw_and_rw_remote_repo",
     "TestBase",
+    "VirtualEnvironment",
     "TestCase",
     "SkipTest",
     "skipIf",
@@ -390,3 +392,42 @@ class TestBase(TestCase):
         with open(abs_path, "w") as fp:
             fp.write(data)
         return abs_path
+
+
+class VirtualEnvironment:
+    """A newly created Python virtual environment for use in a test."""
+
+    __slots__ = ("_env_dir",)
+
+    def __init__(self, env_dir, *, with_pip):
+        self._env_dir = env_dir
+        venv.create(env_dir, symlinks=(os.name != "nt"), with_pip=with_pip)
+
+    @property
+    def env_dir(self):
+        """The top-level directory of the environment."""
+        return self._env_dir
+
+    @property
+    def python(self):
+        """Path to the Python executable in the environment."""
+        return self._executable("python")
+
+    @property
+    def pip(self):
+        """Path to the pip executable in the environment, or RuntimeError if absent."""
+        return self._executable("pip")
+
+    @property
+    def sources(self):
+        """Path to a src directory in the environment, which may not exist yet."""
+        return os.path.join(self.env_dir, "src")
+
+    def _executable(self, basename):
+        if os.name == "nt":
+            path = osp.join(self.env_dir, "Scripts", basename + ".exe")
+        else:
+            path = osp.join(self.env_dir, "bin", basename)
+        if osp.isfile(path) or osp.islink(path):
+            return path
+        raise RuntimeError(f"no regular file or symlink {path!r}")

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -400,8 +400,12 @@ class VirtualEnvironment:
     __slots__ = ("_env_dir",)
 
     def __init__(self, env_dir, *, with_pip):
-        self._env_dir = env_dir
-        venv.create(env_dir, symlinks=(os.name != "nt"), with_pip=with_pip)
+        if os.name == "nt":
+            self._env_dir = osp.realpath(env_dir)
+            venv.create(self.env_dir, symlinks=False, with_pip=with_pip)
+        else:
+            self._env_dir = env_dir
+            venv.create(self.env_dir, symlinks=True, with_pip=with_pip)
 
     @property
     def env_dir(self):

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -25,7 +25,7 @@ else:
 import ddt
 
 from git import Git, refresh, GitCommandError, GitCommandNotFound, Repo, cmd
-from git.util import cwd, finalize_process, safer_popen
+from git.util import cwd, finalize_process
 from test.lib import TestBase, fixture_path, with_rw_directory
 
 
@@ -114,7 +114,6 @@ class TestGit(TestBase):
 
     def _do_shell_combo(self, value_in_call, value_from_class):
         with mock.patch.object(Git, "USE_SHELL", value_from_class):
-            # git.cmd gets Popen via a "from" import, so patch it there.
             with mock.patch.object(cmd, "safer_popen", wraps=cmd.safer_popen) as mock_safer_popen:
                 # Use a command with no arguments (besides the program name), so it runs
                 # with or without a shell, on all OSes, with the same effect.
@@ -389,7 +388,7 @@ class TestGit(TestBase):
                 self.assertIn("FOO", str(err))
 
     def test_handle_process_output(self):
-        from git.cmd import handle_process_output
+        from git.cmd import handle_process_output, safer_popen
 
         line_count = 5002
         count = [None, 0, 0]

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import os
 import os.path as osp
+from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -150,14 +151,13 @@ class TestGit(TestBase):
         if os.name == "nt":
             # Copy an actual binary executable that is not git. (On Windows, running
             # "hostname" only displays the hostname, it never tries to change it.)
-            other_exe_path = os.path.join(os.environ["SystemRoot"], "system32", "hostname.exe")
-            impostor_path = os.path.join(rw_dir, "git.exe")
+            other_exe_path = Path(os.environ["SystemRoot"], "system32", "hostname.exe")
+            impostor_path = Path(rw_dir, "git.exe")
             shutil.copy(other_exe_path, impostor_path)
         else:
             # Create a shell script that doesn't do anything.
-            impostor_path = os.path.join(rw_dir, "git")
-            with open(impostor_path, mode="w", encoding="utf-8") as file:
-                print("#!/bin/sh", file=file)
+            impostor_path = Path(rw_dir, "git")
+            impostor_path.write_text("#!/bin/sh\n", encoding="utf-8")
             os.chmod(impostor_path, 0o755)
 
         with cwd(rw_dir) if chdir_to_repo else contextlib.nullcontext():

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -134,7 +134,13 @@ class TestGit(TestBase):
     def test_it_executes_git_and_returns_result(self):
         self.assertRegex(self.git.execute(["git", "version"]), r"^git version [\d\.]{2}.*$")
 
-    def test_it_executes_git_not_from_cwd(self):
+    @ddt.data(
+        (["git", "version"], False),
+        ("git version", True),
+    )
+    def test_it_executes_git_not_from_cwd(self, case):
+        command, shell = case
+
         with TemporaryDirectory() as tmpdir:
             if os.name == "nt":
                 # Copy an actual binary executable that is not git.
@@ -149,7 +155,9 @@ class TestGit(TestBase):
                 os.chmod(impostor_path, 0o755)
 
             with cwd(tmpdir):
-                self.assertRegex(self.git.execute(["git", "version"]), r"^git version\b")
+                output = self.git.execute(command, shell=shell)
+
+        self.assertRegex(output, r"^git version\b")
 
     @skipUnless(
         os.name == "nt",

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -150,7 +150,7 @@ class TestGit(TestBase):
         if os.name == "nt":
             # Copy an actual binary executable that is not git. (On Windows, running
             # "hostname" only displays the hostname, it never tries to change it.)
-            other_exe_path = os.path.join(os.getenv("WINDIR"), "system32", "hostname.exe")
+            other_exe_path = os.path.join(os.environ["SystemRoot"], "system32", "hostname.exe")
             impostor_path = os.path.join(rw_dir, "git.exe")
             shutil.copy(other_exe_path, impostor_path)
         else:

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1032,16 +1032,16 @@ class TestIndex(TestBase):
         maybe_chdir = cwd(rw_dir) if chdir_to_repo else contextlib.nullcontext()
         repo = Repo.init(rw_dir)
 
-        # We need an impostor shell that works on Windows and that can be distinguished
-        # from the real bash.exe. But even if the real bash.exe is absent or unusable,
-        # we should verify that the impostor is not run. So the impostor needs a clear
-        # side effect (unlike in TestGit.test_it_executes_git_not_from_cwd). Popen on
-        # Windows uses CreateProcessW, which disregards PATHEXT; the impostor may need
-        # to be a binary executable to ensure the vulnerability is found if present. No
-        # compiler need exist, shipping a binary in the test suite may target the wrong
-        # architecture, and generating one in a bespoke way may cause virus scanners to
-        # give a false positive. So we use a Bash/Python polyglot for the hook and use
-        # the Python interpreter itself as the bash.exe impostor. But an interpreter
+        # We need an impostor shell that works on Windows and that the test can
+        # distinguish from the real bash.exe. But even if the real bash.exe is absent or
+        # unusable, we should verify the impostor is not run. So the impostor needs a
+        # clear side effect (unlike in TestGit.test_it_executes_git_not_from_cwd). Popen
+        # on Windows uses CreateProcessW, which disregards PATHEXT; the impostor may
+        # need to be a binary executable to ensure the vulnerability is found if
+        # present. No compiler need exist, shipping a binary in the test suite may
+        # target the wrong architecture, and generating one in a bespoke way may trigger
+        # false positive virus scans. So we use a Bash/Python polyglot for the hook and
+        # use the Python interpreter itself as the bash.exe impostor. But an interpreter
         # from a venv may not run when copied outside of it, and a global interpreter
         # won't run when copied to a different location if it was installed from the
         # Microsoft Store. So we make a new venv in rw_dir and use its interpreter.

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1042,9 +1042,9 @@ class TestIndex(TestBase):
         # architecture, and generating one in a bespoke way may cause virus scanners to
         # give a false positive. So we use a Bash/Python polyglot for the hook and use
         # the Python interpreter itself as the bash.exe impostor. But an interpreter
-        # from a venv may not run outside of it, and a global interpreter won't run from
-        # a different location if it was installed from the Microsoft Store. So we make
-        # a new venv in rw_dir and use its interpreter.
+        # from a venv may not run when copied outside of it, and a global interpreter
+        # won't run when copied to a different location if it was installed from the
+        # Microsoft Store. So we make a new venv in rw_dir and use its interpreter.
         venv = VirtualEnvironment(rw_dir, with_pip=False)
         shutil.copy(venv.python, Path(rw_dir, shell_name))
         shutil.copy(fixture_path("polyglot"), hook_path("polyglot", repo.git_dir))


### PR DESCRIPTION
Although #1636 caused GitPython to avoid using an untrusted search path on Windows under the most typical circumstances, it turns out that some cases remained. I believe only two remain at this time. This pull request fixes those.

This vulnerability was reported privately, and a full public writeup is not available at this time--I want to get this PR out as coordinated/requested, without extra delays. However, some details are present in commit messages, and I'll try to update this in some way in the future, either to include more information or to link to a relevant advisory or other source.

*Edit:* The CI status on all commits appears to be as I expected and intended.