### PR TITLE
Pin Sphinx plugins to compatible versions

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
-sphinx==4.3.0
+sphinx == 4.3.0
 sphinx_rtd_theme
-sphinxcontrib-applehelp==1.0.4
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-applehelp >= 1.0.2, <= 1.0.4
+sphinxcontrib-devhelp == 1.0.2
+sphinxcontrib-htmlhelp >= 2.0.0, <= 2.0.1
+sphinxcontrib-qthelp == 1.0.3
+sphinxcontrib-serializinghtml == 1.1.5
 sphinx-autodoc-typehints

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx == 4.3.0
+sphinx == 4.3.2
 sphinx_rtd_theme
 sphinxcontrib-applehelp >= 1.0.2, <= 1.0.4
 sphinxcontrib-devhelp == 1.0.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,8 @@
 sphinx==4.3.0
 sphinx_rtd_theme
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 sphinx-autodoc-typehints


### PR DESCRIPTION
Fixes #1802

This fixes version incompatibilities with major version 4 of Sphinx, which GitPython is still using for the time being. Some plugins that previously had depended back on Sphinx have had those dependencies removed to avoid dependency cycles, but the effect is that `pip` no longer is aware of or able to enforce version compatibility, and newer plugin versions than can actually run with Sphinx 4 are installed instead of older, usable versions.

This fixes the problem by pinning each of the affected Sphinx plugins' latest actually compatible versions, i.e., latest versions that do not need Sphinx 5 or higher. Two of the plugins are pinned to ranges of a few versions rather than individual versions in order to preserve compatibility with Python 3.7 without making `doc/requirements.txt` more complicated (but Python 3.7 could be special-cased if desired, as discussed at the end of #1802). I also took this opportunity to bump the `sphinx` dependency to the latest *bugfix* release within 4.3, which does not break compatibility. I used whitespace in same style as in `test-requirements.txt`.

The alternative of moving to Sphinx 5 or higher should probably be done eventually, but will require addressing a cross-reference ambiguity in type annotations for the `Actor` class.

For details on the bug, see:

- https://github.com/gitpython-developers/GitPython/pull/1799#discussion_r1451969138 (I believe this is where it was originally discovered.)
- https://github.com/gitpython-developers/GitPython/issues/1802 (Further details and analysis.)