### PR TITLE
Report actual attempted Git command when Git.refresh fails

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -478,7 +478,7 @@ class Git(LazyMixin):
                 # We get here if this was the initial refresh and the refresh mode was
                 # not error. Go ahead and set the GIT_PYTHON_GIT_EXECUTABLE such that we
                 # discern the difference between the first refresh at import time
-                # and subsequent calls to refresh().
+                # and subsequent calls to git.refresh or this refresh method.
                 cls.GIT_PYTHON_GIT_EXECUTABLE = cls.git_exec_name
             else:
                 # After the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is no longer

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -483,7 +483,7 @@ class Git(LazyMixin):
             else:
                 # After the first refresh (when GIT_PYTHON_GIT_EXECUTABLE is no longer
                 # None) we raise an exception.
-                raise GitCommandNotFound("git", err)
+                raise GitCommandNotFound(new_git, err)
 
         return has_git
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -310,8 +310,7 @@ class TestGit(TestBase):
         self.assertRaises(GitCommandNotFound, refresh, "yada")
 
     def test_refresh_good_git_path(self):
-        which_cmd = "where" if os.name == "nt" else "command -v"
-        path = os.popen("{0} git".format(which_cmd)).read().strip().split("\n")[0]
+        path = shutil.which("git")
         refresh(path)
 
     def test_options_are_passed_to_git(self):

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -306,16 +306,23 @@ class TestGit(TestBase):
         ):
             self.assertRaises(GitCommandNotFound, self.git.version)
 
-    def test_refresh_bad_git_path(self):
-        path = "yada"
-        escaped_abspath = re.escape(str(Path(path).absolute()))
-        expected_pattern = rf"\n[ \t]*cmdline: {escaped_abspath}\Z"
+    def test_refresh_bad_absolute_git_path(self):
+        absolute_path = str(Path("yada").absolute())
+        expected_pattern = rf"\n[ \t]*cmdline: {re.escape(absolute_path)}\Z"
         with self.assertRaisesRegex(GitCommandNotFound, expected_pattern):
-            refresh(path)
+            refresh(absolute_path)
 
-    def test_refresh_good_git_path(self):
-        path = shutil.which("git")
-        refresh(path)
+    def test_refresh_bad_relative_git_path(self):
+        relative_path = "yada"
+        absolute_path = str(Path(relative_path).absolute())
+        expected_pattern = rf"\n[ \t]*cmdline: {re.escape(absolute_path)}\Z"
+        with self.assertRaisesRegex(GitCommandNotFound, expected_pattern):
+            refresh(relative_path)
+
+    def test_refresh_good_absolute_git_path(self):
+        absolute_path = shutil.which("git")
+        refresh(absolute_path)
+        self.assertEqual(self.git.GIT_PYTHON_GIT_EXECUTABLE, absolute_path)
 
     def test_options_are_passed_to_git(self):
         # This works because any command after git --version is ignored.

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -315,6 +315,7 @@ class TestGit(TestBase):
             self.assertRaises(GitCommandNotFound, self.git.version)
 
     def test_refresh_bad_absolute_git_path(self):
+        """Bad absolute path arg is reported and not set."""
         absolute_path = str(Path("yada").absolute())
         expected_pattern = rf"\n[ \t]*cmdline: {re.escape(absolute_path)}\Z"
 
@@ -324,6 +325,7 @@ class TestGit(TestBase):
             self.assertEqual(self.git.GIT_PYTHON_GIT_EXECUTABLE, old_git_executable)
 
     def test_refresh_bad_relative_git_path(self):
+        """Bad relative path arg is resolved to absolute path and reported, not set."""
         absolute_path = str(Path("yada").absolute())
         expected_pattern = rf"\n[ \t]*cmdline: {re.escape(absolute_path)}\Z"
 
@@ -333,6 +335,7 @@ class TestGit(TestBase):
             self.assertEqual(self.git.GIT_PYTHON_GIT_EXECUTABLE, old_git_executable)
 
     def test_refresh_good_absolute_git_path(self):
+        """Good absolute path arg is set."""
         absolute_path = shutil.which("git")
 
         with _rollback_refresh():
@@ -340,6 +343,7 @@ class TestGit(TestBase):
             self.assertEqual(self.git.GIT_PYTHON_GIT_EXECUTABLE, absolute_path)
 
     def test_refresh_good_relative_git_path(self):
+        """Good relative path arg is resolved to absolute path and set."""
         absolute_path = shutil.which("git")
         dirname, basename = osp.split(absolute_path)
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -306,11 +306,10 @@ class TestGit(TestBase):
         ):
             self.assertRaises(GitCommandNotFound, self.git.version)
 
-    def test_refresh(self):
-        # Test a bad git path refresh.
+    def test_refresh_bad_git_path(self):
         self.assertRaises(GitCommandNotFound, refresh, "yada")
 
-        # Test a good path refresh.
+    def test_refresh_good_git_path(self):
         which_cmd = "where" if os.name == "nt" else "command -v"
         path = os.popen("{0} git".format(which_cmd)).read().strip().split("\n")[0]
         refresh(path)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -46,9 +46,8 @@ def _patch_out_env(name):
 
 @contextlib.contextmanager
 def _rollback_refresh():
-    old_git_executable = Git.GIT_PYTHON_GIT_EXECUTABLE
     try:
-        yield old_git_executable  # Let test code run that may mutate class state.
+        yield Git.GIT_PYTHON_GIT_EXECUTABLE  # Provide the old value for convenience.
     finally:
         refresh()
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -307,7 +307,11 @@ class TestGit(TestBase):
             self.assertRaises(GitCommandNotFound, self.git.version)
 
     def test_refresh_bad_git_path(self):
-        self.assertRaises(GitCommandNotFound, refresh, "yada")
+        path = "yada"
+        escaped_abspath = re.escape(str(Path(path).absolute()))
+        expected_pattern = rf"\n[ \t]*cmdline: {escaped_abspath}\Z"
+        with self.assertRaisesRegex(GitCommandNotFound, expected_pattern):
+            refresh(path)
 
     def test_refresh_good_git_path(self):
         path = shutil.which("git")


### PR DESCRIPTION
Fixes #1809
Fixes #1811

This modifies `Git.refresh` to report the attempted Git command rather than always `git` even if a different command was used. This affects the `command` attribute of the `GitCommandNotFound` exception, as well as (and automatically) the text displayed as `cmdline:` since that is from that attribute.

It also expands and adds more tests of `git.refesh` (which calls `Git.refresh`) to encompass this behavior, verifying that they fail before #1809 is fixed and pass afterwards, as well as verify some behavior that was already established but not yet under test.

Since #1811 would otherwise be exacerbated by these changes, I've also made it so those tests roll back the global changes they make that may affect other test by calling `git.refresh()` with no arguments. I believe this can be considered to fix that issue.

There is a bit more information in the commit messages, including about why I've taken that approach to #1811, at least so far, rather than specifically capturing and restoring the pieces of state that are currently affected.

This PR also includes some minor refactoring and comment revision for readability in some code called by `git.refresh` that should make no behavioral change. This includes an improvement to the wording of the comment in `Git.refresh` discussed in review comments on #1810; the opportunity for this came closer than I'd predicted in https://github.com/gitpython-developers/GitPython/pull/1810#discussion_r1464565019. (It might be possible to improve it further.)

*Edit: Corrected "some behavior that was not established" to "some behavior that was already established but not yet under test".*