### PR TITLE
Suggest full-path refresh() in failure message

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -438,7 +438,7 @@ class Git:
                 The git executable must be specified in one of the following ways:
                     - be included in your $PATH
                     - be set via $%s
-                    - explicitly set via git.refresh()
+                    - explicitly set via git.refresh("/full/path/to/git")
                 """
                 )
                 % cls._git_exec_env_var

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -397,7 +397,7 @@ class Git:
             3. Pass a *path* argument. This path, if not absolute, it immediately
                resolved, relative to the current directory. This resolution occurs at
                the time of the refresh, and when git commands are run, they are run with
-               that actual path. If a *path* argument is passed, the
+               that previously resolved path. If a *path* argument is passed, the
                ``GIT_PYTHON_GIT_EXECUTABLE`` environment variable is not consulted.
 
         :note: Refreshing always sets the :attr:`Git.GIT_PYTHON_GIT_EXECUTABLE` class


### PR DESCRIPTION
This makes the refresh failure message fill in the made-up path `"/full/path/to/git"` as an argument to `git.refresh`. This small expansion serves two purposes:

- To clarify what kind of explicit refresh is being described: passing a path to `git.refresh`.
- To clarify what kind of path should typically be used when this is done: a full path.

The latter clarification is more important because it cannot be reasoned out from the message and the interface of `git.refresh` and related functions, though it can be learned from their docstrings since #1829, from their implementations, or by trial and error.

I'm not sure how much I like the change in the error message. It seems better than before, but there are three weaknesses:

- The path passed to `git.refresh` doesn't actually have to be a full path. Since this is an item listed under "must be specified in one of the following ways," from this proposed wording one can infer the false claim that `git.refresh(path)`, where `path` is a relative path, never works. It is rarely what one would want, but it *can* work and has been deliberately supported (just not clearly documented) for quite some time.
- To limit the length of the message, which already packs in a lot of information (the string it is part of is concatenated to other strings to produce a message that is often  taller than one's terminal), I only added an argument. I didn't add a statement that one should usually pass a full path. I think that's the right choice, given how much information is already in this message and how one should usually use one of the other techniques to let GitPython find the git executable anyway. But I'm not sure.
- Full paths don't always look like that. In particular, on Windows they usually start with a drive letter. Maybe the message should be customized for Windows to start with `C:`? (`C:` is not always the relevant drive, but I think having it vary based on the current drive or any other aspects of the current location is not justified.)

This pull request also makes a small change to the wording in the `Git.refresh` docstring from #1829, which could have been read to mean the opposite of what I intended.