### PR TITLE
Have initial refresh use a logger to warn

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -409,15 +409,15 @@ class Git(LazyMixin):
                 # expect GIT_PYTHON_REFRESH to either be unset or be one of the
                 # following values:
                 #
-                #   0|q|quiet|s|silence|n|none
-                #   1|w|warn|warning
-                #   2|r|raise|e|error
+                #   0|q|quiet|s|silence|silent|n|none
+                #   1|w|warn|warning|l|log
+                #   2|r|raise|e|error|exception
 
                 mode = os.environ.get(cls._refresh_env_var, "raise").lower()
 
-                quiet = ["quiet", "q", "silence", "s", "none", "n", "0"]
-                warn = ["warn", "w", "warning", "1"]
-                error = ["error", "e", "raise", "r", "2"]
+                quiet = ["quiet", "q", "silence", "s", "silent", "none", "n", "0"]
+                warn = ["warn", "w", "warning", "log", "l", "1"]
+                error = ["error", "e", "exception", "raise", "r", "2"]
 
                 if mode in quiet:
                     pass
@@ -428,10 +428,10 @@ class Git(LazyMixin):
                         %s
                         All git commands will error until this is rectified.
 
-                        This initial warning can be silenced or aggravated in the future by setting the
+                        This initial message can be silenced or aggravated in the future by setting the
                         $%s environment variable. Use one of the following values:
-                            - %s: for no warning or exception
-                            - %s: for a printed warning
+                            - %s: for no message or exception
+                            - %s: for a warning message (logged at level CRITICAL, displayed by default)
                             - %s: for a raised exception
 
                         Example:
@@ -450,7 +450,7 @@ class Git(LazyMixin):
                     )
 
                     if mode in warn:
-                        print("WARNING: %s" % err)
+                        _logger.critical("WARNING: %s", err)
                     else:
                         raise ImportError(err)
                 else:
@@ -460,8 +460,8 @@ class Git(LazyMixin):
                         %s environment variable has been set but it has been set with an invalid value.
 
                         Use only the following values:
-                            - %s: for no warning or exception
-                            - %s: for a printed warning
+                            - %s: for no message or exception
+                            - %s: for a warning message (logged at level CRITICAL, displayed by default)
                             - %s: for a raised exception
                         """
                         )


### PR DESCRIPTION
Fixes #1808 

Code changes in the `git` module:

- When the initial call to `git.refresh` that happens on import fails to find a `git` command and is configured to warn, it warns using a logger rather than with `print`. Although this is conceptually a warning, it is emitted with level `CRTICAL`, for the reasons given in ac50d8e (the commit in this PR that changes the tests for it).

- The message is changed to document this.

- A few more values, for existing `GIT_PYTHON_REFRESH` modes, are added as synonyms. No new modes are added, nor are their states expanded. The motivation for adding new synonyms is so `log` achieves logging, i.e., it is another way to say `warn`. But `l` is also added as its short form. (This might ordinarily be objected to on the grounds that, when written as `l` and not the also-recognized `L`, it could be confused with `1`. Fortunately `1` also means `warn`, so `1` and `l` will have the same meaning anyway.) Furthermore, `silent` is added as a synonym of `quiet`, since `silence` is already recognized for that, so `silent` seems likely to be used by accident anyway.

  The reason I have not gone further at this time (as was discussed in [the second part of this comment](https://github.com/gitpython-developers/GitPython/issues/1808#issuecomment-1913709517) and in [this reply](https://github.com/gitpython-developers/GitPython/issues/1808#issuecomment-1914143887)) is it can be made more configurable in the future if it looks like that is valuable, but removing existing configurability could break more uses. Furthermore, because the level is `CRITICAL` which differs from that of any other GitPython messages, the better approach of controlling the effect in an application's own logging configuration may be sufficient.

Test changes:

- Rename some existing tests more specifically, so they are not confused with new ones. These are the tests of subsequent (i.e., non-initial) calls to `git.refresh` when an explicit `path` argument is passed.

- Test subsequent refreshes performed with no arguments. That is, test calls to `git.refresh` with no arguments, without simulating the state of not yet having performed an initial refresh. This behavior is not changed in this pull request, but it makes sense to test it, doing so may avoid confusion with the different initial-refresh behavior when reading the tests, and the important subtlety of when relative paths are and aren't resolved is made clearer.

- Test an initial refresh. This is a refresh with no arguments that is performed on import, but to make the relationship to the other tests clearer, reduce test complexity, and make the tests run faster (since some of them run with all documented values of `GIT_PYTHON_REFRESH`), this simulates that state by setting `Git.GIT_PYTHON_GIT_EXECUTABLE` to `None` rather than starting a Python subprocess to do an import.

  This includes testing the behavioral change made in this PR and described above.

- Test the new synonyms of existing values for `GIT_PYTHON_REFRESH` (such as `log` for `warn`).

I added the tests first. For the initial-refresh test, I first wrote it for the preexisting behavior, modified it for the desired behavior and saw it fail. Then I applied the changes, causing the tests to pass again. Those changes are based on, but not quite the same as, dc62096 as discussed in #1813 and https://github.com/gitpython-developers/GitPython/issues/1808#issuecomment-1913709517.

There is some more information in commit messages, especially ac50d8e.