### PR TITLE
Test in Docker with Alpine Linux on CI

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -11,20 +11,21 @@ jobs:
 
     defaults:
       run:
-        shell: sh -exo pipefail {0}
+        shell: sudo -u runner sh -exo pipefail {0}
 
     steps:
-    - name: Install Alpine Linux packages
+    - name: Prepare Alpine Linux
       run: |
-        apk add git git-daemon python3 py3-pip
+        apk add sudo git git-daemon python3 py3-pip
+        echo 'Defaults env_keep += "CI GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
+        addgroup -g 127 docker
+        adduser -D -u 1001 runner
+        adduser runner docker
+      shell: sh -exo pipefail {0}  # Run this as root, not the "runner" user.
 
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
-    - name: Special configuration for Alpine Linux git
-      run: |
-        git config --global --add safe.directory "$(pwd)"
 
     - name: Prepare this repo for tests
       run: |
@@ -38,24 +39,17 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Create Python virtual environment
-      run: |
-        python -m venv .venv
-
     - name: Update PyPA packages
       run: |
         # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
-        . .venv/bin/activate
         python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
-        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
-        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -64,5 +58,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -27,6 +27,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set workspace ownership
+      run: |
+        chown -R runner:docker -- "$GITHUB_WORKSPACE"
+      shell: sh -exo pipefail {0}  # Run this as root, not the "runner" user.
+
     - name: Debug ownership
       run: |
         printenv GITHUB_WORKSPACE

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -56,17 +56,24 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
+    - name: Create Python virtual environment
+      run: |
+        python -m venv .venv
+
     - name: Update PyPA packages
       run: |
         # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        . .venv/bin/activate
         python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
+        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
+        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -75,4 +82,5 @@ jobs:
 
     - name: Test with pytest
       run: |
+        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -38,17 +38,24 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
+    - name: Create Python virtual environment
+      run: |
+        python -m venv .venv
+
     - name: Update PyPA packages
       run: |
         # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        . .venv/bin/activate
         python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
+        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
+        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -57,4 +64,5 @@ jobs:
 
     - name: Test with pytest
       run: |
+        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -22,6 +22,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Special configuration for Alpine Linux git
+      run: |
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -27,6 +27,14 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Debug ownership
+      run: |
+        printenv GITHUB_WORKSPACE
+        printenv RUNNER_WORKSPACE
+        whoami
+        id
+        ls -alR /__w
+
     - name: Special configuration for Alpine Linux git
       run: |
         git config --global --add safe.directory "$(pwd)"

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -32,18 +32,6 @@ jobs:
         chown -R runner:docker -- "$GITHUB_WORKSPACE"
       shell: sh -exo pipefail {0}  # Run this as root, not the "runner" user.
 
-    - name: Debug ownership
-      run: |
-        printenv GITHUB_WORKSPACE
-        printenv RUNNER_WORKSPACE
-        whoami
-        id
-        ls -alR /__w
-
-    - name: Special configuration for Alpine Linux git
-      run: |
-        git config --global --add safe.directory "$(pwd)"
-
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -1,0 +1,56 @@
+name: test-alpine
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: alpine:latest
+
+    defaults:
+      run:
+        shell: sh -exo pipefail {0}
+
+    steps:
+    - name: Install Alpine Linux packages
+      run: |
+        apk add git git-daemon python3 py3-pip
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Prepare this repo for tests
+      run: |
+        ./init-tests-after-clone.sh
+
+    - name: Set git user identity and command aliases for the tests
+      run: |
+        git config --global user.email "travis@ci.com"
+        git config --global user.name "Travis Runner"
+        # If we rewrite the user's config by accident, we will mess it up
+        # and cause subsequent tests to fail
+        cat test/fixtures/.gitconfig >> ~/.gitconfig
+
+    - name: Update PyPA packages
+      run: |
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
+
+    - name: Install project and test dependencies
+      run: |
+        pip install ".[test]"
+
+    - name: Show version and platform information
+      run: |
+        uname -a
+        command -v git python
+        git version
+        python --version
+        python -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
+
+    - name: Test with pytest
+      run: |
+        pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -44,24 +44,23 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Create Python virtual environment
+    - name: Set up virtualenv
       run: |
         python -m venv .venv
+        . .venv/bin/activate
+        printf '%s=%s\n' 'PATH' "$PATH" 'VIRTUAL_ENV' "$VIRTUAL_ENV" >>"$GITHUB_ENV"
 
     - name: Update PyPA packages
       run: |
         # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
-        . .venv/bin/activate
         python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
-        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
-        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -70,5 +69,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -27,6 +27,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Special configuration for Alpine Linux git
+      run: |
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -51,7 +51,9 @@ def permission_error_tmpdir(tmp_path):
     # Set up PermissionError on Windows, where we can't delete read-only files.
     (td / "x").chmod(stat.S_IRUSR)
 
-    # Set up PermissionError on Unix, where we can't delete files in read-only directories.
+    # Set up PermissionError on Unix, where non-root users can't delete files in
+    # read-only directories. (Tests that rely on this and assert that rmtree raises
+    # PermissionError will fail if they are run as root.)
     td.chmod(stat.S_IRUSR | stat.S_IXUSR)
 
     yield td


### PR DESCRIPTION
As suggested in https://github.com/gitpython-developers/GitPython/pull/1745#issuecomment-1838018193, this adds a test job that runs the tests inside a Docker container.

This can be done with Ubuntu in the container, but instead I used Alpine Linux in the container. This provides a greater variety of platforms GitPython tests on, potentially uncovering some bugs that would otherwise go undetected. In particular, Alpine Linux does not satisfy some of the assumptions that are sometimes made about platforms, as it does not, by default, have `bash`; its `ps` and related tools are not procps; it does not have GNU coreutils or GNU libc; and so forth.

No tests had to be marked `xfail` for this. In particular, as noted in https://github.com/gitpython-developers/GitPython/pull/1745#issuecomment-1837934984, we have no tests for #1756, so that `ps` is not procps in Alpine Linux does not currently result in any failures (and if there were such a test then the existing macOS jobs would still be sufficient for that).

This adds only one test job, testing only one version of Python. Currently that version is Python 3.11, since the Alpine Linux `python3` apk package provides 3.11 at this time. The specified Docker image is `alpine:latest`, and the version will presumably advance to Python 3.12 eventually. I added only one job for two reasons:

- This is easiest, since one version of Python 3 is packaged officially in Alpine Linux's downstream repositories, and it makes sense to test with that.
- I don't want to create an excessive number of new jobs, since it seems likely that some more jobs covering interesting cases might be added, or at least might be worth considering, in the future. (One possible such case is discussed below.)

I was able to use [the `container` key](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container#overview) to do this, so that the workflow is still expressed in separate steps in the same style as the other test workflows, such that the operations that are analogous are represented by steps written in the same (or very similar) way across all workflows. I think the benefit of readability and comparability justifies this at this time, but depending what is done in the future, it might end up being changed to pack most of the work into a smaller number of steps (maybe one) that use `uses: docker://...`, or `run: docker run ...` or [`docker-run-action`](https://github.com/marketplace/actions/docker-run-action), or something else.

Specific reasons for existing design and implementation decisions, including for the strange and somewhat hacky `sudo` usage, are detailed in commit messages.

---

I've proposed this job as its own pull request, rather than waiting and attempting to introduce it with others, because I think this makes sense to review by itself (and I can incorporate any feedback into future changes), and because if I understand https://github.com/gitpython-developers/GitPython/pull/1745#issuecomment-1838018193 correctly it seems to be valued as a feature by itself (which I do agree with). I think that even if there are to be more Docker test jobs, they are better added in a subsequent PR.

However, I'm even more motivated by a goal that this PR does not itself achieve: testing on a bigendian architecture. Because GitPython uses `git` for most of its work, it *shouldn't* have a problem with that, but maybe some parts of `gitdb`/`smmap` that GitPython uses (for which GitPython's use is under test), or more importantly some seemingly innocuous aspects of encoding and decoding, might inadvertently assume little-endianness.

The good news is that no such bugs appear to be present. I have not yet gotten this to work on CI, but on my local amd64 system I am able [to enable emulation and run s390x images](https://docs.gitlab.com/omnibus/development/s390x.html). This is with no hardware acceleration, and some of the performance tests are too slow for me even to have waited for them to finish (which does *not* mean they would have a problem on an actual s390x machine). But when I tell `pytest` to deselect the performance tests, the remaining tests run in a reasonable time and all pass.

I'd like to do that on CI, which is [not hard to do](https://til.simonwillison.net/docker/emulate-s390x-with-qemu#user-content-doing-this-in-github-actions). If possible I'd like to use a workflow of this form, with the `container` key, and have it be a matrix job with both architectures, with special logic for enabling emulation and for skipping the performance tests for non-amd64 architectures (which would, initially and also probably forever, be just the one other architecture, s390x). I haven't managed to get it working that way, though. Using `container:`, the container is supposed to be able to start before any steps run. Even if I can manage to get emulation enabled without being able to easily run commands directly on the runner, I suspect I can't get that to happen early enough that using `container:` is both effective and reasonable.

If Docker test jobs for both amd64 and s390x architectures are to exist, I would want both to be written the same way, even if it makes the amd64 one less nice than in this PR. That way, it would be easier to compare their output to troubleshoot any future failures (as well as to understand how they are set up). If you have thoughts on whether or not this could be valuable, and also how much of a problem (if any) it would be to end up later converting the workflow to look more [like that with fewer steps and not using `container:`](https://til.simonwillison.net/docker/emulate-s390x-with-qemu#user-content-doing-this-in-github-actions), then that can guide me. However, whether or not you have guidance about that, I think this PR itself can probably stand on its own.

(I considered posting this section of the PR description as an issue instead, but I figured I'd put it here in case requested changes to this PR would substantially affect it or make it moot. and also because it provides a possible reason, beyond that discussed in https://github.com/gitpython-developers/GitPython/pull/1745#issuecomment-1838018193, to have Docker jobs like this one in the first place.)