### PR TITLE
Make sure diff always uses the default diff driver when `create_patch=True`

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -155,7 +155,6 @@ class Diffable:
 
         if create_patch:
             args.append("-p")
-            # we expect the default diff driver
             args.append("--no-ext-diff")
         else:
             args.append("--raw")

--- a/git/diff.py
+++ b/git/diff.py
@@ -155,6 +155,8 @@ class Diffable:
 
         if create_patch:
             args.append("-p")
+            # we expect the default diff driver
+            args.append("--no-ext-diff")
         else:
             args.append("--raw")
             args.append("-z")


### PR DESCRIPTION
Closes #1828

This change forces `diff` to always use the default diff driver when `create_patch=True`. So any user using external diff can reproduce the same result as users that don't.