### PR TITLE
Remove git.util.NullHandler

### DIFF
--- a/git/util.py
+++ b/git/util.py
@@ -1295,5 +1295,20 @@ class Iterable(metaclass=IterableClassWatcher):
 
 
 class NullHandler(logging.Handler):
-    def emit(self, record: object) -> None:
+    """Deprecated, use :class:`logging.NullHandler` instead.
+
+    This noop handler is like :class:`~logging.NullHandler` in the standard library,
+    which should be used instead, because it is now always available, and it overrides
+    more logging methods to make them noop. This class only overrides :meth:`emit`.
+    """
+
+    def __init__(self, level: int = logging.NOTSET) -> None:
+        warnings.warn(
+            "NullHandler in git.util is deprecated. Use logging.NullHandler instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(level)
+
+    def emit(self, record: logging.LogRecord) -> None:
         pass

--- a/git/util.py
+++ b/git/util.py
@@ -1292,23 +1292,3 @@ class Iterable(metaclass=IterableClassWatcher):
 
 
 # } END classes
-
-
-class NullHandler(logging.Handler):
-    """Deprecated, use :class:`logging.NullHandler` instead.
-
-    This noop handler is like :class:`~logging.NullHandler` in the standard library,
-    which should be used instead, because it is now always available, and it overrides
-    more logging methods to make them noop. This class only overrides :meth:`emit`.
-    """
-
-    def __init__(self, level: int = logging.NOTSET) -> None:
-        warnings.warn(
-            "NullHandler in git.util is deprecated. Use logging.NullHandler instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(level)
-
-    def emit(self, record: logging.LogRecord) -> None:
-        pass


### PR DESCRIPTION
*This is not related to the issue of when a noop handler should actually be used, so it is independent of #1806.*

The `NullHandler` class in `git.util` was added when merging #300, to allow a noop handler to be used on Python 2.6, since the standard library `logging.NullHandler` class was added in Python 2.7.

When introduced in d1a9a23, the `git.util.NullHandler` class was also patched into the logging module, but that has no longer been done since 2fced2e (#979), nor does GitPython make other use of it.

`git/util.py` defines `__all__`, which does not list `NullHandler`. As `NullHandler` is not otherwise documented to be public, it is a bug for any code outside GitPython to use it, and removing it is not a breaking change. So there should be no need for a deprecation period or to wait until the next major version of GitPython.

For some reason I had not, at first, thought to check if it was in `__all__`, and assumed it was. The first commit here reflects that mistake, documenting it as deprecated and why the standard library `NullHandler` is preferable, and having it issue `DeprecationWarning` when constructed.

Although I wouldn't have written that if I'd been paying proper attention, I decided to keep it, since the documented difference between it and `logging.NullHandler` may be useful to see in the history. However, I'd be happy to rebase to remove that commit and update the other commit's message accordingly, if desired.
