### PR TITLE
Keep temp files out of project dir and improve cleanup

### DIFF
--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -97,7 +97,8 @@ def with_rw_directory(func):
             return func(self, path, *args, **kwargs)
         except Exception:
             _logger.info(
-                "Test %s.%s failed, output is at %r\n",
+                "%s %s.%s failed, output is at %r\n",
+                "Test" if func.__name__.startswith("test_") else "Helper",
                 type(self).__name__,
                 func.__name__,
                 path,

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -4,13 +4,14 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
+import os.path as osp
+from pathlib import Path
+import subprocess
+import tempfile
 
 from git.objects import Tree, Blob
+from git.util import cwd
 from test.lib import TestBase
-
-import os
-import os.path as osp
-import subprocess
 
 
 class TestTree(TestBase):
@@ -42,28 +43,40 @@ class TestTree(TestBase):
             testtree._deserialize(stream)
         # END for each item in tree
 
-    def test_tree_modifier_ordering(self):
-        def setup_git_repository_and_get_ordered_files():
-            os.mkdir("tmp")
-            os.chdir("tmp")
-            subprocess.run(["git", "init", "-q"], check=True)
-            os.mkdir("file")
-            for filename in [
+    @staticmethod
+    def _get_git_ordered_files():
+        """Get files as git orders them, to compare in test_tree_modifier_ordering."""
+        with tempfile.TemporaryDirectory() as tdir:
+            # Create directory contents.
+            Path(tdir, "file").mkdir()
+            for filename in (
                 "bin",
                 "bin.d",
                 "file.to",
                 "file.toml",
                 "file.toml.bin",
                 "file0",
-                "file/a",
-            ]:
-                open(filename, "a").close()
+            ):
+                Path(tdir, filename).touch()
+            Path(tdir, "file", "a").touch()
 
-            subprocess.run(["git", "add", "."], check=True)
-            subprocess.run(["git", "commit", "-m", "c1"], check=True)
-            tree_hash = subprocess.check_output(["git", "rev-parse", "HEAD^{tree}"]).decode().strip()
-            cat_file_output = subprocess.check_output(["git", "cat-file", "-p", tree_hash]).decode()
+            with cwd(tdir):
+                # Prepare the repository.
+                subprocess.run(["git", "init", "-q"], check=True)
+                subprocess.run(["git", "add", "."], check=True)
+                subprocess.run(["git", "commit", "-m", "c1"], check=True)
+
+                # Get git output from which an ordered file list can be parsed.
+                rev_parse_command = ["git", "rev-parse", "HEAD^{tree}"]
+                tree_hash = subprocess.check_output(rev_parse_command).decode().strip()
+                cat_file_command = ["git", "cat-file", "-p", tree_hash]
+                cat_file_output = subprocess.check_output(cat_file_command).decode()
+
             return [line.split()[-1] for line in cat_file_output.split("\n") if line]
+
+    def test_tree_modifier_ordering(self):
+        """TreeModifier.set_done() sorts files in the same order git does."""
+        git_file_names_in_order = self._get_git_ordered_files()
 
         hexsha = "6c1faef799095f3990e9970bc2cb10aa0221cf9c"
         roottree = self.rorepo.tree(hexsha)
@@ -91,9 +104,6 @@ class TestTree(TestBase):
             a = [t[2] for t in mod._cache]
             here = file_names_in_order()
             return [e for e in a if e in here]
-
-        git_file_names_in_order = setup_git_repository_and_get_ordered_files()
-        os.chdir("..")
 
         mod.set_done()
         assert names_in_mod_cache() == git_file_names_in_order, "set_done() performs git-sorting"

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -7,11 +7,10 @@ from io import BytesIO
 import os.path as osp
 from pathlib import Path
 import subprocess
-import tempfile
 
 from git.objects import Tree, Blob
-from git.util import cwd, rmtree
-from test.lib import TestBase
+from git.util import cwd
+from test.lib import TestBase, with_rw_directory
 
 
 class TestTree(TestBase):
@@ -43,39 +42,35 @@ class TestTree(TestBase):
             testtree._deserialize(stream)
         # END for each item in tree
 
-    @staticmethod
-    def _get_git_ordered_files():
+    @with_rw_directory
+    def _get_git_ordered_files(self, rw_dir):
         """Get files as git orders them, to compare in test_tree_modifier_ordering."""
-        with tempfile.TemporaryDirectory() as tdir:
-            # Create directory contents.
-            Path(tdir, "file").mkdir()
-            for filename in (
-                "bin",
-                "bin.d",
-                "file.to",
-                "file.toml",
-                "file.toml.bin",
-                "file0",
-            ):
-                Path(tdir, filename).touch()
-            Path(tdir, "file", "a").touch()
+        # Create directory contents.
+        Path(rw_dir, "file").mkdir()
+        for filename in (
+            "bin",
+            "bin.d",
+            "file.to",
+            "file.toml",
+            "file.toml.bin",
+            "file0",
+        ):
+            Path(rw_dir, filename).touch()
+        Path(rw_dir, "file", "a").touch()
 
-            try:
-                with cwd(tdir):
-                    # Prepare the repository.
-                    subprocess.run(["git", "init", "-q"], check=True)
-                    subprocess.run(["git", "add", "."], check=True)
-                    subprocess.run(["git", "commit", "-m", "c1"], check=True)
+        with cwd(rw_dir):
+            # Prepare the repository.
+            subprocess.run(["git", "init", "-q"], check=True)
+            subprocess.run(["git", "add", "."], check=True)
+            subprocess.run(["git", "commit", "-m", "c1"], check=True)
 
-                    # Get git output from which an ordered file list can be parsed.
-                    rev_parse_command = ["git", "rev-parse", "HEAD^{tree}"]
-                    tree_hash = subprocess.check_output(rev_parse_command).decode().strip()
-                    cat_file_command = ["git", "cat-file", "-p", tree_hash]
-                    cat_file_output = subprocess.check_output(cat_file_command).decode()
-            finally:
-                rmtree(Path(tdir, ".git"))
+            # Get git output from which an ordered file list can be parsed.
+            rev_parse_command = ["git", "rev-parse", "HEAD^{tree}"]
+            tree_hash = subprocess.check_output(rev_parse_command).decode().strip()
+            cat_file_command = ["git", "cat-file", "-p", tree_hash]
+            cat_file_output = subprocess.check_output(cat_file_command).decode()
 
-            return [line.split()[-1] for line in cat_file_output.split("\n") if line]
+        return [line.split()[-1] for line in cat_file_output.split("\n") if line]
 
     def test_tree_modifier_ordering(self):
         """TreeModifier.set_done() sorts files in the same order git does."""

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -7,11 +7,10 @@ from io import BytesIO
 import os.path as osp
 from pathlib import Path
 import subprocess
-import tempfile
 
 from git.objects import Tree, Blob
 from git.util import cwd
-from test.lib import TestBase
+from test.lib import TestBase, with_rw_directory
 
 
 class TestTree(TestBase):
@@ -43,36 +42,35 @@ class TestTree(TestBase):
             testtree._deserialize(stream)
         # END for each item in tree
 
-    @staticmethod
-    def _get_git_ordered_files():
+    @with_rw_directory
+    def _get_git_ordered_files(self, rw_dir):
         """Get files as git orders them, to compare in test_tree_modifier_ordering."""
-        with tempfile.TemporaryDirectory() as tdir:
-            # Create directory contents.
-            Path(tdir, "file").mkdir()
-            for filename in (
-                "bin",
-                "bin.d",
-                "file.to",
-                "file.toml",
-                "file.toml.bin",
-                "file0",
-            ):
-                Path(tdir, filename).touch()
-            Path(tdir, "file", "a").touch()
+        # Create directory contents.
+        Path(rw_dir, "file").mkdir()
+        for filename in (
+            "bin",
+            "bin.d",
+            "file.to",
+            "file.toml",
+            "file.toml.bin",
+            "file0",
+        ):
+            Path(rw_dir, filename).touch()
+        Path(rw_dir, "file", "a").touch()
 
-            with cwd(tdir):
-                # Prepare the repository.
-                subprocess.run(["git", "init", "-q"], check=True)
-                subprocess.run(["git", "add", "."], check=True)
-                subprocess.run(["git", "commit", "-m", "c1"], check=True)
+        with cwd(rw_dir):
+            # Prepare the repository.
+            subprocess.run(["git", "init", "-q"], check=True)
+            subprocess.run(["git", "add", "."], check=True)
+            subprocess.run(["git", "commit", "-m", "c1"], check=True)
 
-                # Get git output from which an ordered file list can be parsed.
-                rev_parse_command = ["git", "rev-parse", "HEAD^{tree}"]
-                tree_hash = subprocess.check_output(rev_parse_command).decode().strip()
-                cat_file_command = ["git", "cat-file", "-p", tree_hash]
-                cat_file_output = subprocess.check_output(cat_file_command).decode()
+            # Get git output from which an ordered file list can be parsed.
+            rev_parse_command = ["git", "rev-parse", "HEAD^{tree}"]
+            tree_hash = subprocess.check_output(rev_parse_command).decode().strip()
+            cat_file_command = ["git", "cat-file", "-p", tree_hash]
+            cat_file_output = subprocess.check_output(cat_file_command).decode()
 
-            return [line.split()[-1] for line in cat_file_output.split("\n") if line]
+        return [line.split()[-1] for line in cat_file_output.split("\n") if line]
 
     def test_tree_modifier_ordering(self):
         """TreeModifier.set_done() sorts files in the same order git does."""


### PR DESCRIPTION
Fixes #1824

This fixes temporary directory creation and cleanup in `test_tree_modifier_ordering`, extracts its helper to a separate method, slightly extends `@with_rw_directory` so it can be used directly on helper methods while still logging accurate descriptions, and uses it to ensure cleanup of the temporary directory that is used by the helper to generate the expected value that the test will compare its results to.

Because that decorator was not previously used on any test helper methods, only on test methods, it is not obvious that my use of it on the helper, and my modification to it to properly support such use, is justified. The reason I think it is justified is that we really do want to complete cleanup, including deleting the temporary directory, before beginning to use the code under test, in order to make clear (when reading the code or when debugging tests or inspecting output) that the helper really is just arranging an expected value for the test.

There's a little more information in the commit messages, but it's mostly covered by the details in #1824 and this PR description.

One important question is whether the new test really still works as a regression test. The answer is yes, as shown by a temporary non-committed revert of 365d44f (the fix in #1799). This is from before the change in this PR:

```text
(.venv) ek@Glub:~/repos-wsl/GitPython (main $=)$ git log -1 365d44f50a3d72d7ebfa063b142d2abd4082cfaa
commit 365d44f50a3d72d7ebfa063b142d2abd4082cfaa
Author: Ｅthan <et-repositories@proton.me>
Date:   Mon Jan 15 14:50:43 2024 +0800

    fix: treeNotSorted issue
(.venv) ek@Glub:~/repos-wsl/GitPython (main $=)$ git revert --no-commit 365d44f50a3d72d7ebfa063b142d2abd4082cfaa
(.venv) ek@Glub:~/repos-wsl/GitPython (main +$|REVERTING=)$ pytest --no-cov -vv test/test_tree.py
Test session starts (platform: linux, Python 3.12.1, pytest 8.0.0, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/ek/repos-wsl/GitPython
configfile: pyproject.toml
plugins: mock-3.12.0, sugar-1.0.0, cov-4.1.0, instafail-0.5.0
collected 3 items

 test/test_tree.py::TestTree.test_serializable ✓                                                          33% ███▍
 test/test_tree.py::TestTree.test_traverse ✓                                                              67% ██████▋

――――――――――――――――――――――――――――――――――――――――― TestTree.test_tree_modifier_ordering ―――――――――――――――――――――――――――――――――――――――――

self = <test.test_tree.TestTree testMethod=test_tree_modifier_ordering>

    def test_tree_modifier_ordering(self):
        def setup_git_repository_and_get_ordered_files():
            os.mkdir("tmp")
            os.chdir("tmp")
            subprocess.run(["git", "init", "-q"], check=True)
            os.mkdir("file")
            for filename in [
                "bin",
                "bin.d",
                "file.to",
                "file.toml",
                "file.toml.bin",
                "file0",
                "file/a",
            ]:
                open(filename, "a").close()

            subprocess.run(["git", "add", "."], check=True)
            subprocess.run(["git", "commit", "-m", "c1"], check=True)
            tree_hash = subprocess.check_output(["git", "rev-parse", "HEAD^{tree}"]).decode().strip()
            cat_file_output = subprocess.check_output(["git", "cat-file", "-p", tree_hash]).decode()
            return [line.split()[-1] for line in cat_file_output.split("\n") if line]

        hexsha = "6c1faef799095f3990e9970bc2cb10aa0221cf9c"
        roottree = self.rorepo.tree(hexsha)
        blob_mode = Tree.blob_id << 12
        tree_mode = Tree.tree_id << 12

        files_in_desired_order = [
            (blob_mode, "bin"),
            (blob_mode, "bin.d"),
            (blob_mode, "file.to"),
            (blob_mode, "file.toml"),
            (blob_mode, "file.toml.bin"),
            (blob_mode, "file0"),
            (tree_mode, "file"),
        ]
        mod = roottree.cache
        for file_mode, file_name in files_in_desired_order:
            mod.add(hexsha, file_mode, file_name)
        # end for each file

        def file_names_in_order():
            return [t[1] for t in files_in_desired_order]

        def names_in_mod_cache():
            a = [t[2] for t in mod._cache]
            here = file_names_in_order()
            return [e for e in a if e in here]

        git_file_names_in_order = setup_git_repository_and_get_ordered_files()
        os.chdir("..")

        mod.set_done()
>       assert names_in_mod_cache() == git_file_names_in_order, "set_done() performs git-sorting"
E       AssertionError: set_done() performs git-sorting
E       assert ['bin', 'bin.d', 'file', 'file.to', 'file.toml', 'file.toml.bin', 'file0'] == ['bin', 'bin.d', 'file.to', 'file.toml', 'file.toml.bin', 'file', 'file0']
E
E         At index 2 diff: 'file' != 'file.to'
E
E         Full diff:
E           [
E               'bin',
E               'bin.d',
E         +     'file',
E               'file.to',
E               'file.toml',
E               'file.toml.bin',
E         -     'file',
E               'file0',
E           ]

test/test_tree.py:99: AssertionError
------------------------------------------------- Captured stdout call -------------------------------------------------
[main (root-commit) ef03b86] c1
 7 files changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 bin
 create mode 100644 bin.d
 create mode 100644 file.to
 create mode 100644 file.toml
 create mode 100644 file.toml.bin
 create mode 100644 file/a
 create mode 100644 file0

 test/test_tree.py::TestTree.test_tree_modifier_ordering ⨯                                               100% ██████████
=============================================== short test summary info ================================================
FAILED test/test_tree.py::TestTree::test_tree_modifier_ordering - AssertionError: set_done() performs git-sorting

Results (0.24s):
       2 passed
       1 failed
         - test/test_tree.py:45 TestTree.test_tree_modifier_ordering
(.venv) ek@Glub:~/repos-wsl/GitPython (main +$%|REVERTING=)$ rm -rf tmp
(.venv) ek@Glub:~/repos-wsl/GitPython (main +$|REVERTING=)$ git revert --abort
(.venv) ek@Glub:~/repos-wsl/GitPython (main $=)$ pytest --no-cov -vv test/test_tree.py
Test session starts (platform: linux, Python 3.12.1, pytest 8.0.0, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/ek/repos-wsl/GitPython
configfile: pyproject.toml
plugins: mock-3.12.0, sugar-1.0.0, cov-4.1.0, instafail-0.5.0
collected 3 items

 test/test_tree.py::TestTree.test_serializable ✓                                                          33% ███▍
 test/test_tree.py::TestTree.test_traverse ✓                                                              67% ██████▋
 test/test_tree.py::TestTree.test_tree_modifier_ordering ✓                                               100% ██████████

Results (0.29s):
       3 passed
(.venv) ek@Glub:~/repos-wsl/GitPython (main $%=)$ rm -rf tmp
(.venv) ek@Glub:~/repos-wsl/GitPython (main $=)$
```

And this is from after the changes in this PR:

```text
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test $=)$ git status
On branch tree-test
Your branch is up to date with 'origin/tree-test'.

nothing to commit, working tree clean
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test $=)$ git revert --no-commit 365d44f50a3d72d7ebfa063b142d2abd4082cfaa
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test +$|REVERTING=)$ pytest --no-cov -vv test/test_tree.py
Test session starts (platform: linux, Python 3.12.1, pytest 8.0.0, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/ek/repos-wsl/GitPython
configfile: pyproject.toml
plugins: mock-3.12.0, sugar-1.0.0, cov-4.1.0, instafail-0.5.0
collected 3 items

 test/test_tree.py::TestTree.test_serializable ✓                                                          33% ███▍
 test/test_tree.py::TestTree.test_traverse ✓                                                              67% ██████▋

――――――――――――――――――――――――――――――――――――――――― TestTree.test_tree_modifier_ordering ―――――――――――――――――――――――――――――――――――――――――

self = <test.test_tree.TestTree testMethod=test_tree_modifier_ordering>

    def test_tree_modifier_ordering(self):
        """TreeModifier.set_done() sorts files in the same order git does."""
        git_file_names_in_order = self._get_git_ordered_files()

        hexsha = "6c1faef799095f3990e9970bc2cb10aa0221cf9c"
        roottree = self.rorepo.tree(hexsha)
        blob_mode = Tree.blob_id << 12
        tree_mode = Tree.tree_id << 12

        files_in_desired_order = [
            (blob_mode, "bin"),
            (blob_mode, "bin.d"),
            (blob_mode, "file.to"),
            (blob_mode, "file.toml"),
            (blob_mode, "file.toml.bin"),
            (blob_mode, "file0"),
            (tree_mode, "file"),
        ]
        mod = roottree.cache
        for file_mode, file_name in files_in_desired_order:
            mod.add(hexsha, file_mode, file_name)
        # end for each file

        def file_names_in_order():
            return [t[1] for t in files_in_desired_order]

        def names_in_mod_cache():
            a = [t[2] for t in mod._cache]
            here = file_names_in_order()
            return [e for e in a if e in here]

        mod.set_done()
>       assert names_in_mod_cache() == git_file_names_in_order, "set_done() performs git-sorting"
E       AssertionError: set_done() performs git-sorting
E       assert ['bin', 'bin.d', 'file', 'file.to', 'file.toml', 'file.toml.bin', 'file0'] == ['bin', 'bin.d', 'file.to', 'file.toml', 'file.toml.bin', 'file', 'file0']
E
E         At index 2 diff: 'file' != 'file.to'
E
E         Full diff:
E           [
E               'bin',
E               'bin.d',
E         +     'file',
E               'file.to',
E               'file.toml',
E               'file.toml.bin',
E         -     'file',
E               'file0',
E           ]

test/test_tree.py:107: AssertionError
------------------------------------------------- Captured stdout call -------------------------------------------------
[main (root-commit) 391489e] c1
 7 files changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 bin
 create mode 100644 bin.d
 create mode 100644 file.to
 create mode 100644 file.toml
 create mode 100644 file.toml.bin
 create mode 100644 file/a
 create mode 100644 file0

 test/test_tree.py::TestTree.test_tree_modifier_ordering ⨯                                               100% ██████████
=============================================== short test summary info ================================================
FAILED test/test_tree.py::TestTree::test_tree_modifier_ordering - AssertionError: set_done() performs git-sorting

Results (0.48s):
       2 passed
       1 failed
         - test/test_tree.py:75 TestTree.test_tree_modifier_ordering
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test +$|REVERTING=)$ git revert --abort
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test $=)$ pytest --no-cov -vv test/test_tree.py
Test session starts (platform: linux, Python 3.12.1, pytest 8.0.0, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/ek/repos-wsl/GitPython
configfile: pyproject.toml
plugins: mock-3.12.0, sugar-1.0.0, cov-4.1.0, instafail-0.5.0
collected 3 items

 test/test_tree.py::TestTree.test_serializable ✓                                                          33% ███▍
 test/test_tree.py::TestTree.test_traverse ✓                                                              67% ██████▋
 test/test_tree.py::TestTree.test_tree_modifier_ordering ✓                                               100% ██████████

Results (0.25s):
       3 passed
(.venv) ek@Glub:~/repos-wsl/GitPython (tree-test $=)$
```

Note that they fail the same way, as desired, when the original bug is temporarily brought back--in particular, see the file list order diff under "Full diff" in each run--and pass when the bugfix is applied.