### PR TITLE
`repo.blame` and `repo.blame_incremental` now accept `None` as the `rev` parameter.

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -957,7 +957,7 @@ class Repo:
         # reveal_type(self.head.reference)  # => Reference
         return self.head.reference
 
-    def blame_incremental(self, rev: str | HEAD, file: str, **kwargs: Any) -> Iterator["BlameEntry"]:
+    def blame_incremental(self, rev: str | HEAD | None, file: str, **kwargs: Any) -> Iterator["BlameEntry"]:
         """Iterator for blame information for the given file at the given revision.
 
         Unlike :meth:`blame`, this does not return the actual file's contents, only a
@@ -1045,7 +1045,7 @@ class Repo:
 
     def blame(
         self,
-        rev: Union[str, HEAD],
+        rev: Union[str, HEAD, None],
         file: str,
         incremental: bool = False,
         rev_opts: Optional[List[str]] = None,

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -963,7 +963,9 @@ class Repo:
         Unlike :meth:`blame`, this does not return the actual file's contents, only a
         stream of :class:`BlameEntry` tuples.
 
-        :param rev: Revision specifier, see git-rev-parse for viable options.
+        :param rev: Revision specifier. If `None`, the blame will include all the latest
+            uncommitted changes. Otherwise, anything succesfully parsed by git-rev-parse
+            is a valid option.
 
         :return: Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates
             the commit to blame for the line, and range indicates a span of line numbers
@@ -1053,7 +1055,9 @@ class Repo:
     ) -> List[List[Commit | List[str | bytes] | None]] | Iterator[BlameEntry] | None:
         """The blame information for the given file at the given revision.
 
-        :param rev: Revision specifier, see git-rev-parse for viable options.
+        :param rev: Revision specifier. If `None`, the blame will include all the latest
+            uncommitted changes. Otherwise, anything succesfully parsed by git-rev-parse
+            is a valid option.
 
         :return:
             list: [git.Commit, list: [<line>]]


### PR DESCRIPTION
Fixes #1835.

As this pull request only affects the typings and does not change the behavior in any way, I did not write a test for the changes I made. 

While a test definitely *could* be written to see if the library does parse a blame output with uncommited changes, I don't perticularily think this is necessary, as the output format of the `git blame -p` command is the same as if there had been a commit, just with hard-coded values (such as the null SHA as the commit hash). Therefore, there is no reason the parsing would fail.

I did manually test both methods with the `None` rev parameter and they do give the expected behavior. 

Let me know if you want me to change anything else!