### PR TITLE
Don't suppress messages when logging is not configured

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -81,8 +81,8 @@ execute_kwargs = {
     "strip_newline_in_stdout",
 }
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 __all__ = ("Git",)
 
@@ -146,7 +146,7 @@ def handle_process_output(
                         handler(line)
 
         except Exception as ex:
-            log.error(f"Pumping {name!r} of cmd({remove_password_if_present(cmdline)}) failed due to: {ex!r}")
+            _logger.error(f"Pumping {name!r} of cmd({remove_password_if_present(cmdline)}) failed due to: {ex!r}")
             if "I/O operation on closed file" not in str(ex):
                 # Only reraise if the error was not due to the stream closing
                 raise CommandError([f"<{name}-pump>"] + remove_password_if_present(cmdline), ex) from ex
@@ -600,7 +600,7 @@ class Git(LazyMixin):
                     self.status = self._status_code_if_terminate or proc.poll()
                     return
             except OSError as ex:
-                log.info("Ignored error after process had died: %r", ex)
+                _logger.info("Ignored error after process had died: %r", ex)
 
             # It can be that nothing really exists anymore...
             if os is None or getattr(os, "kill", None) is None:
@@ -613,7 +613,7 @@ class Git(LazyMixin):
 
                 self.status = self._status_code_if_terminate or status
             except OSError as ex:
-                log.info("Ignored error after process had died: %r", ex)
+                _logger.info("Ignored error after process had died: %r", ex)
             # END exception handling
 
         def __del__(self) -> None:
@@ -654,7 +654,7 @@ class Git(LazyMixin):
 
             if status != 0:
                 errstr = read_all_from_possibly_closed_stream(p_stderr)
-                log.debug("AutoInterrupt wait stderr: %r" % (errstr,))
+                _logger.debug("AutoInterrupt wait stderr: %r" % (errstr,))
                 raise GitCommandError(remove_password_if_present(self.args), status, errstr)
             return status
 
@@ -1018,7 +1018,7 @@ class Git(LazyMixin):
         # Remove password for the command if present.
         redacted_command = remove_password_if_present(command)
         if self.GIT_PYTHON_TRACE and (self.GIT_PYTHON_TRACE != "full" or as_process):
-            log.info(" ".join(redacted_command))
+            _logger.info(" ".join(redacted_command))
 
         # Allow the user to have the command executed in their working dir.
         try:
@@ -1055,7 +1055,7 @@ class Git(LazyMixin):
         stdout_sink = PIPE if with_stdout else getattr(subprocess, "DEVNULL", None) or open(os.devnull, "wb")
         if shell is None:
             shell = self.USE_SHELL
-        log.debug(
+        _logger.debug(
             "Popen(%s, cwd=%s, stdin=%s, shell=%s, universal_newlines=%s)",
             redacted_command,
             cwd,
@@ -1167,7 +1167,7 @@ class Git(LazyMixin):
             # END as_text
 
             if stderr_value:
-                log.info(
+                _logger.info(
                     "%s -> %d; stdout: '%s'; stderr: '%s'",
                     cmdstr,
                     status,
@@ -1175,9 +1175,9 @@ class Git(LazyMixin):
                     safe_decode(stderr_value),
                 )
             elif stdout_value:
-                log.info("%s -> %d; stdout: '%s'", cmdstr, status, as_text(stdout_value))
+                _logger.info("%s -> %d; stdout: '%s'", cmdstr, status, as_text(stdout_value))
             else:
-                log.info("%s -> %d", cmdstr, status)
+                _logger.info("%s -> %d", cmdstr, status)
         # END handle debug printing
 
         if with_exceptions and status != 0:

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -82,7 +82,6 @@ execute_kwargs = {
 }
 
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
 
 __all__ = ("Git",)
 

--- a/git/config.py
+++ b/git/config.py
@@ -61,7 +61,7 @@ else:
 __all__ = ("GitConfigParser", "SectionConstraint")
 
 
-log = logging.getLogger("git.config")
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 

--- a/git/config.py
+++ b/git/config.py
@@ -61,8 +61,8 @@ else:
 __all__ = ("GitConfigParser", "SectionConstraint")
 
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 
 CONFIG_LEVELS: ConfigLevels_Tup = ("system", "user", "global", "repository")
@@ -412,7 +412,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         try:
             self.write()
         except IOError:
-            log.error("Exception during destruction of GitConfigParser", exc_info=True)
+            _logger.error("Exception during destruction of GitConfigParser", exc_info=True)
         except ReferenceError:
             # This happens in Python 3... and usually means that some state cannot be
             # written as the sections dict cannot be iterated. This usually happens when
@@ -712,7 +712,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         # END assert multiple files
 
         if self._has_includes():
-            log.debug(
+            _logger.debug(
                 "Skipping write-back of configuration file as include files were merged in."
                 + "Set merge_includes=False to prevent this."
             )

--- a/git/config.py
+++ b/git/config.py
@@ -60,10 +60,7 @@ else:
 
 __all__ = ("GitConfigParser", "SectionConstraint")
 
-
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
-
 
 CONFIG_LEVELS: ConfigLevels_Tup = ("system", "user", "global", "repository")
 """The configuration level of a configuration file."""

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -52,8 +52,8 @@ if TYPE_CHECKING:
 
 # ------------------------------------------------------------------------
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 __all__ = ("Commit",)
 
@@ -767,7 +767,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 self.author_tz_offset,
             ) = parse_actor_and_date(author_line.decode(self.encoding, "replace"))
         except UnicodeDecodeError:
-            log.error(
+            _logger.error(
                 "Failed to decode author line '%s' using encoding %s",
                 author_line,
                 self.encoding,
@@ -781,7 +781,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 self.committer_tz_offset,
             ) = parse_actor_and_date(committer_line.decode(self.encoding, "replace"))
         except UnicodeDecodeError:
-            log.error(
+            _logger.error(
                 "Failed to decode committer line '%s' using encoding %s",
                 committer_line,
                 self.encoding,
@@ -795,7 +795,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         try:
             self.message = self.message.decode(self.encoding, "replace")
         except UnicodeDecodeError:
-            log.error(
+            _logger.error(
                 "Failed to decode message '%s' using encoding %s",
                 self.message,
                 self.encoding,

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
 # ------------------------------------------------------------------------
 
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
 
 __all__ = ("Commit",)
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 # ------------------------------------------------------------------------
 
-log = logging.getLogger("git.objects.commit")
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 __all__ = ("Commit",)

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 __all__ = ["Submodule", "UpdateProgress"]
 
 
-log = logging.getLogger("git.objects.submodule.base")
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -40,6 +40,7 @@ from .util import (
 
 
 # typing ----------------------------------------------------------------------
+
 from typing import Callable, Dict, Mapping, Sequence, TYPE_CHECKING, cast
 from typing import Any, Iterator, Union
 
@@ -50,14 +51,11 @@ if TYPE_CHECKING:
     from git.repo import Repo
     from git.refs import Head
 
-
 # -----------------------------------------------------------------------------
 
 __all__ = ["Submodule", "UpdateProgress"]
 
-
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
 
 
 class UpdateProgress(RemoteProgress):

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -56,8 +56,8 @@ if TYPE_CHECKING:
 __all__ = ["Submodule", "UpdateProgress"]
 
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 
 class UpdateProgress(RemoteProgress):
@@ -731,7 +731,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                         )
                         mrepo.head.reference.set_tracking_branch(remote_branch)
                     except (IndexError, InvalidGitRepositoryError):
-                        log.warning("Failed to checkout tracking branch %s", self.branch_path)
+                        _logger.warning("Failed to checkout tracking branch %s", self.branch_path)
                     # END handle tracking branch
 
                     # NOTE: Have to write the repo config file as well, otherwise the
@@ -761,14 +761,14 @@ class Submodule(IndexObject, TraversableIterableObj):
                         binsha = rcommit.binsha
                         hexsha = rcommit.hexsha
                     else:
-                        log.error(
+                        _logger.error(
                             "%s a tracking branch was not set for local branch '%s'",
                             msg_base,
                             mrepo.head.reference,
                         )
                     # END handle remote ref
                 else:
-                    log.error("%s there was no local tracking branch", msg_base)
+                    _logger.error("%s there was no local tracking branch", msg_base)
                 # END handle detached head
             # END handle to_latest_revision option
 
@@ -786,7 +786,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                         if force:
                             msg = "Will force checkout or reset on local branch that is possibly in the future of"
                             msg += " the commit it will be checked out to, effectively 'forgetting' new commits"
-                            log.debug(msg)
+                            _logger.debug(msg)
                         else:
                             msg = "Skipping %s on branch '%s' of submodule repo '%s' as it contains un-pushed commits"
                             msg %= (
@@ -794,7 +794,7 @@ class Submodule(IndexObject, TraversableIterableObj):
                                 mrepo.head,
                                 mrepo,
                             )
-                            log.info(msg)
+                            _logger.info(msg)
                             may_reset = False
                         # END handle force
                     # END handle if we are in the future
@@ -834,7 +834,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         except Exception as err:
             if not keep_going:
                 raise
-            log.error(str(err))
+            _logger.error(str(err))
         # END handle keep_going
 
         # HANDLE RECURSION

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 __all__ = ["RootModule", "RootUpdateProgress"]
 
-log = logging.getLogger("git.objects.submodule.root")
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
 __all__ = ["RootModule", "RootUpdateProgress"]
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 
 class RootUpdateProgress(UpdateProgress):
@@ -321,7 +321,7 @@ class RootModule(Submodule):
                                     # this way, it will be checked out in the next step.
                                     # This will change the submodule relative to us, so
                                     # the user will be able to commit the change easily.
-                                    log.warning(
+                                    _logger.warning(
                                         "Current sha %s was not contained in the tracking\
              branch at the new remote, setting it the the remote's tracking branch",
                                         sm.hexsha,
@@ -393,7 +393,7 @@ class RootModule(Submodule):
         except Exception as err:
             if not keep_going:
                 raise
-            log.error(str(err))
+            _logger.error(str(err))
         # END handle keep_going
 
         # FINALLY UPDATE ALL ACTUAL SUBMODULES

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 __all__ = ["RootModule", "RootUpdateProgress"]
 
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
 
 
 class RootUpdateProgress(UpdateProgress):

--- a/git/remote.py
+++ b/git/remote.py
@@ -65,8 +65,8 @@ flagKeyLiteral = Literal[" ", "!", "+", "-", "*", "=", "t", "?"]
 # -------------------------------------------------------------
 
 
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
 
 
 __all__ = ("RemoteProgress", "PushInfo", "FetchInfo", "Remote")
@@ -857,7 +857,7 @@ class Remote(LazyMixin, IterableObj):
         stderr_text = progress.error_lines and "\n".join(progress.error_lines) or ""
         proc.wait(stderr=stderr_text)
         if stderr_text:
-            log.warning("Error lines received while fetching: %s", stderr_text)
+            _logger.warning("Error lines received while fetching: %s", stderr_text)
 
         for line in progress.other_lines:
             line = force_text(line)
@@ -878,9 +878,9 @@ class Remote(LazyMixin, IterableObj):
             msg += "length of progress lines %i should be equal to lines in FETCH_HEAD file %i\n"
             msg += "Will ignore extra progress lines or fetch head lines."
             msg %= (l_fil, l_fhi)
-            log.debug(msg)
-            log.debug(b"info lines: " + str(fetch_info_lines).encode("UTF-8"))
-            log.debug(b"head info: " + str(fetch_head_info).encode("UTF-8"))
+            _logger.debug(msg)
+            _logger.debug(b"info lines: " + str(fetch_info_lines).encode("UTF-8"))
+            _logger.debug(b"head info: " + str(fetch_head_info).encode("UTF-8"))
             if l_fil < l_fhi:
                 fetch_head_info = fetch_head_info[:l_fil]
             else:
@@ -892,8 +892,8 @@ class Remote(LazyMixin, IterableObj):
             try:
                 output.append(FetchInfo._from_line(self.repo, err_line, fetch_line))
             except ValueError as exc:
-                log.debug("Caught error while parsing line: %s", exc)
-                log.warning("Git informed while fetching: %s", err_line.strip())
+                _logger.debug("Caught error while parsing line: %s", exc)
+                _logger.warning("Git informed while fetching: %s", err_line.strip())
         return output
 
     def _get_push_info(
@@ -935,7 +935,7 @@ class Remote(LazyMixin, IterableObj):
             if not output:
                 raise
             elif stderr_text:
-                log.warning("Error lines received while fetching: %s", stderr_text)
+                _logger.warning("Error lines received while fetching: %s", stderr_text)
                 output.error = e
 
         return output

--- a/git/remote.py
+++ b/git/remote.py
@@ -65,7 +65,7 @@ flagKeyLiteral = Literal[" ", "!", "+", "-", "*", "=", "t", "?"]
 # -------------------------------------------------------------
 
 
-log = logging.getLogger("git.remote")
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -64,10 +64,7 @@ flagKeyLiteral = Literal[" ", "!", "+", "-", "*", "=", "t", "?"]
 
 # -------------------------------------------------------------
 
-
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.NullHandler())
-
 
 __all__ = ("RemoteProgress", "PushInfo", "FetchInfo", "Remote")
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
 
 # -----------------------------------------------------------
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 __all__ = ("Repo",)
 
@@ -772,7 +772,7 @@ class Repo:
                 if object_info.type == object_type.encode():
                     return True
                 else:
-                    log.debug(
+                    _logger.debug(
                         "Commit hash points to an object of type '%s'. Requested were objects of type '%s'",
                         object_info.type.decode(),
                         object_type,
@@ -781,7 +781,7 @@ class Repo:
             else:
                 return True
         except BadObject:
-            log.debug("Commit hash is invalid.")
+            _logger.debug("Commit hash is invalid.")
             return False
 
     def _get_daemon_export(self) -> bool:
@@ -1298,7 +1298,7 @@ class Repo:
             cmdline = getattr(proc, "args", "")
             cmdline = remove_password_if_present(cmdline)
 
-            log.debug("Cmd(%s)'s unused stdout: %s", cmdline, stdout)
+            _logger.debug("Cmd(%s)'s unused stdout: %s", cmdline, stdout)
             finalize_process(proc, stderr=stderr)
 
         # Our git command could have a different working dir than our actual

--- a/git/util.py
+++ b/git/util.py
@@ -104,7 +104,7 @@ __all__ = [
     "HIDE_WINDOWS_KNOWN_ERRORS",
 ]
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def _read_win_env_flag(name: str, default: bool) -> bool:
@@ -124,7 +124,7 @@ def _read_win_env_flag(name: str, default: bool) -> bool:
     except KeyError:
         return default
 
-    log.warning(
+    _logger.warning(
         "The %s environment variable is deprecated. Its effect has never been documented and changes without warning.",
         name,
     )
@@ -135,7 +135,7 @@ def _read_win_env_flag(name: str, default: bool) -> bool:
         return False
     if adjusted_value in {"1", "true", "yes"}:
         return True
-    log.warning("%s has unrecognized value %r, treating as %r.", name, value, default)
+    _logger.warning("%s has unrecognized value %r, treating as %r.", name, value, default)
     return default
 
 
@@ -466,7 +466,7 @@ def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
             # retcode = process.poll()
             is_cygwin = "CYGWIN" in uname_out
         except Exception as ex:
-            log.debug("Failed checking if running in CYGWIN due to: %r", ex)
+            _logger.debug("Failed checking if running in CYGWIN due to: %r", ex)
         _is_cygwin_cache[git_executable] = is_cygwin
 
     return is_cygwin

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -45,7 +45,7 @@ __all__ = (
     "GIT_DAEMON_PORT",
 )
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 # { Routines
 
@@ -96,7 +96,7 @@ def with_rw_directory(func):
         try:
             return func(self, path, *args, **kwargs)
         except Exception:
-            log.info(
+            _logger.info(
                 "Test %s.%s failed, output is at %r\n",
                 type(self).__name__,
                 func.__name__,
@@ -147,7 +147,7 @@ def with_rw_repo(working_tree_ref, bare=False):
             try:
                 return func(self, rw_repo)
             except:  # noqa: E722 B001
-                log.info("Keeping repo after failure: %s", repo_dir)
+                _logger.info("Keeping repo after failure: %s", repo_dir)
                 repo_dir = None
                 raise
             finally:
@@ -212,7 +212,7 @@ def git_daemon_launched(base_path, ip, port):
           and setting the environment variable GIT_PYTHON_TEST_GIT_DAEMON_PORT to <port>
         """
         )
-        log.warning(msg, ex, ip, port, base_path, base_path, exc_info=1)
+        _logger.warning(msg, ex, ip, port, base_path, base_path, exc_info=1)
 
         yield  # OK, assume daemon started manually.
 
@@ -221,11 +221,11 @@ def git_daemon_launched(base_path, ip, port):
     finally:
         if gd:
             try:
-                log.debug("Killing git-daemon...")
+                _logger.debug("Killing git-daemon...")
                 gd.proc.kill()
             except Exception as ex:
                 # Either it has died (and we're here), or it won't die, again here...
-                log.debug("Hidden error while Killing git-daemon: %s", ex, exc_info=1)
+                _logger.debug("Hidden error while Killing git-daemon: %s", ex, exc_info=1)
 
 
 def with_rw_and_rw_remote_repo(working_tree_ref):
@@ -307,7 +307,7 @@ def with_rw_and_rw_remote_repo(working_tree_ref):
                         try:
                             return func(self, rw_repo, rw_daemon_repo)
                         except:  # noqa: E722 B001
-                            log.info(
+                            _logger.info(
                                 "Keeping repos after failure: \n  rw_repo_dir: %s \n  rw_daemon_repo_dir: %s",
                                 rw_repo_dir,
                                 rw_daemon_repo_dir,

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -133,7 +133,7 @@ class TestGit(TestBase):
     def test_it_logs_if_it_uses_a_shell(self, case):
         """``shell=`` in the log message agrees with what is passed to `Popen`."""
         value_in_call, value_from_class = case
-        with self.assertLogs(cmd.log, level=logging.DEBUG) as log_watcher:
+        with self.assertLogs(cmd._logger, level=logging.DEBUG) as log_watcher:
             mock_safer_popen = self._do_shell_combo(value_in_call, value_from_class)
         self._assert_logged_for_popen(log_watcher, "shell", mock_safer_popen.call_args.kwargs["shell"])
 
@@ -143,7 +143,7 @@ class TestGit(TestBase):
     )
     def test_it_logs_istream_summary_for_stdin(self, case):
         expected_summary, istream_argument = case
-        with self.assertLogs(cmd.log, level=logging.DEBUG) as log_watcher:
+        with self.assertLogs(cmd._logger, level=logging.DEBUG) as log_watcher:
             self.git.execute(["git", "version"], istream=istream_argument)
         self._assert_logged_for_popen(log_watcher, "stdin", expected_summary)
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -133,7 +133,7 @@ class TestGit(TestBase):
     def test_it_logs_if_it_uses_a_shell(self, case):
         """``shell=`` in the log message agrees with what is passed to `Popen`."""
         value_in_call, value_from_class = case
-        with self.assertLogs(cmd._logger, level=logging.DEBUG) as log_watcher:
+        with self.assertLogs(cmd.__name__, level=logging.DEBUG) as log_watcher:
             mock_safer_popen = self._do_shell_combo(value_in_call, value_from_class)
         self._assert_logged_for_popen(log_watcher, "shell", mock_safer_popen.call_args.kwargs["shell"])
 
@@ -143,7 +143,7 @@ class TestGit(TestBase):
     )
     def test_it_logs_istream_summary_for_stdin(self, case):
         expected_summary, istream_argument = case
-        with self.assertLogs(cmd._logger, level=logging.DEBUG) as log_watcher:
+        with self.assertLogs(cmd.__name__, level=logging.DEBUG) as log_watcher:
             self.git.execute(["git", "version"], istream=istream_argument)
         self._assert_logged_for_popen(log_watcher, "stdin", expected_summary)
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -52,7 +52,7 @@ from test.lib import (
 
 HOOKS_SHEBANG = "#!/usr/bin/env sh\n"
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def _get_windows_ansi_encoding():
@@ -144,13 +144,13 @@ class WinBashStatus:
         if process.returncode == 1 and re.search(r"\bhttps://aka.ms/wslstore\b", text):
             return cls.WslNoDistro(process, text)
         if process.returncode != 0:
-            log.error("Error running bash.exe to check WSL status: %s", text)
+            _logger.error("Error running bash.exe to check WSL status: %s", text)
             return cls.CheckError(process, text)
         if text == "0":
             return cls.Wsl()
         if text == "1":
             return cls.Native()
-        log.error("Strange output checking WSL status: %s", text)
+        _logger.error("Strange output checking WSL status: %s", text)
         return cls.CheckError(process, text)
 
     @staticmethod
@@ -174,7 +174,7 @@ class WinBashStatus:
         except UnicodeDecodeError:
             pass
         except LookupError as error:
-            log.warning("%s", str(error))  # Message already says "Unknown encoding:".
+            _logger.warning("%s", str(error))  # Message already says "Unknown encoding:".
 
         # Assume UTF-8. If invalid, substitute Unicode replacement characters.
         return stdout.decode("utf-8", errors="replace")


### PR DESCRIPTION
Fixes #1806

This stops adding `NullHandler` instances to GitPython's loggers. As noted in #1806, when they were added in #300 this prevented errors when GitPython logged messages and logging was not enabled, but since Python 3.2 there is a logger of last resort providing a nicer default behavior of showing the messages. (They are still shown with better formatting if logging is configured, even if just done with `logging.basicConfig()`, so applications should still typically configure logging.)

This also makes a few more minor related changes, detailed in the commit messages. This includes changing variable names from `log` to `_logger`, as mentioned in https://github.com/gitpython-developers/GitPython/issues/1806#issuecomment-1907690901, as well as consistently passing `__name__` to `logging.getLogger` instead of hard-coding names in a few places, as mentioned in https://github.com/gitpython-developers/GitPython/issues/1808#issuecomment-1911301659.

The major effect of the changes here is that messages of level `WARNING` or higher are not suppressed by default anymore, even when logging is not configured. So I could have included a change here to take care of #1808 as well, such as dc62096. But I plan to introduce that in a future pull request instead, because it would be best to add tests for it, which I think should build on the tests proposed in #1812. If both #1812 and this PR are merged, I can add tests followed by the changes from dc62096 that would make them pass. (If they are not merged, or they are merged with major changes, then that will also clarify how to move forward with making a warning from the initial refresh use the logging framework.)

This shows as resolving several CodeQL alerts and also adding new alerts that correspond exactly to them. This happens as a result of renaming `log` to `_logger`; CodeQL considers the alert resolved because there are no more calls to `log`, and issues new equivalent alerts for the same situations with `_logger`. The new alerts produce a failing *Code scanning results* check for the PR.