### PR TITLE
Clarify why GIT_PYTHON_GIT_EXECUTABLE may be set on failure

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -475,9 +475,10 @@ class Git(LazyMixin):
                     )
                     raise ImportError(err)
 
-                # We get here if this was the init refresh and the refresh mode was not
-                # error. Go ahead and set the GIT_PYTHON_GIT_EXECUTABLE such that we
-                # discern the difference between a first import and a second import.
+                # We get here if this was the initial refresh and the refresh mode was
+                # not error. Go ahead and set the GIT_PYTHON_GIT_EXECUTABLE such that we
+                # discern the the difference between the first refresh at import time
+                # and subsequent calls to refresh.
                 cls.GIT_PYTHON_GIT_EXECUTABLE = cls.git_exec_name
             else:
                 # After the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is no longer

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -477,8 +477,8 @@ class Git(LazyMixin):
 
                 # We get here if this was the initial refresh and the refresh mode was
                 # not error. Go ahead and set the GIT_PYTHON_GIT_EXECUTABLE such that we
-                # discern the the difference between the first refresh at import time
-                # and subsequent calls to refresh.
+                # discern the difference between the first refresh at import time
+                # and subsequent calls to refresh().
                 cls.GIT_PYTHON_GIT_EXECUTABLE = cls.git_exec_name
             else:
                 # After the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is no longer


### PR DESCRIPTION
Fixes #1804

This clarifies the comment that explains the significance of setting the `Git.GIT_PYTHON_GIT_EXECUTABLE` attribute when running Git failed but the attribute wasn't set before.

This happens in the code path in `Git.refresh` where `has_git` is `False` and `old_git` is `None`, provided the refresh mode doesn't call for the initial refresh to raise an exception on failure.

It was previously described in terms of a "first" and "second" import, but as discussed in #1804, the rationale and effect were not altogether clear. This uses wording along the lines of what I suggested there, adjusted a bit for context.