### PR TITLE
Remove test dependency on sumtypes library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,3 @@ pytest-cov
 pytest-instafail
 pytest-mock
 pytest-sugar
-sumtypes

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import re
 import shutil
 from stat import S_ISLNK, ST_MODE
-from subprocess import CompletedProcess, run
+import subprocess
 import tempfile
 
 import ddt
@@ -93,14 +93,14 @@ class WinBashStatus:
     class WslNoDistro:
         """Running bash.exe tries to run bash on a WSL distribution, but none exists."""
 
-        process: CompletedProcess[bytes]
+        process: "subprocess.CompletedProcess[bytes]"
         message: str
 
     @dataclass
     class CheckError:
         """Running bash.exe fails in an unexpected error or gives unexpected output."""
 
-        process: CompletedProcess[bytes]
+        process: "subprocess.CompletedProcess[bytes]"
         message: str
 
     @dataclass
@@ -133,7 +133,7 @@ class WinBashStatus:
             # information on ways to check for WSL, see https://superuser.com/a/1749811.
             script = 'test -e /proc/sys/fs/binfmt_misc/WSLInterop; echo "$?"'
             command = ["bash.exe", "-c", script]
-            process = run(command, capture_output=True)
+            process = subprocess.run(command, capture_output=True)
         except FileNotFoundError:
             return cls.Absent()
         except OSError as error:

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -4,6 +4,7 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import contextlib
+from dataclasses import dataclass
 from io import BytesIO
 import logging
 import os
@@ -12,12 +13,11 @@ from pathlib import Path
 import re
 import shutil
 from stat import S_ISLNK, ST_MODE
-import subprocess
+from subprocess import CompletedProcess, run
 import tempfile
 
 import ddt
 import pytest
-from sumtypes import constructor, sumtype
 
 from git import (
     BlobFilter,
@@ -66,34 +66,48 @@ def _get_windows_ansi_encoding():
     return f"cp{value}"
 
 
-@sumtype
 class WinBashStatus:
-    """Status of bash.exe for native Windows. Affects which commit hook tests can pass.
+    """Namespace of native-Windows bash.exe statuses. Affects what hook tests can pass.
 
     Call check() to check the status. (CheckError and WinError should not typically be
     used to trigger skip or xfail, because they represent unexpected situations.)
     """
 
-    Inapplicable = constructor()
-    """This system is not native Windows: either not Windows at all, or Cygwin."""
+    @dataclass
+    class Inapplicable:
+        """This system is not native Windows: either not Windows at all, or Cygwin."""
 
-    Absent = constructor()
-    """No command for bash.exe is found on the system."""
+    @dataclass
+    class Absent:
+        """No command for bash.exe is found on the system."""
 
-    Native = constructor()
-    """Running bash.exe operates outside any WSL distribution (as with Git Bash)."""
+    @dataclass
+    class Native:
+        """Running bash.exe operates outside any WSL distribution (as with Git Bash)."""
 
-    Wsl = constructor()
-    """Running bash.exe calls bash in a WSL distribution."""
+    @dataclass
+    class Wsl:
+        """Running bash.exe calls bash in a WSL distribution."""
 
-    WslNoDistro = constructor("process", "message")
-    """Running bash.exe tries to run bash on a WSL distribution, but none exists."""
+    @dataclass
+    class WslNoDistro:
+        """Running bash.exe tries to run bash on a WSL distribution, but none exists."""
 
-    CheckError = constructor("process", "message")
-    """Running bash.exe fails in an unexpected error or gives unexpected output."""
+        process: CompletedProcess[bytes]
+        message: str
 
-    WinError = constructor("exception")
-    """bash.exe may exist but can't run. CreateProcessW fails unexpectedly."""
+    @dataclass
+    class CheckError:
+        """Running bash.exe fails in an unexpected error or gives unexpected output."""
+
+        process: CompletedProcess[bytes]
+        message: str
+
+    @dataclass
+    class WinError:
+        """bash.exe may exist but can't run. CreateProcessW fails unexpectedly."""
+
+        exception: OSError
 
     @classmethod
     def check(cls):
@@ -119,7 +133,7 @@ class WinBashStatus:
             # information on ways to check for WSL, see https://superuser.com/a/1749811.
             script = 'test -e /proc/sys/fs/binfmt_misc/WSLInterop; echo "$?"'
             command = ["bash.exe", "-c", script]
-            process = subprocess.run(command, capture_output=True)
+            process = run(command, capture_output=True)
         except FileNotFoundError:
             return cls.Absent()
         except OSError as error:


### PR DESCRIPTION
Fixes #1797

The `WinBashStatus` class in `test_index.py`, introduced in #1745, had used the `sumtypes` library to express the various cases relevant to xfail markings and troubleshooting and, where applicable, to express some associated debugging information. This includes the `Inapplicable` case, so `sumtypes` was used on all systems, not just Windows, which also usefully allowed the other cases to be inspected dynamically on any system, and allowed xfail markings to be written without excess complexity.

However, that only used a small fragment of `sumtypes` functionality, which can be expressed with only minor inelegance with explicit data classes. This pull request makes that change and removes `sumtypes` as a test dependency.

Because the `sumtypes` dependency was apparently causing problems for downstream maintainers (per #1797), I believe this change is justified. I believe the small inelegance of less compact definitions, and of the case classes not having an inheritance relationship to `WinBashStatus` itself, are the only disadvantages of this changed approach. The actual logic, stored information, and available debugging information is the same, fully useful `repr`s are still produced, no code change is needed in any of the markings that use `WinBashStatus`, and the class is still defined on all systems.

Nonetheless I have retested the cases locally (since only two of them occur on CI), verifying that they still work and that the same debugging information remains available.