### PR TITLE
Revise docstrings, comments, and a few messages

### DIFF
--- a/git/__init__.py
+++ b/git/__init__.py
@@ -127,7 +127,7 @@ def refresh(path: Optional[PathLike] = None) -> None:
         immediately, relative to the current directory.
 
     :note:
-        The *path* parameter is usually omitted and cannot be used to specify a custom
+        The `path` parameter is usually omitted and cannot be used to specify a custom
         command whose location is looked up in a path search on each call. See
         :meth:`Git.refresh <git.cmd.Git.refresh>` for details on how to achieve this.
 

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -129,12 +129,13 @@ def refresh(path: Optional[PathLike] = None) -> None:
     :note:
         The *path* parameter is usually omitted and cannot be used to specify a custom
         command whose location is looked up in a path search on each call. See
-        :meth:`Git.refresh` for details on how to achieve this.
+        :meth:`Git.refresh <git.cmd.Git.refresh>` for details on how to achieve this.
 
     :note:
-        This calls :meth:`Git.refresh` and sets other global configuration according to
-        the effect of doing so. As such, this function should usually be used instead of
-        using :meth:`Git.refresh` or :meth:`FetchInfo.refresh` directly.
+        This calls :meth:`Git.refresh <git.cmd.Git.refresh>` and sets other global
+        configuration according to the effect of doing so. As such, this function should
+        usually be used instead of using :meth:`Git.refresh <git.cmd.Git.refresh>` or
+        :meth:`FetchInfo.refresh <git.remote.FetchInfo.refresh>` directly.
 
     :note:
         This function is called automatically, with no arguments, at import time.

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -122,18 +122,22 @@ GIT_OK = None
 def refresh(path: Optional[PathLike] = None) -> None:
     """Convenience method for setting the git executable path.
 
-    :param path: Optional path to the Git executable. If not absolute, it is resolved
+    :param path:
+        Optional path to the Git executable. If not absolute, it is resolved
         immediately, relative to the current directory.
 
-    :note: The *path* parameter is usually omitted and cannot be used to specify a
-        custom command whose location is looked up in a path search on each call. See
+    :note:
+        The *path* parameter is usually omitted and cannot be used to specify a custom
+        command whose location is looked up in a path search on each call. See
         :meth:`Git.refresh` for details on how to achieve this.
 
-    :note: This calls :meth:`Git.refresh` and sets other global configuration according
-        to the effect of doing so. As such, this function should usually be used instead
-        of using :meth:`Git.refresh` or :meth:`FetchInfo.refresh` directly.
+    :note:
+        This calls :meth:`Git.refresh` and sets other global configuration according to
+        the effect of doing so. As such, this function should usually be used instead of
+        using :meth:`Git.refresh` or :meth:`FetchInfo.refresh` directly.
 
-    :note: This function is called automatically, with no arguments, at import time.
+    :note:
+        This function is called automatically, with no arguments, at import time.
     """
     global GIT_OK
     GIT_OK = False

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -106,7 +106,7 @@ def handle_process_output(
     decode_streams: bool = True,
     kill_after_timeout: Union[None, float] = None,
 ) -> None:
-    """Register for notifications to learn that process output is ready to read, and
+    R"""Register for notifications to learn that process output is ready to read, and
     dispatch lines to the respective line handlers.
 
     This function returns once the finalizer returns.
@@ -126,8 +126,11 @@ def handle_process_output(
     :param decode_streams:
         Assume stdout/stderr streams are binary and decode them before pushing their
         contents to handlers.
-        Set this to ``False`` if ``universal_newlines == True`` (then streams are in
-        text mode) or if decoding must happen later (i.e. for :class:`~git.diff.Diff`s).
+
+        This defaults to ``True``. Set it to ``False``:
+
+        - if ``universal_newlines == True``, as then streams are in text mode, or
+        - if decoding must happen later, such as for :class:`~git.diff.Diff`\s.
 
     :param kill_after_timeout:
         :class:`float` or ``None``, Default = ``None``
@@ -379,15 +382,14 @@ class Git:
 
     :note:
         The git executable is actually found during the refresh step in the top level
-        :mod:`__init__`. It can also be changed by explicitly calling
-        :func:`git.refresh`.
+        ``__init__``. It can also be changed by explicitly calling :func:`git.refresh`.
     """
 
     _refresh_token = object()  # Since None would match an initial _version_info_token.
 
     @classmethod
     def refresh(cls, path: Union[None, PathLike] = None) -> bool:
-        """This gets called by the refresh function (see the top level __init__).
+        """This gets called by the refresh function (see the top level ``__init__``).
 
         :param path:
             Optional path to the git executable. If not absolute, it is resolved
@@ -868,8 +870,7 @@ class Git:
         self.cat_file_all: Union[None, TBD] = None
 
     def __getattr__(self, name: str) -> Any:
-        """A convenience method as it allows to call the command as if it was
-        an object.
+        """A convenience method as it allows to call the command as if it was an object.
 
         :return:
             Callable object that will execute call :meth:`_call_process` with your
@@ -899,7 +900,7 @@ class Git:
     @property
     def version_info(self) -> Tuple[int, ...]:
         """
-        :return:  tuple with integers representing the major, minor and additional
+        :return: Tuple with integers representing the major, minor and additional
             version numbers as parsed from ``git version``. Up to four fields are used.
 
             This value is generated on demand and is cached.
@@ -1021,7 +1022,7 @@ class Git:
         :param output_stream:
             If set to a file-like object, data produced by the git command will be
             copied to the given stream instead of being returned as a string.
-            This feature only has any effect if `as_process` is False.
+            This feature only has any effect if `as_process` is ``False``.
 
         :param stdout_as_string:
             If ``False``, the command's standard output will be bytes. Otherwise, it
@@ -1030,10 +1031,10 @@ class Git:
 
         :param kill_after_timeout:
             Specifies a timeout in seconds for the git command, after which the process
-            should be killed. This will have no effect if `as_process` is set to True.
-            It is set to None by default and will let the process run until the timeout
-            is explicitly specified. Uses of this feature should be carefully
-            considered, due to the following limitations:
+            should be killed. This will have no effect if `as_process` is set to
+            ``True``. It is set to ``None`` by default and will let the process run
+            until the timeout is explicitly specified. Uses of this feature should be
+            carefully considered, due to the following limitations:
 
             1. This feature is not supported at all on Windows.
             2. Effectiveness may vary by operating system. ``ps --ppid`` is used to
@@ -1099,7 +1100,7 @@ class Git:
 
         :note:
            If you add additional keyword arguments to the signature of this method,
-           you must update the execute_kwargs tuple housed in this module.
+           you must update the ``execute_kwargs`` variable housed in this module.
         """
         # Remove password for the command if present.
         redacted_command = remove_password_if_present(command)
@@ -1420,9 +1421,10 @@ class Git:
         :param kwargs:
             Contains key-values for the following:
 
-            - The :meth:`execute()` kwds, as listed in :var:`execute_kwargs`.
+            - The :meth:`execute()` kwds, as listed in ``execute_kwargs``.
             - "Command options" to be converted by :meth:`transform_kwargs`.
-            - The ``insert_kwargs_after`` key which its value must match one of ``*args``.
+            - The ``insert_kwargs_after`` key which its value must match one of
+              ``*args``.
 
             It also contains any command options, to be appended after the matched arg.
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -479,7 +479,7 @@ class Git:
                         This initial message can be silenced or aggravated in the future by setting the
                         $%s environment variable. Use one of the following values:
                             - %s: for no message or exception
-                            - %s: for a warning message (logged at level CRITICAL, displayed by default)
+                            - %s: for a warning message (logging level CRITICAL, displayed by default)
                             - %s: for a raised exception
 
                         Example:
@@ -509,7 +509,7 @@ class Git:
 
                         Use only the following values:
                             - %s: for no message or exception
-                            - %s: for a warning message (logged at level CRITICAL, displayed by default)
+                            - %s: for a warning message (logging level CRITICAL, displayed by default)
                             - %s: for a raised exception
                         """
                         )

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -127,10 +127,10 @@ def handle_process_output(
         Assume stdout/stderr streams are binary and decode them before pushing their
         contents to handlers.
 
-        This defaults to ``True``. Set it to ``False``:
+        This defaults to ``True``. Set it to ``False`` if:
 
-        - if ``universal_newlines == True``, as then streams are in text mode, or
-        - if decoding must happen later, such as for :class:`~git.diff.Diff`\s.
+        - ``universal_newlines == True``, as then streams are in text mode, or
+        - decoding must happen later, such as for :class:`~git.diff.Diff`\s.
 
     :param kill_after_timeout:
         :class:`float` or ``None``, Default = ``None``
@@ -1085,13 +1085,15 @@ class Git:
             specify may not be the same ones.
 
         :return:
-            * str(output) if extended_output = False (Default)
-            * tuple(int(status), str(stdout), str(stderr)) if extended_output = True
+            * str(output), if `extended_output` is ``False`` (Default)
+            * tuple(int(status), str(stdout), str(stderr)),
+              if `extended_output` is ``True``
 
             If `output_stream` is ``True``, the stdout value will be your output stream:
 
-            * output_stream if extended_output = False
-            * tuple(int(status), output_stream, str(stderr)) if extended_output = True
+            * output_stream, if `extended_output` is ``False``
+            * tuple(int(status), output_stream, str(stderr)),
+              if `extended_output` is ``True``
 
             Note that git is executed with ``LC_MESSAGES="C"`` to ensure consistent
             output regardless of system language.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1018,12 +1018,8 @@ class Git:
 
         :param output_stream:
             If set to a file-like object, data produced by the git command will be
-            output to the given stream directly.
-            This feature only has any effect if `as_process` is False. Processes will
-            always be created with a pipe due to issues with subprocess.
-            This merely is a workaround as data will be copied from the
-            output pipe to the given output stream directly.
-            Judging from the implementation, you shouldn't use this parameter!
+            copied to the given stream instead of being returned as a string.
+            This feature only has any effect if `as_process` is False.
 
         :param stdout_as_string:
             If False, the command's standard output will be bytes. Otherwise, it will be

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1067,9 +1067,9 @@ class Git:
             A dictionary of environment variables to be passed to :class:`subprocess.Popen`.
 
         :param max_chunk_size:
-            Maximum number of bytes in one chunk of data passed to the output_stream in
-            one invocation of write() method. If the given number is not positive then
-            the default value is used.
+            Maximum number of bytes in one chunk of data passed to the `output_stream`
+            in one invocation of its ``write()`` method. If the given number is not
+            positive then the default value is used.
 
         :param strip_newline_in_stdout:
             Whether to strip the trailing ``\n`` of the command stdout.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -699,7 +699,7 @@ class Git:
                 May deadlock if output or error pipes are used and not handled
                 separately.
 
-            :raise GitCommandError:
+            :raise git.exc.GitCommandError:
                 If the return status is not 0.
             """
             if stderr is None:
@@ -1091,7 +1091,7 @@ class Git:
             Note that git is executed with ``LC_MESSAGES="C"`` to ensure consistent
             output regardless of system language.
 
-        :raise GitCommandError:
+        :raise git.exc.GitCommandError:
 
         :note:
            If you add additional keyword arguments to the signature of this method,

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -250,9 +250,10 @@ def _safer_popen_windows(
     # When not using a shell, the current process does the search in a CreateProcessW
     # API call, so the variable must be set in our environment. With a shell, this is
     # unnecessary, in versions where https://github.com/python/cpython/issues/101283 is
-    # patched. If not, in the rare case the ComSpec environment variable is unset, the
-    # shell is searched for unsafely. Setting NoDefaultCurrentDirectoryInExePath in all
-    # cases, as here, is simpler and protects against that. (The "1" can be any value.)
+    # patched. If that is unpatched, then in the rare case the ComSpec environment
+    # variable is unset, the search for the shell itself is unsafe. Setting
+    # NoDefaultCurrentDirectoryInExePath in all cases, as is done here, is simpler and
+    # protects against that. (As above, the "1" can be any value.)
     with patch_env("NoDefaultCurrentDirectoryInExePath", "1"):
         return Popen(
             command,

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -458,7 +458,7 @@ class Git:
                 The git executable must be specified in one of the following ways:
                     - be included in your $PATH
                     - be set via $%s
-                    - explicitly set via git.refresh("/full/path/to/git")
+                    - explicitly set via git.refresh(<full-path-to-git-executable>)
                 """
                 )
                 % cls._git_exec_env_var

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -112,25 +112,25 @@ def handle_process_output(
     This function returns once the finalizer returns.
 
     :param process:
-        :class:`subprocess.Popen` instance
+        :class:`subprocess.Popen` instance.
 
     :param stdout_handler:
-        f(stdout_line_string), or None
+        f(stdout_line_string), or ``None``.
 
     :param stderr_handler:
-        f(stderr_line_string), or None
+        f(stderr_line_string), or ``None``.
 
     :param finalizer:
-        f(proc) - wait for proc to finish
+        f(proc) - wait for proc to finish.
 
     :param decode_streams:
         Assume stdout/stderr streams are binary and decode them before pushing their
         contents to handlers.
-        Set this to False if ``universal_newlines == True`` (then streams are in text
-        mode) or if decoding must happen later (i.e. for :class:`git.diff.Diff`s).
+        Set this to ``False`` if ``universal_newlines == True`` (then streams are in
+        text mode) or if decoding must happen later (i.e. for :class:`~git.diff.Diff`s).
 
     :param kill_after_timeout:
-        float or None, Default = None
+        :class:`float` or ``None``, Default = ``None``
 
         To specify a timeout in seconds for the git command, after which the process
         should be killed.
@@ -236,7 +236,7 @@ def _safer_popen_windows(
     itself be searched automatically by the shell. This wrapper covers all those cases.
 
     :note:
-        This currently works by setting the ``NoDefaultCurrentDirectoryInExePath``
+        This currently works by setting the :envvar:`NoDefaultCurrentDirectoryInExePath`
         environment variable during subprocess creation. It also takes care of passing
         Windows-specific process creation flags, but that is unrelated to path search.
 
@@ -311,8 +311,8 @@ class Git:
 
     Debugging:
 
-    * Set the ``GIT_PYTHON_TRACE`` environment variable print each invocation of the
-      command to stdout.
+    * Set the :envvar:`GIT_PYTHON_TRACE` environment variable to print each invocation
+      of the command to stdout.
     * Set its value to ``full`` to see details about the returned values.
     """
 
@@ -351,7 +351,7 @@ class Git:
     """Enables debugging of GitPython's git commands."""
 
     USE_SHELL = False
-    """Deprecated. If set to True, a shell will be used when executing git commands.
+    """Deprecated. If set to ``True``, a shell will be used when executing git commands.
 
     Prior to GitPython 2.0.8, this had a narrow purpose in suppressing console windows
     in graphical Windows applications. In 2.0.8 and higher, it provides no benefit, as
@@ -401,30 +401,32 @@ class Git:
             There are three different ways to specify the command that refreshing causes
             to be used for git:
 
-            1. Pass no `path` argument and do not set the ``GIT_PYTHON_GIT_EXECUTABLE``
-               environment variable. The command name ``git`` is used. It is looked up
-               in a path search by the system, in each command run (roughly similar to
-               how git is found when running ``git`` commands manually). This is usually
-               the desired behavior.
+            1. Pass no `path` argument and do not set the
+               :envvar:`GIT_PYTHON_GIT_EXECUTABLE` environment variable. The command
+               name ``git`` is used. It is looked up in a path search by the system, in
+               each command run (roughly similar to how git is found when running
+               ``git`` commands manually). This is usually the desired behavior.
 
-            2. Pass no `path` argument but set the ``GIT_PYTHON_GIT_EXECUTABLE``
+            2. Pass no `path` argument but set the :envvar:`GIT_PYTHON_GIT_EXECUTABLE`
                environment variable. The command given as the value of that variable is
                used. This may be a simple command or an arbitrary path. It is looked up
-               in each command run. Setting ``GIT_PYTHON_GIT_EXECUTABLE`` to ``git`` has
-               the same effect as not setting it.
+               in each command run. Setting :envvar:`GIT_PYTHON_GIT_EXECUTABLE` to
+               ``git`` has the same effect as not setting it.
 
             3. Pass a `path` argument. This path, if not absolute, is immediately
                resolved, relative to the current directory. This resolution occurs at
                the time of the refresh. When git commands are run, they are run using
                that previously resolved path. If a `path` argument is passed, the
-               ``GIT_PYTHON_GIT_EXECUTABLE`` environment variable is not consulted.
+               :envvar:`GIT_PYTHON_GIT_EXECUTABLE` environment variable is not
+               consulted.
 
         :note:
             Refreshing always sets the :attr:`Git.GIT_PYTHON_GIT_EXECUTABLE` class
             attribute, which can be read on the :class:`Git` class or any of its
             instances to check what command is used to run git. This attribute should
-            not be confused with the related ``GIT_PYTHON_GIT_EXECUTABLE`` environment
-            variable. The class attribute is set no matter how refreshing is performed.
+            not be confused with the related :envvar:`GIT_PYTHON_GIT_EXECUTABLE`
+            environment variable. The class attribute is set no matter how refreshing is
+            performed.
         """
         # Discern which path to refresh with.
         if path is not None:
@@ -571,9 +573,9 @@ class Git:
     def polish_url(cls, url: str, is_cygwin: Union[None, bool] = None) -> PathLike:
         """Remove any backslashes from URLs to be written in config files.
 
-        Windows might create config files containing paths with backslashes,
-        but git stops liking them as it will escape the backslashes. Hence we
-        undo the escaping just to be sure.
+        Windows might create config files containing paths with backslashes, but git
+        stops liking them as it will escape the backslashes. Hence we undo the escaping
+        just to be sure.
         """
         if is_cygwin is None:
             is_cygwin = cls.is_cygwin()
@@ -638,8 +640,8 @@ class Git:
 
         __slots__ = ("proc", "args", "status")
 
-        # If this is non-zero it will override any status code during
-        # _terminate, used to prevent race conditions in testing.
+        # If this is non-zero it will override any status code during _terminate, used
+        # to prevent race conditions in testing.
         _status_code_if_terminate: int = 0
 
         def __init__(self, proc: Union[None, subprocess.Popen], args: Any) -> None:
@@ -844,7 +846,7 @@ class Git:
         """Initialize this instance with:
 
         :param working_dir:
-           Git directory we should work in. If None, we always work in the current
+           Git directory we should work in. If ``None``, we always work in the current
            directory as returned by :func:`os.getcwd`.
            This is meant to be the working tree directory if available, or the
            ``.git`` directory in case of bare repositories.
@@ -1022,8 +1024,8 @@ class Git:
             This feature only has any effect if `as_process` is False.
 
         :param stdout_as_string:
-            If False, the command's standard output will be bytes. Otherwise, it will be
-            decoded into a string using the default encoding (usually UTF-8).
+            If ``False``, the command's standard output will be bytes. Otherwise, it
+            will be decoded into a string using the default encoding (usually UTF-8).
             The latter can fail, if the output contains binary data.
 
         :param kill_after_timeout:
@@ -1045,15 +1047,16 @@ class Git:
                is manually removed.
 
         :param with_stdout:
-            If True, default True, we open stdout on the created process.
+            If ``True``, default ``True``, we open stdout on the created process.
 
         :param universal_newlines:
-            If True, pipes will be opened as text, and lines are split at all known line
-            endings.
+            If ``True``, pipes will be opened as text, and lines are split at all known
+            line endings.
 
         :param shell:
-            Whether to invoke commands through a shell (see `Popen(..., shell=True)`).
-            If this is not `None`, it overrides :attr:`USE_SHELL`.
+            Whether to invoke commands through a shell
+            (see :class:`Popen(..., shell=True) <subprocess.Popen>`).
+            If this is not ``None``, it overrides :attr:`USE_SHELL`.
 
             Passing ``shell=True`` to this or any other GitPython function should be
             avoided, as it is unsafe under most circumstances. This is because it is
@@ -1064,7 +1067,8 @@ class Git:
             issues.
 
         :param env:
-            A dictionary of environment variables to be passed to :class:`subprocess.Popen`.
+            A dictionary of environment variables to be passed to
+            :class:`subprocess.Popen`.
 
         :param max_chunk_size:
             Maximum number of bytes in one chunk of data passed to the `output_stream`
@@ -1083,7 +1087,7 @@ class Git:
             * str(output) if extended_output = False (Default)
             * tuple(int(status), str(stdout), str(stderr)) if extended_output = True
 
-            If output_stream is True, the stdout value will be your output stream:
+            If `output_stream` is ``True``, the stdout value will be your output stream:
 
             * output_stream if extended_output = False
             * tuple(int(status), output_stream, str(stderr)) if extended_output = True
@@ -1288,7 +1292,7 @@ class Git:
             self.update_environment(**old_env)
 
         :param kwargs:
-            Environment variables to use for git processes
+            Environment variables to use for git processes.
 
         :return:
             Dict that maps environment variables to their old values
@@ -1367,8 +1371,8 @@ class Git:
 
         :param kwargs:
             A dict of keyword arguments.
-            These arguments are passed as in :meth:`_call_process`, but will be
-            passed to the git command rather than the subcommand.
+            These arguments are passed as in :meth:`_call_process`, but will be passed
+            to the git command rather than the subcommand.
 
         Examples::
 
@@ -1409,16 +1413,16 @@ class Git:
             as in ``ls_files`` to call ``ls-files``.
 
         :param args:
-            The list of arguments. If None is included, it will be pruned.
-            This allows your commands to call git more conveniently, as None is realized
-            as non-existent.
+            The list of arguments. If ``None`` is included, it will be pruned.
+            This allows your commands to call git more conveniently, as ``None`` is
+            realized as non-existent.
 
         :param kwargs:
             Contains key-values for the following:
 
             - The :meth:`execute()` kwds, as listed in :var:`execute_kwargs`.
             - "Command options" to be converted by :meth:`transform_kwargs`.
-            - The `'insert_kwargs_after'` key which its value must match one of ``*args``.
+            - The ``insert_kwargs_after`` key which its value must match one of ``*args``.
 
             It also contains any command options, to be appended after the matched arg.
 
@@ -1431,9 +1435,9 @@ class Git:
            git rev-list max-count 10 --header master
 
         :return:
-            Same as :meth:`execute`.
-            If no args are given, used :meth:`execute`'s default (especially
-            ``as_process = False``, ``stdout_as_string = True``) and return str.
+            Same as :meth:`execute`. If no args are given, used :meth:`execute`'s
+            default (especially ``as_process = False``, ``stdout_as_string = True``) and
+            return :class:`str`.
         """
         # Handle optional arguments prior to calling transform_kwargs.
         # Otherwise these'll end up in args, which is bad.
@@ -1480,10 +1484,11 @@ class Git:
         :param header_line:
             <hex_sha> type_string size_as_int
 
-        :return: (hex_sha, type_string, size_as_int)
+        :return:
+            (hex_sha, type_string, size_as_int)
 
         :raise ValueError:
-            If the header contains indication for an error due to incorrect input sha
+            If the header contains indication for an error due to incorrect input sha.
         """
         tokens = header_line.split()
         if len(tokens) != 3:

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -379,8 +379,8 @@ class Git:
         :note: The top-level :func:`git.refresh` should be preferred because it calls
             this method and may also update other state accordingly.
 
-        :note: There are three different ways to specify what command refreshing causes
-            to be uses for git:
+        :note: There are three different ways to specify the command that refreshing
+            causes to be used for git:
 
             1. Pass no *path* argument and do not set the ``GIT_PYTHON_GIT_EXECUTABLE``
                environment variable. The command name ``git`` is used. It is looked up
@@ -394,9 +394,9 @@ class Git:
                in each command run. Setting ``GIT_PYTHON_GIT_EXECUTABLE`` to ``git`` has
                the same effect as not setting it.
 
-            3. Pass a *path* argument. This path, if not absolute, it immediately
+            3. Pass a *path* argument. This path, if not absolute, is immediately
                resolved, relative to the current directory. This resolution occurs at
-               the time of the refresh, and when git commands are run, they are run with
+               the time of the refresh. When git commands are run, they are run using
                that previously resolved path. If a *path* argument is passed, the
                ``GIT_PYTHON_GIT_EXECUTABLE`` environment variable is not consulted.
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1572,8 +1572,8 @@ class Git:
             (hexsha, type_string, size_as_int, stream)
 
         :note:
-            This method is not threadsafe. You need one independent Command instance per
-            thread to be safe!
+            This method is not threadsafe. You need one independent :class:`Git`
+            instance per thread to be safe!
         """
         cmd = self._get_persistent_cmd("cat_file_all", "cat_file", batch=True)
         hexsha, typename, size = self.__get_object_header(cmd, ref)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -922,7 +922,12 @@ class Git:
         return self._version_info
 
     @overload
-    def execute(self, command: Union[str, Sequence[Any]], *, as_process: Literal[True]) -> "AutoInterrupt":
+    def execute(
+        self,
+        command: Union[str, Sequence[Any]],
+        *,
+        as_process: Literal[True],
+    ) -> "AutoInterrupt":
         ...
 
     @overload

--- a/git/compat.py
+++ b/git/compat.py
@@ -35,8 +35,9 @@ This is deprecated because it is clearer to write out :attr:`os.name` or
 :attr:`sys.platform` checks explicitly, especially in cases where it matters which is
 used.
 
-:note: ``is_win`` is ``False`` on Cygwin, but is often wrongly assumed ``True``. To
-    detect Cygwin, use ``sys.platform == "cygwin"``.
+:note:
+    ``is_win`` is ``False`` on Cygwin, but is often wrongly assumed ``True``. To detect
+    Cygwin, use ``sys.platform == "cygwin"``.
 """
 
 is_posix = os.name == "posix"
@@ -46,9 +47,10 @@ This is deprecated because it clearer to write out :attr:`os.name` or
 :attr:`sys.platform` checks explicitly, especially in cases where it matters which is
 used.
 
-:note: For POSIX systems, more detailed information is available in
-    :attr:`sys.platform`, while :attr:`os.name` is always ``"posix"`` on such systems,
-    including macOS (Darwin).
+:note:
+    For POSIX systems, more detailed information is available in :attr:`sys.platform`,
+    while :attr:`os.name` is always ``"posix"`` on such systems, including macOS
+    (Darwin).
 """
 
 is_darwin = sys.platform == "darwin"
@@ -57,7 +59,8 @@ is_darwin = sys.platform == "darwin"
 This is deprecated because it clearer to write out :attr:`os.name` or
 :attr:`sys.platform` checks explicitly.
 
-:note: For macOS (Darwin), ``os.name == "posix"`` as in other Unix-like systems, while
+:note:
+    For macOS (Darwin), ``os.name == "posix"`` as in other Unix-like systems, while
     ``sys.platform == "darwin"`.
 """
 

--- a/git/config.py
+++ b/git/config.py
@@ -411,7 +411,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         not be used anymore afterwards.
 
         In Python 3, it's required to explicitly release locks and flush changes, as
-        :meth:`__del__` is not called deterministically anymore.
+        ``__del__`` is not called deterministically anymore.
         """
         # Checking for the lock here makes sure we do not raise during write()
         # in case an invalid parser was created who could not get a lock.
@@ -539,7 +539,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """List all paths that must be included to configuration.
 
         :return:
-            The list of paths, where each path is a tuple of ``(option, value)``.
+            The list of paths, where each path is a tuple of (option, value).
         """
         paths = []
 
@@ -590,9 +590,6 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
         This will ignore files that cannot be read, possibly leaving an empty
         configuration.
-
-        :return:
-            Nothing
 
         :raise IOError:
             If a file cannot be handled.
@@ -765,7 +762,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     @property
     def read_only(self) -> bool:
-        """:return: True if this instance may change the configuration file"""
+        """:return: ``True`` if this instance may change the configuration file"""
         return self._read_only
 
     # FIXME: Figure out if default or return type can really include bool.
@@ -918,7 +915,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return self
 
     def rename_section(self, section: str, new_name: str) -> "GitConfigParser":
-        """Rename the given section to new_name.
+        """Rename the given section to `new_name`.
 
         :raise ValueError:
             If:

--- a/git/config.py
+++ b/git/config.py
@@ -920,8 +920,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :raise ValueError:
             If:
 
-            * ``section`` doesn't exist.
-            * A section with ``new_name`` does already exist.
+            * `section` doesn't exist.
+            * A section with `new_name` does already exist.
 
         :return:
             This instance

--- a/git/config.py
+++ b/git/config.py
@@ -73,11 +73,13 @@ See: https://git-scm.com/docs/git-config#_conditional_includes
 
 
 class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
-    """Utility class wrapping base-class methods into decorators that assure read-only properties."""
+    """Utility class wrapping base-class methods into decorators that assure read-only
+    properties."""
 
     def __new__(cls, name: str, bases: Tuple, clsdict: Dict[str, Any]) -> "MetaParserBuilder":
         """Equip all base-class methods with a needs_values decorator, and all non-const
-        methods with a set_dirty_and_flush_changes decorator in addition to that.
+        methods with a :func:`set_dirty_and_flush_changes` decorator in addition to
+        that.
         """
         kmm = "_mutating_methods_"
         if kmm in clsdict:
@@ -102,7 +104,8 @@ class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
 
 
 def needs_values(func: Callable[..., _T]) -> Callable[..., _T]:
-    """Return a method for ensuring we read values (on demand) before we try to access them."""
+    """Return a method for ensuring we read values (on demand) before we try to access
+    them."""
 
     @wraps(func)
     def assure_data_present(self: "GitConfigParser", *args: Any, **kwargs: Any) -> _T:
@@ -116,7 +119,8 @@ def needs_values(func: Callable[..., _T]) -> Callable[..., _T]:
 def set_dirty_and_flush_changes(non_const_func: Callable[..., _T]) -> Callable[..., _T]:
     """Return a method that checks whether given non constant function may be called.
 
-    If so, the instance will be set dirty. Additionally, we flush the changes right to disk.
+    If so, the instance will be set dirty. Additionally, we flush the changes right to
+    disk.
     """
 
     def flush_changes(self: "GitConfigParser", *args: Any, **kwargs: Any) -> _T:
@@ -136,7 +140,8 @@ class SectionConstraint(Generic[T_ConfigParser]):
 
     It supports all ConfigParser methods that operate on an option.
 
-    :note: If used as a context manager, will release the wrapped ConfigParser.
+    :note:
+        If used as a context manager, will release the wrapped ConfigParser.
     """
 
     __slots__ = ("_config", "_section_name")
@@ -171,8 +176,8 @@ class SectionConstraint(Generic[T_ConfigParser]):
         return super().__getattribute__(attr)
 
     def _call_config(self, method: str, *args: Any, **kwargs: Any) -> Any:
-        """Call the configuration at the given method which must take a section name
-        as first argument."""
+        """Call the configuration at the given method which must take a section name as
+        first argument."""
         return getattr(self._config, method)(self._section_name, *args, **kwargs)
 
     @property
@@ -254,7 +259,8 @@ def get_config_path(config_level: Lit_config_levels) -> str:
     elif config_level == "repository":
         raise ValueError("No repo to get repository configuration from. Use Repo._get_config_path")
     else:
-        # Should not reach here. Will raise ValueError if does. Static typing will warn missing elifs
+        # Should not reach here. Will raise ValueError if does. Static typing will warn
+        # about missing elifs.
         assert_never(  # type: ignore[unreachable]
             config_level,
             ValueError(f"Invalid configuration level: {config_level!r}"),
@@ -264,14 +270,15 @@ def get_config_path(config_level: Lit_config_levels) -> str:
 class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     """Implements specifics required to read git style configuration files.
 
-    This variation behaves much like the git.config command such that the configuration
-    will be read on demand based on the filepath given during initialization.
+    This variation behaves much like the ``git config`` command, such that the
+    configuration will be read on demand based on the filepath given during
+    initialization.
 
     The changes will automatically be written once the instance goes out of scope, but
     can be triggered manually as well.
 
-    The configuration file will be locked if you intend to change values preventing other
-    instances to write concurrently.
+    The configuration file will be locked if you intend to change values preventing
+    other instances to write concurrently.
 
     :note:
         The config is case-sensitive even when queried, hence section and option names
@@ -301,7 +308,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     del optvalueonly_source
 
     _mutating_methods_ = ("add_section", "remove_section", "remove_option", "set")
-    """List of RawConfigParser methods able to change the instance."""
+    """Names of :class:`~configparser.RawConfigParser` methods able to change the
+    instance."""
 
     def __init__(
         self,
@@ -311,8 +319,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         config_level: Union[Lit_config_levels, None] = None,
         repo: Union["Repo", None] = None,
     ) -> None:
-        """Initialize a configuration reader to read the given file_or_files and to
-        possibly allow changes to it by setting read_only False.
+        """Initialize a configuration reader to read the given `file_or_files` and to
+        possibly allow changes to it by setting `read_only` False.
 
         :param file_or_files:
             A file path or file object, or a sequence of possibly more than one of them.
@@ -385,7 +393,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         # END read-only check
 
     def __del__(self) -> None:
-        """Write pending changes if required and release locks"""
+        """Write pending changes if required and release locks."""
         # NOTE: Only consistent in Python 2.
         self.release()
 
@@ -397,10 +405,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         self.release()
 
     def release(self) -> None:
-        """Flush changes and release the configuration write lock. This instance must not be used anymore afterwards.
+        """Flush changes and release the configuration write lock. This instance must
+        not be used anymore afterwards.
 
-        In Python 3, it's required to explicitly release locks and flush changes, as __del__ is not called
-        deterministically anymore."""
+        In Python 3, it's required to explicitly release locks and flush changes, as
+        :meth:`__del__` is not called deterministically anymore.
+        """
         # Checking for the lock here makes sure we do not raise during write()
         # in case an invalid parser was created who could not get a lock.
         if self.read_only or (self._lock and not self._lock._has_lock()):
@@ -424,8 +434,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         return optionstr
 
     def _read(self, fp: Union[BufferedReader, IO[bytes]], fpname: str) -> None:
-        """Originally a direct copy of the Python 2.4 version of RawConfigParser._read,
-        to ensure it uses ordered dicts.
+        """Originally a direct copy of the Python 2.4 version of
+        :meth:`RawConfigParser._read <configparser.RawConfigParser._read>`, to ensure it
+        uses ordered dicts.
 
         The ordering bug was fixed in Python 2.4, and dict itself keeps ordering since
         Python 3.7. This has some other changes, especially that it ignores initial
@@ -525,7 +536,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     def _included_paths(self) -> List[Tuple[str, str]]:
         """List all paths that must be included to configuration.
 
-        :return: The list of paths, where each path is a tuple of ``(option, value)``.
+        :return:
+            The list of paths, where each path is a tuple of ``(option, value)``.
         """
         paths = []
 
@@ -577,8 +589,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         This will ignore files that cannot be read, possibly leaving an empty
         configuration.
 
-        :return: Nothing
-        :raise IOError: If a file cannot be handled
+        :return:
+            Nothing
+
+        :raise IOError:
+            If a file cannot be handled
         """
         if self._is_initialized:
             return
@@ -591,7 +606,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         elif not isinstance(self._file_or_files, (tuple, list, Sequence)):
             # Could merge with above isinstance once runtime type known.
             files_to_read = [self._file_or_files]
-        else:  # for lists or tuples
+        else:  # For lists or tuples.
             files_to_read = list(self._file_or_files)
         # END ensure we have a copy of the paths to handle
 
@@ -603,7 +618,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
             if hasattr(file_path, "seek"):
                 # Must be a file-object.
-                file_path = cast(IO[bytes], file_path)  # TODO: Replace with assert to narrow type, once sure.
+                # TODO: Replace cast with assert to narrow type, once sure.
+                file_path = cast(IO[bytes], file_path)
                 self._read(file_path, file_path.name)
             else:
                 # Assume a path if it is not a file-object.
@@ -615,8 +631,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 except IOError:
                     continue
 
-            # Read includes and append those that we didn't handle yet.
-            # We expect all paths to be normalized and absolute (and will ensure that is the case).
+            # Read includes and append those that we didn't handle yet. We expect all
+            # paths to be normalized and absolute (and will ensure that is the case).
             if self._has_includes():
                 for _, include_path in self._included_paths():
                     if include_path.startswith("~"):
@@ -695,8 +711,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     def write(self) -> None:
         """Write changes to our file, if there are changes at all.
 
-        :raise IOError: If this is a read-only writer instance or if we could not obtain
-            a file lock"""
+        :raise IOError:
+            If this is a read-only writer instance or if we could not obtain a file lock
+        """
         self._assure_writable("write")
         if not self._dirty:
             return
@@ -740,7 +757,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             raise IOError("Cannot execute non-constant method %s.%s" % (self, method_name))
 
     def add_section(self, section: str) -> None:
-        """Assures added options will stay in order"""
+        """Assures added options will stay in order."""
         return super().add_section(section)
 
     @property
@@ -757,16 +774,18 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     ) -> Union[int, float, str, bool]:
         """Get an option's value.
 
-        If multiple values are specified for this option in the section, the
-        last one specified is returned.
+        If multiple values are specified for this option in the section, the last one
+        specified is returned.
 
         :param default:
-            If not None, the given default value will be returned in case
-            the option did not exist
+            If not None, the given default value will be returned in case the option did
+            not exist
 
-        :return: a properly typed value, either int, float or string
+        :return:
+            A properly typed value, either int, float or string
 
-        :raise TypeError: in case the value could not be understood
+        :raise TypeError:
+            In case the value could not be understood.
             Otherwise the exceptions known to the ConfigParser will be raised.
         """
         try:
@@ -790,12 +809,14 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         returned.
 
         :param default:
-            If not None, a list containing the given default value will be
-            returned in case the option did not exist
+            If not None, a list containing the given default value will be returned in
+            case the option did not exist.
 
-        :return: a list of properly typed values, either int, float or string
+        :return:
+            A list of properly typed values, either int, float or string
 
-        :raise TypeError: in case the value could not be understood
+        :raise TypeError:
+            In case the value could not be understood.
             Otherwise the exceptions known to the ConfigParser will be raised.
         """
         try:
@@ -849,11 +870,17 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         This will create the section if required, and will not throw as opposed to the
         default ConfigParser 'set' method.
 
-        :param section: Name of the section in which the option resides or should reside
-        :param option: Name of the options whose value to set
-        :param value: Value to set the option to. It must be a string or convertible to
-            a string.
-        :return: This instance
+        :param section:
+            Name of the section in which the option resides or should reside.
+
+        :param option:
+            Name of the options whose value to set.
+
+        :param value:
+            Value to set the option to. It must be a string or convertible to a string.
+
+        :return:
+            This instance
         """
         if not self.has_section(section):
             self.add_section(section)
@@ -865,15 +892,22 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     def add_value(self, section: str, option: str, value: Union[str, bytes, int, float, bool]) -> "GitConfigParser":
         """Add a value for the given option in section.
 
-        This will create the section if required, and will not throw as opposed to the default
-        ConfigParser 'set' method. The value becomes the new value of the option as returned
-        by 'get_value', and appends to the list of values returned by 'get_values`'.
+        This will create the section if required, and will not throw as opposed to the
+        default ConfigParser 'set' method. The value becomes the new value of the option
+        as returned by 'get_value', and appends to the list of values returned by
+        'get_values'.
 
-        :param section: Name of the section in which the option resides or should reside
-        :param option: Name of the option
-        :param value: Value to add to option. It must be a string or convertible
-            to a string
-        :return: This instance
+        :param section:
+            Name of the section in which the option resides or should reside.
+
+        :param option:
+            Name of the option.
+
+        :param value:
+            Value to add to option. It must be a string or convertible to a string.
+
+        :return:
+            This instance
         """
         if not self.has_section(section):
             self.add_section(section)
@@ -883,8 +917,12 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     def rename_section(self, section: str, new_name: str) -> "GitConfigParser":
         """Rename the given section to new_name.
 
-        :raise ValueError: If ``section`` doesn't exist
-        :raise ValueError: If a section with ``new_name`` does already exist
+        :raise ValueError:
+            If:
+
+            * ``section`` doesn't exist.
+            * A section with ``new_name`` does already exist.
+
         :return: This instance
         """
         if not self.has_section(section):
@@ -898,6 +936,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             new_section.setall(k, vs)
         # END for each value to copy
 
-        # This call writes back the changes, which is why we don't have the respective decorator.
+        # This call writes back the changes, which is why we don't have the respective
+        # decorator.
         self.remove_section(section)
         return self

--- a/git/config.py
+++ b/git/config.py
@@ -186,8 +186,8 @@ class SectionConstraint(Generic[T_ConfigParser]):
         return self._config
 
     def release(self) -> None:
-        """Equivalent to GitConfigParser.release(), which is called on our underlying
-        parser instance."""
+        """Equivalent to :meth:`GitConfigParser.release`, which is called on our
+        underlying parser instance."""
         return self._config.release()
 
     def __enter__(self) -> "SectionConstraint[T_ConfigParser]":
@@ -292,7 +292,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     t_lock = LockFile
     """The lock type determines the type of lock to use in new configuration readers.
 
-    They must be compatible to the LockFile interface.
+    They must be compatible to the :class:`~git.util.LockFile` interface.
     A suitable alternative would be the :class:`~git.util.BlockingLockFile`.
     """
 
@@ -326,14 +326,15 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             A file path or file object, or a sequence of possibly more than one of them.
 
         :param read_only:
-            If True, the ConfigParser may only read the data, but not change it.
-            If False, only a single file path or file object may be given. We will write
-            back the changes when they happen, or when the ConfigParser is released.
-            This will not happen if other configuration files have been included.
+            If ``True``, the ConfigParser may only read the data, but not change it.
+            If ``False``, only a single file path or file object may be given. We will
+            write back the changes when they happen, or when the ConfigParser is
+            released. This will not happen if other configuration files have been
+            included.
 
         :param merge_includes:
-            If True, we will read files mentioned in ``[include]`` sections and merge
-            their contents into ours. This makes it impossible to write back an
+            If ``True``, we will read files mentioned in ``[include]`` sections and
+            merge their contents into ours. This makes it impossible to write back an
             individual configuration file. Thus, if you want to modify a single
             configuration file, turn this off to leave the original dataset unaltered
             when reading it.
@@ -347,7 +348,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         self._defaults: _OMD
         self._sections: _OMD  # type: ignore  # mypy/typeshed bug?
 
-        # Used in Python 3. Needs to stay in sync with sections for underlying implementation to work.
+        # Used in Python 3. Needs to stay in sync with sections for underlying
+        # implementation to work.
         if not hasattr(self, "_proxies"):
             self._proxies = self._dict()
 
@@ -593,7 +595,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             Nothing
 
         :raise IOError:
-            If a file cannot be handled
+            If a file cannot be handled.
         """
         if self._is_initialized:
             return
@@ -712,7 +714,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """Write changes to our file, if there are changes at all.
 
         :raise IOError:
-            If this is a read-only writer instance or if we could not obtain a file lock
+            If this is a read-only writer instance or if we could not obtain a file
+            lock.
         """
         self._assure_writable("write")
         if not self._dirty:
@@ -778,8 +781,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         specified is returned.
 
         :param default:
-            If not None, the given default value will be returned in case the option did
-            not exist
+            If not ``None``, the given default value will be returned in case the option
+            did not exist.
 
         :return:
             A properly typed value, either int, float or string
@@ -809,8 +812,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         returned.
 
         :param default:
-            If not None, a list containing the given default value will be returned in
-            case the option did not exist.
+            If not ``None``, a list containing the given default value will be returned
+            in case the option did not exist.
 
         :return:
             A list of properly typed values, either int, float or string
@@ -868,7 +871,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """Set the given option in section to the given value.
 
         This will create the section if required, and will not throw as opposed to the
-        default ConfigParser 'set' method.
+        default ConfigParser ``set`` method.
 
         :param section:
             Name of the section in which the option resides or should reside.
@@ -893,9 +896,9 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """Add a value for the given option in section.
 
         This will create the section if required, and will not throw as opposed to the
-        default ConfigParser 'set' method. The value becomes the new value of the option
-        as returned by 'get_value', and appends to the list of values returned by
-        'get_values'.
+        default ConfigParser ``set`` method. The value becomes the new value of the
+        option as returned by :meth:`get_value`, and appends to the list of values
+        returned by :meth:`get_values`.
 
         :param section:
             Name of the section in which the option resides or should reside.
@@ -923,7 +926,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             * ``section`` doesn't exist.
             * A section with ``new_name`` does already exist.
 
-        :return: This instance
+        :return:
+            This instance
         """
         if not self.has_section(section):
             raise ValueError("Source section '%s' doesn't exist" % section)

--- a/git/db.py
+++ b/git/db.py
@@ -54,7 +54,8 @@ class GitCmdObjectDB(LooseObjectDB):
 
     def partial_to_complete_sha_hex(self, partial_hexsha: str) -> bytes:
         """
-        :return: Full binary 20 byte sha from the given partial hexsha
+        :return:
+            Full binary 20 byte sha from the given partial hexsha
 
         :raise gitdb.exc.AmbiguousObjectName:
 

--- a/git/db.py
+++ b/git/db.py
@@ -31,8 +31,9 @@ class GitCmdObjectDB(LooseObjectDB):
 
     It will create objects only in the loose object database.
 
-    :note: For now, we use the git command to do all the lookup, just until we
-        have packs and the other implementations.
+    :note:
+        For now, we use the git command to do all the lookup, just until we have packs
+        and the other implementations.
     """
 
     def __init__(self, root_path: PathLike, git: "Git") -> None:
@@ -56,9 +57,11 @@ class GitCmdObjectDB(LooseObjectDB):
         :return: Full binary 20 byte sha from the given partial hexsha
 
         :raise AmbiguousObjectName:
+
         :raise BadObject:
 
-        :note: Currently we only raise :class:`BadObject` as git does not communicate
+        :note:
+            Currently we only raise :class:`BadObject` as git does not communicate
             ambiguous objects separately.
         """
         try:

--- a/git/db.py
+++ b/git/db.py
@@ -56,13 +56,13 @@ class GitCmdObjectDB(LooseObjectDB):
         """
         :return: Full binary 20 byte sha from the given partial hexsha
 
-        :raise AmbiguousObjectName:
+        :raise gitdb.exc.AmbiguousObjectName:
 
-        :raise BadObject:
+        :raise gitdb.exc.BadObject:
 
         :note:
-            Currently we only raise :class:`BadObject` as git does not communicate
-            ambiguous objects separately.
+            Currently we only raise :class:`~gitdb.exc.BadObject` as git does not
+            communicate ambiguous objects separately.
         """
         try:
             hexsha, _typename, _size = self._git.get_object_header(partial_hexsha)

--- a/git/db.py
+++ b/git/db.py
@@ -59,7 +59,7 @@ class GitCmdObjectDB(LooseObjectDB):
         :raise BadObject:
 
         :note: Currently we only raise :class:`BadObject` as git does not communicate
-            AmbiguousObjects separately.
+            ambiguous objects separately.
         """
         try:
             hexsha, _typename, _size = self._git.get_object_header(partial_hexsha)

--- a/git/db.py
+++ b/git/db.py
@@ -30,10 +30,6 @@ class GitCmdObjectDB(LooseObjectDB):
     objects, pack files and an alternates file.
 
     It will create objects only in the loose object database.
-
-    :note:
-        For now, we use the git command to do all the lookup, just until we have packs
-        and the other implementations.
     """
 
     def __init__(self, root_path: PathLike, git: "Git") -> None:

--- a/git/diff.py
+++ b/git/diff.py
@@ -118,7 +118,7 @@ class Diffable:
         :param other:
             This the item to compare us with.
 
-            * If None, we will be compared to the working tree.
+            * If ``None``, we will be compared to the working tree.
             * If :class:`~git.index.base.Treeish`, it will be compared against the
               respective tree.
             * If :class:`~Diffable.Index`, it will be compared against the index.
@@ -131,7 +131,7 @@ class Diffable:
             include at least one of the given path or paths.
 
         :param create_patch:
-            If True, the returned :class:`Diff` contains a detailed patch that if
+            If ``True``, the returned :class:`Diff` contains a detailed patch that if
             applied makes the self to other. Patches are somewhat costly as blobs have
             to be read and diffed.
 
@@ -139,7 +139,8 @@ class Diffable:
             Additional arguments passed to ``git diff``, such as ``R=True`` to swap both
             sides of the diff.
 
-        :return: git.DiffIndex
+        :return:
+            :class:`DiffIndex`
 
         :note:
             On a bare repository, `other` needs to be provided as
@@ -262,7 +263,7 @@ class Diff:
     Diffs keep information about the changed blob objects, the file mode, renames,
     deletions and new files.
 
-    There are a few cases where None has to be expected as member variable value:
+    There are a few cases where ``None`` has to be expected as member variable value:
 
     New File::
 
@@ -468,7 +469,8 @@ class Diff:
     @property
     def renamed(self) -> bool:
         """
-        :return: True if the blob of our diff has been renamed
+        :return:
+            ``True`` if the blob of our diff has been renamed
 
         :note:
             This property is deprecated.
@@ -499,11 +501,12 @@ class Diff:
         """Create a new :class:`DiffIndex` from the given process output which must be
         in patch format.
 
-        :param repo: The repository we are operating on.
+        :param repo:
+            The repository we are operating on.
 
         :param proc:
             ``git diff`` process to read from
-            (supports :class:`Git.AutoInterrupt` wrapper).
+            (supports :class:`Git.AutoInterrupt <git.cmd.Git.AutoInterrupt>` wrapper).
 
         :return:
             :class:`DiffIndex`

--- a/git/diff.py
+++ b/git/diff.py
@@ -84,8 +84,9 @@ class Diffable:
     compatible type.
 
     :note:
-        Subclasses require a repo member as it is the case for Object instances, for
-        practical reasons we do not derive from Object.
+        Subclasses require a repo member as it is the case for
+        :class:`~git.objects.base.Object` instances, for practical reasons we do not
+        derive from :class:`~git.objects.base.Object`.
     """
 
     __slots__ = ()
@@ -135,13 +136,13 @@ class Diffable:
             to be read and diffed.
 
         :param kwargs:
-            Additional arguments passed to git-diff, such as ``R=True`` to swap both
+            Additional arguments passed to ``git diff``, such as ``R=True`` to swap both
             sides of the diff.
 
         :return: git.DiffIndex
 
         :note:
-            On a bare repository, 'other' needs to be provided as
+            On a bare repository, `other` needs to be provided as
             :class:`~Diffable.Index`, or as :class:`~git.objects.tree.Tree` or
             :class:`~git.objects.commit.Commit`, or a git command error will occur.
         """
@@ -183,7 +184,7 @@ class Diffable:
 
         args.insert(0, self)
 
-        # paths is list here, or None.
+        # paths is a list here, or None.
         if paths:
             args.append("--")
             args.extend(paths)
@@ -203,7 +204,7 @@ T_Diff = TypeVar("T_Diff", bound="Diff")
 
 
 class DiffIndex(List[T_Diff]):
-    """An Index for diffs, allowing a list of Diffs to be queried by the diff
+    R"""An Index for diffs, allowing a list of :class:`Diff`\s to be queried by the diff
     properties.
 
     The class improves the diff handling convenience.
@@ -255,27 +256,27 @@ class DiffIndex(List[T_Diff]):
 class Diff:
     """A Diff contains diff information between two Trees.
 
-    It contains two sides a and b of the diff, members are prefixed with
-    "a" and "b" respectively to indicate that.
+    It contains two sides a and b of the diff. Members are prefixed with "a" and "b"
+    respectively to indicate that.
 
     Diffs keep information about the changed blob objects, the file mode, renames,
     deletions and new files.
 
     There are a few cases where None has to be expected as member variable value:
 
-    ``New File``::
+    New File::
 
         a_mode is None
         a_blob is None
         a_path is None
 
-    ``Deleted File``::
+    Deleted File::
 
         b_mode is None
         b_blob is None
         b_path is None
 
-    ``Working Tree Blobs``
+    Working Tree Blobs:
 
         When comparing to working trees, the working tree blob will have a null hexsha
         as a corresponding object does not yet exist. The mode will be null as well.
@@ -469,7 +470,8 @@ class Diff:
         """
         :return: True if the blob of our diff has been renamed
 
-        :note: This property is deprecated.
+        :note:
+            This property is deprecated.
             Please use the :attr:`renamed_file` property instead.
         """
         return self.renamed_file
@@ -494,11 +496,17 @@ class Diff:
 
     @classmethod
     def _index_from_patch_format(cls, repo: "Repo", proc: Union["Popen", "Git.AutoInterrupt"]) -> DiffIndex:
-        """Create a new DiffIndex from the given process output which must be in patch format.
+        """Create a new :class:`DiffIndex` from the given process output which must be
+        in patch format.
 
-        :param repo: The repository we are operating on
-        :param proc: ``git diff`` process to read from (supports :class:`Git.AutoInterrupt` wrapper)
-        :return: git.DiffIndex
+        :param repo: The repository we are operating on.
+
+        :param proc:
+            ``git diff`` process to read from
+            (supports :class:`Git.AutoInterrupt` wrapper).
+
+        :return:
+            :class:`DiffIndex`
         """
 
         # FIXME: Here SLURPING raw, need to re-phrase header-regexes linewise.
@@ -539,14 +547,14 @@ class Diff:
             a_path = cls._pick_best_path(a_path, rename_from, a_path_fallback)
             b_path = cls._pick_best_path(b_path, rename_to, b_path_fallback)
 
-            # Our only means to find the actual text is to see what has not been matched by our regex,
-            # and then retro-actively assign it to our index.
+            # Our only means to find the actual text is to see what has not been matched
+            # by our regex, and then retro-actively assign it to our index.
             if previous_header is not None:
                 index[-1].diff = text[previous_header.end() : _header.start()]
             # END assign actual diff
 
-            # Make sure the mode is set if the path is set. Otherwise the resulting blob is invalid.
-            # We just use the one mode we should have parsed.
+            # Make sure the mode is set if the path is set. Otherwise the resulting blob
+            # is invalid. We just use the one mode we should have parsed.
             a_mode = old_mode or deleted_file_mode or (a_path and (b_mode or new_mode or new_file_mode))
             b_mode = b_mode or new_mode or new_file_mode or (b_path and a_mode)
             index.append(
@@ -610,7 +618,7 @@ class Diff:
             rename_from = None
             rename_to = None
 
-            # NOTE: We cannot conclude from the existence of a blob to change type
+            # NOTE: We cannot conclude from the existence of a blob to change type,
             # as diffs with the working do not have blobs yet.
             if change_type == "D":
                 b_blob_id = None  # Optional[str]
@@ -654,11 +662,17 @@ class Diff:
 
     @classmethod
     def _index_from_raw_format(cls, repo: "Repo", proc: "Popen") -> "DiffIndex":
-        """Create a new DiffIndex from the given process output which must be in raw format.
+        """Create a new :class:`DiffIndex` from the given process output which must be
+        in raw format.
 
-        :param repo: The repository we are operating on
-        :param proc: Process to read output from
-        :return: git.DiffIndex
+        :param repo:
+            The repository we are operating on.
+
+        :param proc:
+            Process to read output from.
+
+        :return:
+            :class:`DiffIndex`
         """
         # handles
         # :100644 100644 687099101... 37c5e30c8... M    .gitignore

--- a/git/diff.py
+++ b/git/diff.py
@@ -121,9 +121,9 @@ class Diffable:
             * If ``None``, we will be compared to the working tree.
             * If :class:`~git.index.base.Treeish`, it will be compared against the
               respective tree.
-            * If :class:`~Diffable.Index`, it will be compared against the index.
+            * If :class:`Diffable.Index`, it will be compared against the index.
             * If :attr:`git.NULL_TREE`, it will compare against the empty tree.
-            * It defaults to :class:`~Diffable.Index` so that the method will not by
+            * It defaults to :class:`Diffable.Index` so that the method will not by
               default fail on bare repositories.
 
         :param paths:
@@ -280,11 +280,11 @@ class Diff:
     Working Tree Blobs:
 
         When comparing to working trees, the working tree blob will have a null hexsha
-        as a corresponding object does not yet exist. The mode will be null as well.
-        The path will be available, though.
+        as a corresponding object does not yet exist. The mode will be null as well. The
+        path will be available, though.
 
-        If it is listed in a diff, the working tree version of the file must
-        differ from the version in the index or tree, and hence has been modified.
+        If it is listed in a diff, the working tree version of the file must differ from
+        the version in the index or tree, and hence has been modified.
     """
 
     # Precompiled regex.
@@ -468,7 +468,8 @@ class Diff:
 
     @property
     def renamed(self) -> bool:
-        """
+        """Deprecated, use :attr:`renamed_file` instead.
+
         :return:
             ``True`` if the blob of our diff has been renamed
 
@@ -480,7 +481,7 @@ class Diff:
 
     @property
     def renamed_file(self) -> bool:
-        """:return: True if the blob of our diff has been renamed"""
+        """:return: ``True`` if the blob of our diff has been renamed"""
         return self.rename_from != self.rename_to
 
     @classmethod

--- a/git/diff.py
+++ b/git/diff.py
@@ -112,8 +112,8 @@ class Diffable:
         create_patch: bool = False,
         **kwargs: Any,
     ) -> "DiffIndex":
-        """Create diffs between two items being trees, trees and index or an
-        index and the working tree. Detects renames automatically.
+        """Create diffs between two items being trees, trees and index or an index and
+        the working tree. Detects renames automatically.
 
         :param other:
             This the item to compare us with.

--- a/git/exc.py
+++ b/git/exc.py
@@ -87,10 +87,13 @@ class CommandError(GitError):
         A non-empty list of argv comprising the command-line.
     """
 
-    #: A unicode print-format with 2 `%s for `<cmdline>` and the rest,
-    #:  e.g.
-    #:     "'%s' failed%s"
     _msg = "Cmd('%s') failed%s"
+    """Format string with 2 ``%s`` for ``<cmdline>`` and the rest.
+
+    For example: ``"'%s' failed%s"``
+
+    Subclasses may override this attribute, provided it is still in this form.
+    """
 
     def __init__(
         self,

--- a/git/exc.py
+++ b/git/exc.py
@@ -81,7 +81,8 @@ class UnsafeOptionError(GitError):
 
 
 class CommandError(GitError):
-    """Base class for exceptions thrown at every stage of `Popen()` execution.
+    """Base class for exceptions thrown at every stage of :class:`~subprocess.Popen`
+    execution.
 
     :param command:
         A non-empty list of argv comprising the command-line.
@@ -135,8 +136,8 @@ class CommandError(GitError):
 
 
 class GitCommandNotFound(CommandError):
-    """Thrown if we cannot find the `git` executable in the PATH or at the path given by
-    the GIT_PYTHON_GIT_EXECUTABLE environment variable."""
+    """Thrown if we cannot find the `git` executable in the ``PATH`` or at the path
+    given by the ``GIT_PYTHON_GIT_EXECUTABLE`` environment variable."""
 
     def __init__(self, command: Union[List[str], Tuple[str], str], cause: Union[str, Exception]) -> None:
         super().__init__(command, cause)
@@ -187,7 +188,7 @@ class CheckoutError(GitError):
 
 
 class CacheError(GitError):
-    """Base for all errors related to the git index, which is called cache
+    """Base for all errors related to the git index, which is called "cache"
     internally."""
 
 

--- a/git/exc.py
+++ b/git/exc.py
@@ -136,8 +136,8 @@ class CommandError(GitError):
 
 
 class GitCommandNotFound(CommandError):
-    """Thrown if we cannot find the `git` executable in the ``PATH`` or at the path
-    given by the ``GIT_PYTHON_GIT_EXECUTABLE`` environment variable."""
+    """Thrown if we cannot find the ``git`` executable in the :envvar:`PATH` or at the
+    path given by the :envvar:`GIT_PYTHON_GIT_EXECUTABLE` environment variable."""
 
     def __init__(self, command: Union[List[str], Tuple[str], str], cause: Union[str, Exception]) -> None:
         super().__init__(command, cause)

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -3,8 +3,8 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-"""Module containing IndexFile, an Index implementation facilitating all kinds of index
-manipulations such as querying and merging."""
+"""Module containing :class:`IndexFile`, an Index implementation facilitating all kinds
+of index manipulations such as querying and merging."""
 
 import contextlib
 import datetime
@@ -125,9 +125,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     git command function calls wherever possible.
 
     This provides custom merging facilities allowing to merge without actually changing
-    your index or your working tree. This way you can perform own test-merges based on
-    the index only without having to deal with the working copy. This is useful in case
-    of partial working trees.
+    your index or your working tree. This way you can perform your own test merges based
+    on the index only without having to deal with the working copy. This is useful in
+    case of partial working trees.
 
     Entries:
 
@@ -211,7 +211,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return self
 
     def _entries_sorted(self) -> List[IndexEntry]:
-        """:return: list of entries, in a sorted fashion, first by path, then by stage"""
+        """:return: List of entries, in a sorted fashion, first by path, then by stage"""
         return sorted(self.entries.values(), key=lambda e: (e.path, e.stage))
 
     def _serialize(self, stream: IO, ignore_extension_data: bool = False) -> "IndexFile":
@@ -232,17 +232,17 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Write the current state to our file path or to the given one.
 
         :param file_path:
-            If None, we will write to our stored file path from which we have been
+            If ``None``, we will write to our stored file path from which we have been
             initialized. Otherwise we write to the given file path. Please note that
-            this will change the file_path of this index to the one you gave.
+            this will change the `file_path` of this index to the one you gave.
 
         :param ignore_extension_data:
-            If True, the TREE type extension data read in the index will not be written
-            to disk. NOTE that no extension data is actually written.
-            Use this if you have altered the index and would like to use git-write-tree
-            afterwards to create a tree representing your written changes.
-            If this data is present in the written index, git-write-tree will instead
-            write the stored/cached tree.
+            If ``True``, the TREE type extension data read in the index will not be
+            written to disk. NOTE that no extension data is actually written.
+            Use this if you have altered the index and would like to use
+            ``git write-tree`` afterwards to create a tree representing your written
+            changes. If this data is present in the written index, ``git write-tree``
+            will instead write the stored/cached tree.
             Alternatively, use :meth:`write_tree` to handle this case automatically.
         """
         # Make sure we have our entries read before getting a write lock.
@@ -479,8 +479,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             stdout string
 
         :param read_from_stdout:
-            If True, proc.stdout will be read after the item was sent to stdin. In that
-            case, it will return None.
+            If ``True``, ``proc.stdout`` will be read after the item was sent to stdin.
+            In that case, it will return ``None``.
 
         :note:
             There is a bug in git-update-index that prevents it from sending reports
@@ -516,12 +516,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     ) -> Iterator[Tuple[StageType, Blob]]:
         """
         :return:
-            Iterator yielding tuples of Blob objects and stages, tuple(stage, Blob).
+            Iterator yielding tuples of :class:`~git.objects.blob.Blob` objects and
+            stages, tuple(stage, Blob).
 
         :param predicate:
-            Function(t) returning True if tuple(stage, Blob) should be yielded by the
-            iterator. A default filter, the `~git.index.typ.BlobFilter`, allows you to
-            yield blobs only if they match a given list of paths.
+            Function(t) returning ``True`` if tuple(stage, Blob) should be yielded by
+            the iterator. A default filter, the `~git.index.typ.BlobFilter`, allows you
+            to yield blobs only if they match a given list of paths.
         """
         for entry in self.entries.values():
             blob = entry.to_blob(self.repo)
@@ -534,8 +535,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     def unmerged_blobs(self) -> Dict[PathLike, List[Tuple[StageType, Blob]]]:
         """
         :return:
-            Dict(path : list( tuple( stage, Blob, ...))), being a dictionary associating
-            a path in the index with a list containing sorted stage/blob pairs.
+            Dict(path : list(tuple(stage, Blob, ...))), being a dictionary associating a
+            path in the index with a list containing sorted stage/blob pairs.
 
         :note:
             Blobs that have been removed in one side simply do not exist in the given
@@ -562,8 +563,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         This will effectively remove the index entries of the respective path at all
         non-null stages and add the given blob as new stage null blob.
 
-        For each path there may only be one blob, otherwise a ValueError will be raised
-        claiming the path is already at stage 0.
+        For each path there may only be one blob, otherwise a :class:`ValueError` will
+        be raised claiming the path is already at stage 0.
 
         :raise ValueError:
             If one of the blobs already existed at stage 0.
@@ -603,7 +604,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             This is a possibly dangerous operations as it will discard your changes to
             :attr:`index.entries <entries>`.
 
-        :return: self
+        :return:
+            self
         """
         self._delete_entries_cache()
         # Allows to lazily reread on demand.
@@ -654,8 +656,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
     def _to_relative_path(self, path: PathLike) -> PathLike:
         """
-        :return: Version of path relative to our git directory or raise
-            :class:`ValueError` if it is not within our git directory.
+        :return:
+            Version of path relative to our git directory or raise :class:`ValueError`
+            if it is not within our git directory.
 
         :raise ValueError:
         """
@@ -693,7 +696,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Store file at filepath in the database and return the base index entry.
 
         :note:
-            This needs the git_working_dir decorator active!
+            This needs the :func:`~git.index.util.git_working_dir` decorator active!
             This must be ensured in the calling code.
         """
         st = os.lstat(filepath)  # Handles non-symlinks as well.
@@ -810,24 +813,25 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 The handling now very much equals the way string paths are processed,
                 except that the mode you have set will be kept. This allows you to
                 create symlinks by settings the mode respectively and writing the target
-                of the symlink directly into the file. This equals a default
-                Linux symlink which is not dereferenced automatically, except that it
-                can be created on filesystems not supporting it as well.
+                of the symlink directly into the file. This equals a default Linux
+                symlink which is not dereferenced automatically, except that it can be
+                created on filesystems not supporting it as well.
 
                 Please note that globs or directories are not allowed in
-                :class:~`git.objects.blob.Blob` objects.
+                :class:`~git.objects.blob.Blob` objects.
 
                 They are added at stage 0.
 
             - :class:`~git.index.typ.BaseIndexEntry` or type
 
-                Handling equals the one of Blob objects, but the stage may be explicitly
-                set. Please note that Index Entries require binary sha's.
+                Handling equals the one of :class:~`git.objects.blob.Blob` objects, but
+                the stage may be explicitly set. Please note that Index Entries require
+                binary sha's.
 
         :param force:
             **CURRENTLY INEFFECTIVE**
-            If True, otherwise ignored or excluded files will be added anyway.
-            As opposed to the ``git add`` command, we enable this flag by default as the
+            If ``True``, otherwise ignored or excluded files will be added anyway. As
+            opposed to the ``git add`` command, we enable this flag by default as the
             API user usually wants the item to be added even though they might be
             excluded.
 
@@ -835,8 +839,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             Function with signature ``f(path, done=False, item=item)`` called for each
             path to be added, one time once it is about to be added where ``done=False``
             and once after it was added where ``done=True``.
-            ``item`` is set to the actual item we handle, either a Path or a
+
+            ``item`` is set to the actual item we handle, either a path or a
             :class:`~git.index.typ.BaseIndexEntry`.
+
             Please note that the processed path is not guaranteed to be present in the
             index already as the index is currently being processed.
 
@@ -845,24 +851,24 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             for each passed entry which is the path to be actually recorded for the
             object created from :attr:`entry.path <git.index.typ.BaseIndexEntry.path>`.
             This allows you to write an index which is not identical to the layout of
-            the actual files on your hard-disk. If not None and `items` contain plain
-            paths, these paths will be converted to Entries beforehand and passed to the
-            path_rewriter. Please note that ``entry.path`` is relative to the git
+            the actual files on your hard-disk. If not ``None`` and `items` contain
+            plain paths, these paths will be converted to Entries beforehand and passed
+            to the path_rewriter. Please note that ``entry.path`` is relative to the git
             repository.
 
         :param write:
-            If True, the index will be written once it was altered. Otherwise the
+            If ``True``, the index will be written once it was altered. Otherwise the
             changes only exist in memory and are not available to git commands.
 
         :param write_extension_data:
-            If True, extension data will be written back to the index. This can lead to
-            issues in case it is containing the 'TREE' extension, which will cause the
-            ``git commit`` command to write an old tree, instead of a new one
+            If ``True``, extension data will be written back to the index. This can lead
+            to issues in case it is containing the 'TREE' extension, which will cause
+            the ``git commit`` command to write an old tree, instead of a new one
             representing the now changed index.
 
             This doesn't matter if you use :meth:`IndexFile.commit`, which ignores the
-            'TREE' extension altogether. You should set it to True if you intend to use
-            :meth:`IndexFile.commit` exclusively while maintaining support for
+            'TREE' extension altogether. You should set it to ``True`` if you intend to
+            use :meth:`IndexFile.commit` exclusively while maintaining support for
             third-party extensions. Besides that, you can usually safely ignore the
             built-in extensions when using GitPython on repositories that are not
             handled manually at all.
@@ -875,7 +881,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             just actually added.
 
         :raise OSError:
-            If a supplied Path did not exist. Please note that
+            If a supplied path did not exist. Please note that
             :class:`~git.index.typ.BaseIndexEntry` objects that do not have a null sha
             will be added even if their paths do not exist.
         """
@@ -999,7 +1005,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 it. If absolute paths are given, they will be converted to a path
                 relative to the git repository directory containing the working tree
 
-                The path string may include globs, such as \*.c.
+                The path string may include globs, such as ``*.c``.
 
             - :class:~`git.objects.blob.Blob` object
 
@@ -1010,9 +1016,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 The only relevant information here is the path. The stage is ignored.
 
         :param working_tree:
-            If True, the entry will also be removed from the working tree, physically
-            removing the respective file. This may fail if there are uncommitted changes
-            in it.
+            If ``True``, the entry will also be removed from the working tree,
+            physically removing the respective file. This may fail if there are
+            uncommitted changes in it.
 
         :param kwargs:
             Additional keyword arguments to be passed to ``git rm``, such as ``r`` to
@@ -1061,7 +1067,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             for reference.
 
         :param skip_errors:
-            If True, errors such as ones resulting from missing source files will be
+            If ``True``, errors such as ones resulting from missing source files will be
             skipped.
 
         :param kwargs:
@@ -1214,21 +1220,21 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             case you have altered the entries dictionary directly.
 
         :param paths:
-            If None, all paths in the index will be checked out. Otherwise an iterable
-            of relative or absolute paths or a single path pointing to files or
-            directories in the index is expected.
+            If ``None``, all paths in the index will be checked out.
+            Otherwise an iterable of relative or absolute paths or a single path
+            pointing to files or directories in the index is expected.
 
         :param force:
-            If True, existing files will be overwritten even if they contain local
+            If ``True``, existing files will be overwritten even if they contain local
             modifications.
-            If False, these will trigger a :class:`~git.exc.CheckoutError`.
+            If ``False``, these will trigger a :class:`~git.exc.CheckoutError`.
 
         :param fprogress:
             See :meth:`IndexFile.add` for signature and explanation.
 
-            The provided progress information will contain None as path and item if no
-            explicit paths are given. Otherwise progress information will be send prior
-            and after a file has been checked out.
+            The provided progress information will contain ``None`` as path and item if
+            no explicit paths are given. Otherwise progress information will be send
+            prior and after a file has been checked out.
 
         :param kwargs:
             Additional arguments to be passed to ``git checkout-index``.
@@ -1238,10 +1244,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             guaranteed to match the version stored in the index.
 
         :raise git.exc.CheckoutError:
-            If at least one file failed to be checked out. This is a summary, hence it
-            will checkout as many files as it can anyway.
-            If one of files or directories do not exist in the index (as opposed to the
-            original git command, which ignores them).
+            * If at least one file failed to be checked out. This is a summary, hence it
+              will checkout as many files as it can anyway.
+            * If one of files or directories do not exist in the index (as opposed to
+              the original git command, which ignores them).
 
         :raise git.exc.GitCommandError:
             If error lines could not be parsed - this truly is an exceptional state.
@@ -1394,7 +1400,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         **kwargs: Any,
     ) -> "IndexFile":
         """Reset the index to reflect the tree at the given commit. This will not adjust
-        our ``HEAD`` reference by default, as opposed to
+        our HEAD reference by default, as opposed to
         :meth:`HEAD.reset <git.refs.head.HEAD.reset>`.
 
         :param commit:
@@ -1406,14 +1412,14 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             overwrite the default index.
 
         :param working_tree:
-            If True, the files in the working tree will reflect the changed index.
-            If False, the working tree will not be touched.
+            If ``True``, the files in the working tree will reflect the changed index.
+            If ``False``, the working tree will not be touched.
             Please note that changes to the working copy will be discarded without
             warning!
 
         :param head:
-            If True, the head will be set to the given commit. This is False by default,
-            but if True, this method behaves like
+            If ``True``, the head will be set to the given commit. This is ``False`` by
+            default, but if ``True``, this method behaves like
             :meth:`HEAD.reset <git.refs.head.HEAD.reset>`.
 
         :param paths:
@@ -1433,7 +1439,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             If you want ``git reset``-like behaviour, use
             :meth:`HEAD.reset <git.refs.head.HEAD.reset>` instead.
 
-        :return: self
+        :return:
+            self
         """
         # What we actually want to do is to merge the tree into our existing index,
         # which is what git-read-tree does.

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -284,7 +284,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             self (containing the merge and possibly unmerged entries in case of
             conflicts)
 
-        :raise GitCommandError:
+        :raise git.exc.GitCommandError:
             If there is a merge conflict. The error will be raised at the first
             conflicting path. If you want to have proper merge resolution to be done by
             yourself, you have to commit the changed index (or make a valid tree from
@@ -624,7 +624,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         :raise ValueError:
             If there are no entries in the cache.
 
-        :raise UnmergedEntriesError:
+        :raise git.exc.UnmergedEntriesError:
         """
         # We obtain no lock as we just flush our contents to disk as tree.
         # If we are a new index, the entries access will load our data accordingly.
@@ -1077,7 +1077,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         :raise ValueError:
             If only one item was given.
 
-        :raise GitCommandError:
+        :raise git.exc.GitCommandError:
             If git could not handle your request.
         """
         args = []

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -101,10 +101,12 @@ __all__ = ("IndexFile", "CheckoutError", "StageType")
 def _named_temporary_file_for_subprocess(directory: PathLike) -> Generator[str, None, None]:
     """Create a named temporary file git subprocesses can open, deleting it afterward.
 
-    :param directory: The directory in which the file is created.
+    :param directory:
+        The directory in which the file is created.
 
-    :return: A context manager object that creates the file and provides its name on
-        entry, and deletes it on exit.
+    :return:
+        A context manager object that creates the file and provides its name on entry,
+        and deletes it on exit.
     """
     if os.name == "nt":
         fd, name = tempfile.mkstemp(dir=directory)
@@ -123,21 +125,21 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     git command function calls wherever possible.
 
     This provides custom merging facilities allowing to merge without actually changing
-    your index or your working tree. This way you can perform own test-merges based
-    on the index only without having to deal with the working copy. This is useful
-    in case of partial working trees.
+    your index or your working tree. This way you can perform own test-merges based on
+    the index only without having to deal with the working copy. This is useful in case
+    of partial working trees.
 
-    ``Entries``
+    Entries:
 
-    The index contains an entries dict whose keys are tuples of type IndexEntry
-    to facilitate access.
+        The index contains an entries dict whose keys are tuples of type
+        :class:`~git.index.typ.IndexEntry` to facilitate access.
 
-    You may read the entries dict or manipulate it using IndexEntry instance, i.e.::
+        You may read the entries dict or manipulate it using IndexEntry instance, i.e.::
 
-        index.entries[index.entry_key(index_entry_instance)] = index_entry_instance
+            index.entries[index.entry_key(index_entry_instance)] = index_entry_instance
 
-    Make sure you use index.write() once you are done manipulating the index directly
-    before operating on it using the git command.
+    Make sure you use :meth:`index.write() <write>` once you are done manipulating the
+    index directly before operating on it using the git command.
     """
 
     __slots__ = ("repo", "version", "entries", "_extension_data", "_file_path")
@@ -149,9 +151,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     """Flags for a submodule."""
 
     def __init__(self, repo: "Repo", file_path: Union[PathLike, None] = None) -> None:
-        """Initialize this Index instance, optionally from the given ``file_path``.
+        """Initialize this Index instance, optionally from the given `file_path`.
 
-        If no file_path is given, we will be created from the current index file.
+        If no `file_path` is given, we will be created from the current index file.
 
         If a stream is not given, the stream will be initialized from the current
         repository's index on demand.
@@ -230,25 +232,22 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Write the current state to our file path or to the given one.
 
         :param file_path:
-            If None, we will write to our stored file path from which we have
-            been initialized. Otherwise we write to the given file path.
-            Please note that this will change the file_path of this index to
-            the one you gave.
+            If None, we will write to our stored file path from which we have been
+            initialized. Otherwise we write to the given file path. Please note that
+            this will change the file_path of this index to the one you gave.
 
         :param ignore_extension_data:
-            If True, the TREE type extension data read in the index will not
-            be written to disk. NOTE that no extension data is actually written.
-            Use this if you have altered the index and
-            would like to use git-write-tree afterwards to create a tree
-            representing your written changes.
-            If this data is present in the written index, git-write-tree
-            will instead write the stored/cached tree.
-            Alternatively, use IndexFile.write_tree() to handle this case
-            automatically.
+            If True, the TREE type extension data read in the index will not be written
+            to disk. NOTE that no extension data is actually written.
+            Use this if you have altered the index and would like to use git-write-tree
+            afterwards to create a tree representing your written changes.
+            If this data is present in the written index, git-write-tree will instead
+            write the stored/cached tree.
+            Alternatively, use :meth:`write_tree` to handle this case automatically.
         """
         # Make sure we have our entries read before getting a write lock.
-        # Otherwise it would be done when streaming. This can happen if one
-        # doesn't change the index, but writes it right away.
+        # Otherwise it would be done when streaming.
+        # This can happen if one doesn't change the index, but writes it right away.
         self.entries
         lfd = LockedFD(file_path or self._file_path)
         stream = lfd.open(write=True, stream=True)
@@ -268,17 +267,17 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     @post_clear_cache
     @default_index
     def merge_tree(self, rhs: Treeish, base: Union[None, Treeish] = None) -> "IndexFile":
-        """Merge the given rhs treeish into the current index, possibly taking
+        """Merge the given `rhs` treeish into the current index, possibly taking
         a common base treeish into account.
 
-        As opposed to the :func:`IndexFile.from_tree` method, this allows you to use an
-        already existing tree as the left side of the merge.
+        As opposed to the :func:`from_tree` method, this allows you to use an already
+        existing tree as the left side of the merge.
 
         :param rhs:
             Treeish reference pointing to the 'other' side of the merge.
 
         :param base:
-            Optional treeish reference pointing to the common base of 'rhs' and this
+            Optional treeish reference pointing to the common base of `rhs` and this
             index which equals lhs.
 
         :return:
@@ -289,7 +288,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             If there is a merge conflict. The error will be raised at the first
             conflicting path. If you want to have proper merge resolution to be done by
             yourself, you have to commit the changed index (or make a valid tree from
-            it) and retry with a three-way index.from_tree call.
+            it) and retry with a three-way :meth:`index.from_tree <from_tree>` call.
         """
         # -i : ignore working tree status
         # --aggressive : handle more merge cases
@@ -308,15 +307,16 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         This method behaves like ``git-read-tree --aggressive`` when doing the merge.
 
-        :param repo: The repository treeish are located in.
+        :param repo:
+            The repository treeish are located in.
 
         :param tree_sha:
             20 byte or 40 byte tree sha or tree objects.
 
         :return:
-            New IndexFile instance. Its path will be undefined.
-            If you intend to write such a merged Index, supply an alternate file_path
-            to its 'write' method.
+            New :class:`IndexFile` instance. Its path will be undefined.
+            If you intend to write such a merged Index, supply an alternate
+            ``file_path`` to its :meth:`write` method.
         """
         tree_sha_bytes: List[bytes] = [to_bin_sha(str(t)) for t in tree_sha]
         base_entries = aggressive_tree_merge(repo.odb, tree_sha_bytes)
@@ -335,37 +335,40 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
     @classmethod
     def from_tree(cls, repo: "Repo", *treeish: Treeish, **kwargs: Any) -> "IndexFile":
-        """Merge the given treeish revisions into a new index which is returned.
+        R"""Merge the given treeish revisions into a new index which is returned.
         The original index will remain unaltered.
 
         :param repo:
             The repository treeish are located in.
 
         :param treeish:
-            One, two or three Tree Objects, Commits or 40 byte hexshas. The result
-            changes according to the amount of trees.
-            If 1 Tree is given, it will just be read into a new index
-            If 2 Trees are given, they will be merged into a new index using a
-            two way merge algorithm. Tree 1 is the 'current' tree, tree 2 is the 'other'
-            one. It behaves like a fast-forward.
-            If 3 Trees are given, a 3-way merge will be performed with the first tree
-            being the common ancestor of tree 2 and tree 3. Tree 2 is the 'current' tree,
-            tree 3 is the 'other' one.
+            One, two or three :class:`~git.objects.tree.Tree` objects,
+            :class:`~git.objects.commit.Commit`\s or 40 byte hexshas.
+
+            The result changes according to the amount of trees:
+
+            1. If 1 Tree is given, it will just be read into a new index.
+            2. If 2 Trees are given, they will be merged into a new index using a two
+               way merge algorithm. Tree 1 is the 'current' tree, tree 2 is the 'other'
+               one. It behaves like a fast-forward.
+            3. If 3 Trees are given, a 3-way merge will be performed with the first tree
+               being the common ancestor of tree 2 and tree 3. Tree 2 is the 'current'
+               tree, tree 3 is the 'other' one.
 
         :param kwargs:
-            Additional arguments passed to git-read-tree.
+            Additional arguments passed to ``git read-tree``.
 
         :return:
-            New IndexFile instance. It will point to a temporary index location which
-            does not exist anymore. If you intend to write such a merged Index, supply
-            an alternate file_path to its 'write' method.
+            New :class:`IndexFile` instance. It will point to a temporary index location
+            which does not exist anymore. If you intend to write such a merged Index,
+            supply an alternate ``file_path`` to its :meth:`write` method.
 
         :note:
-            In the three-way merge case, --aggressive will be specified to automatically
-            resolve more cases in a commonly correct manner. Specify trivial=True as kwarg
-            to override that.
+            In the three-way merge case, ``--aggressive`` will be specified to
+            automatically resolve more cases in a commonly correct manner. Specify
+            ``trivial=True`` as a keyword argument to override that.
 
-            As the underlying git-read-tree command takes into account the current
+            As the underlying ``git read-tree`` command takes into account the current
             index, it will be temporarily moved out of the way to prevent any unexpected
             interference.
         """
@@ -387,8 +390,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             arg_list.append("--index-output=%s" % tmp_index)
             arg_list.extend(treeish)
 
-            # Move the current index out of the way - otherwise the merge may fail
-            # as it considers existing entries. Moving it essentially clears the index.
+            # Move the current index out of the way - otherwise the merge may fail as it
+            # considers existing entries. Moving it essentially clears the index.
             # Unfortunately there is no 'soft' way to do it.
             # The TemporaryFileSwap ensures the original file gets put back.
             with TemporaryFileSwap(join_path_native(repo.git_dir, "index")):
@@ -402,12 +405,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
     @unbare_repo
     def _iter_expand_paths(self: "IndexFile", paths: Sequence[PathLike]) -> Iterator[PathLike]:
-        """Expand the directories in list of paths to the corresponding paths accordingly.
+        """Expand the directories in list of paths to the corresponding paths
+        accordingly.
 
         :note:
-            git will add items multiple times even if a glob overlapped
-            with manually specified paths or if paths where specified multiple
-            times - we respect that and do not prune.
+            git will add items multiple times even if a glob overlapped with manually
+            specified paths or if paths where specified multiple times - we respect that
+            and do not prune.
         """
 
         def raise_exc(e: Exception) -> NoReturn:
@@ -436,11 +440,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             if not os.path.exists(abs_path) and ("?" in abs_path or "*" in abs_path or "[" in abs_path):
                 resolved_paths = glob.glob(abs_path)
                 # not abs_path in resolved_paths:
-                #   a glob() resolving to the same path we are feeding it with
-                #   is a glob() that failed to resolve. If we continued calling
-                #   ourselves we'd endlessly recurse. If the condition below
-                #   evaluates to true then we are likely dealing with a file
-                #   whose name contains wildcard characters.
+                #   A glob() resolving to the same path we are feeding it with is a
+                #   glob() that failed to resolve. If we continued calling ourselves
+                #   we'd endlessly recurse. If the condition below evaluates to true
+                #   then we are likely dealing with a file whose name contains wildcard
+                #   characters.
                 if abs_path not in resolved_paths:
                     for f in self._iter_expand_paths(glob.glob(abs_path)):
                         yield str(f).replace(rs, "")
@@ -468,22 +472,27 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         fprogress: Callable[[PathLike, bool, PathLike], None],
         read_from_stdout: bool = True,
     ) -> Union[None, str]:
-        """Write path to proc.stdin and make sure it processes the item, including progress.
+        """Write path to ``proc.stdin`` and make sure it processes the item, including
+        progress.
 
-        :return: stdout string
+        :return:
+            stdout string
 
-        :param read_from_stdout: if True, proc.stdout will be read after the item
-            was sent to stdin. In that case, it will return None.
+        :param read_from_stdout:
+            If True, proc.stdout will be read after the item was sent to stdin. In that
+            case, it will return None.
 
-        :note: There is a bug in git-update-index that prevents it from sending
-            reports just in time. This is why we have a version that tries to
-            read stdout and one which doesn't. In fact, the stdout is not
-            important as the piped-in files are processed anyway and just in time.
+        :note:
+            There is a bug in git-update-index that prevents it from sending reports
+            just in time. This is why we have a version that tries to read stdout and
+            one which doesn't. In fact, the stdout is not important as the piped-in
+            files are processed anyway and just in time.
 
-        :note: Newlines are essential here, gits behaviour is somewhat inconsistent
-            on this depending on the version, hence we try our best to deal with
-            newlines carefully. Usually the last newline will not be sent, instead
-            we will close stdin to break the pipe.
+        :note:
+            Newlines are essential here, git's behaviour is somewhat inconsistent on
+            this depending on the version, hence we try our best to deal with newlines
+            carefully. Usually the last newline will not be sent, instead we will close
+            stdin to break the pipe.
         """
         fprogress(filepath, False, item)
         rval: Union[None, str] = None
@@ -506,12 +515,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         self, predicate: Callable[[Tuple[StageType, Blob]], bool] = lambda t: True
     ) -> Iterator[Tuple[StageType, Blob]]:
         """
-        :return: Iterator yielding tuples of Blob objects and stages, tuple(stage, Blob)
+        :return:
+            Iterator yielding tuples of Blob objects and stages, tuple(stage, Blob).
 
         :param predicate:
             Function(t) returning True if tuple(stage, Blob) should be yielded by the
-            iterator. A default filter, the BlobFilter, allows you to yield blobs
-            only if they match a given list of paths.
+            iterator. A default filter, the `~git.index.typ.BlobFilter`, allows you to
+            yield blobs only if they match a given list of paths.
         """
         for entry in self.entries.values():
             blob = entry.to_blob(self.repo)
@@ -524,14 +534,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     def unmerged_blobs(self) -> Dict[PathLike, List[Tuple[StageType, Blob]]]:
         """
         :return:
-            Dict(path : list( tuple( stage, Blob, ...))), being
-            a dictionary associating a path in the index with a list containing
-            sorted stage/blob pairs.
+            Dict(path : list( tuple( stage, Blob, ...))), being a dictionary associating
+            a path in the index with a list containing sorted stage/blob pairs.
 
         :note:
-            Blobs that have been removed in one side simply do not exist in the
-            given stage. I.e. a file removed on the 'other' branch whose entries
-            are at stage 3 will not have a stage 3 entry.
+            Blobs that have been removed in one side simply do not exist in the given
+            stage. That is, a file removed on the 'other' branch whose entries are at
+            stage 3 will not have a stage 3 entry.
         """
         is_unmerged_blob = lambda t: t[0] != 0
         path_map: Dict[PathLike, List[Tuple[StageType, Blob]]] = {}
@@ -556,9 +565,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         For each path there may only be one blob, otherwise a ValueError will be raised
         claiming the path is already at stage 0.
 
-        :raise ValueError: if one of the blobs already existed at stage 0
+        :raise ValueError:
+            If one of the blobs already existed at stage 0.
 
-        :return: self
+        :return:
+            self
 
         :note:
             You will have to write the index manually once you are done, i.e.
@@ -588,8 +599,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Reread the contents of our index file, discarding all cached information
         we might have.
 
-        :note: This is a possibly dangerous operations as it will discard your changes
-            to index.entries.
+        :note:
+            This is a possibly dangerous operations as it will discard your changes to
+            :attr:`index.entries <entries>`.
 
         :return: self
         """
@@ -598,16 +610,19 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return self
 
     def write_tree(self) -> Tree:
-        """Write this index to a corresponding Tree object into the repository's
-        object database and return it.
+        """Write this index to a corresponding :class:`~git.objects.tree.Tree` object
+        into the repository's object database and return it.
 
-        :return: Tree object representing this index.
+        :return:
+            :class:`~git.objects.tree.Tree` object representing this index.
 
-        :note: The tree will be written even if one or more objects the tree refers to
-            does not yet exist in the object database. This could happen if you added
-            Entries to the index directly.
+        :note:
+            The tree will be written even if one or more objects the tree refers to does
+            not yet exist in the object database. This could happen if you added entries
+            to the index directly.
 
-        :raise ValueError: if there are no entries in the cache
+        :raise ValueError:
+            If there are no entries in the cache.
 
         :raise UnmergedEntriesError:
         """
@@ -620,8 +635,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         # Copy changed trees only.
         mdb.stream_copy(mdb.sha_iter(), self.repo.odb)
 
-        # Note: Additional deserialization could be saved if write_tree_from_cache
-        # would return sorted tree entries.
+        # Note: Additional deserialization could be saved if write_tree_from_cache would
+        # return sorted tree entries.
         root_tree = Tree(self.repo, binsha, path="")
         root_tree._cache = tree_items
         return root_tree
@@ -639,8 +654,11 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
     def _to_relative_path(self, path: PathLike) -> PathLike:
         """
-        :return: Version of path relative to our git directory or raise ValueError
-            if it is not within our git directory"""
+        :return: Version of path relative to our git directory or raise
+            :class:`ValueError` if it is not within our git directory.
+
+        :raise ValueError:
+        """
         if not osp.isabs(path):
             return path
         if self.repo.bare:
@@ -672,8 +690,12 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return paths, entries
 
     def _store_path(self, filepath: PathLike, fprogress: Callable) -> BaseIndexEntry:
-        """Store file at filepath in the database and return the base index entry
-        Needs the git_working_dir decorator active ! This must be assured in the calling code"""
+        """Store file at filepath in the database and return the base index entry.
+
+        :note:
+            This needs the git_working_dir decorator active!
+            This must be ensured in the calling code.
+        """
         st = os.lstat(filepath)  # Handles non-symlinks as well.
         if S_ISLNK(st.st_mode):
             # In PY3, readlink is a string, but we need bytes.
@@ -744,8 +766,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         write: bool = True,
         write_extension_data: bool = False,
     ) -> List[BaseIndexEntry]:
-        """Add files from the working tree, specific blobs or BaseIndexEntries
-        to the index.
+        R"""Add files from the working tree, specific blobs, or
+        :class:`~git.index.typ.BaseIndexEntry`\s to the index.
 
         :param items:
             Multiple types of items are supported, types can be mixed within one call.
@@ -753,9 +775,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             relative or absolute.
 
             - path string
+
                 Strings denote a relative or absolute path into the repository pointing
-                to an existing file, e.g., CHANGES, lib/myfile.ext,
-                '/home/gitrepo/lib/myfile.ext'.
+                to an existing file, e.g., ``CHANGES``, `lib/myfile.ext``,
+                ``/home/gitrepo/lib/myfile.ext``.
 
                 Absolute paths must start with working tree directory of this index's
                 repository to be considered valid. For example, if it was initialized
@@ -769,11 +792,12 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 directories like ``lib``, which will add all the files within the
                 directory and subdirectories.
 
-                This equals a straight git-add.
+                This equals a straight ``git add``.
 
                 They are added at stage 0.
 
-            - Blob or Submodule object
+            - :class:~`git.objects.blob.Blob` or :class:`~git.objects.submodule.base.Submodule` object
+
                 Blobs are added as they are assuming a valid mode is set.
 
                 The file they refer to may or may not exist in the file system, but must
@@ -787,53 +811,57 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 except that the mode you have set will be kept. This allows you to
                 create symlinks by settings the mode respectively and writing the target
                 of the symlink directly into the file. This equals a default
-                Linux-Symlink which is not dereferenced automatically, except that it
+                Linux symlink which is not dereferenced automatically, except that it
                 can be created on filesystems not supporting it as well.
 
-                Please note that globs or directories are not allowed in Blob objects.
+                Please note that globs or directories are not allowed in
+                :class:~`git.objects.blob.Blob` objects.
 
                 They are added at stage 0.
 
-            - BaseIndexEntry or type
+            - :class:`~git.index.typ.BaseIndexEntry` or type
+
                 Handling equals the one of Blob objects, but the stage may be explicitly
                 set. Please note that Index Entries require binary sha's.
 
         :param force:
             **CURRENTLY INEFFECTIVE**
             If True, otherwise ignored or excluded files will be added anyway.
-            As opposed to the git-add command, we enable this flag by default
-            as the API user usually wants the item to be added even though
-            they might be excluded.
+            As opposed to the ``git add`` command, we enable this flag by default as the
+            API user usually wants the item to be added even though they might be
+            excluded.
 
         :param fprogress:
-            Function with signature f(path, done=False, item=item) called for each
-            path to be added, one time once it is about to be added where done==False
-            and once after it was added where done=True.
-            item is set to the actual item we handle, either a Path or a BaseIndexEntry
-            Please note that the processed path is not guaranteed to be present
-            in the index already as the index is currently being processed.
+            Function with signature ``f(path, done=False, item=item)`` called for each
+            path to be added, one time once it is about to be added where ``done=False``
+            and once after it was added where ``done=True``.
+            ``item`` is set to the actual item we handle, either a Path or a
+            :class:`~git.index.typ.BaseIndexEntry`.
+            Please note that the processed path is not guaranteed to be present in the
+            index already as the index is currently being processed.
 
         :param path_rewriter:
-            Function with signature (string) func(BaseIndexEntry) function returning a
-            path for each passed entry which is the path to be actually recorded for the
-            object created from entry.path. This allows you to write an index which is
-            not identical to the layout of the actual files on your hard-disk. If not
-            None and ``items`` contain plain paths, these paths will be converted to
-            Entries beforehand and passed to the path_rewriter. Please note that
-            entry.path is relative to the git repository.
+            Function, with signature ``(string) func(BaseIndexEntry)``, returning a path
+            for each passed entry which is the path to be actually recorded for the
+            object created from :attr:`entry.path <git.index.typ.BaseIndexEntry.path>`.
+            This allows you to write an index which is not identical to the layout of
+            the actual files on your hard-disk. If not None and `items` contain plain
+            paths, these paths will be converted to Entries beforehand and passed to the
+            path_rewriter. Please note that ``entry.path`` is relative to the git
+            repository.
 
         :param write:
-            If True, the index will be written once it was altered. Otherwise
-            the changes only exist in memory and are not available to git commands.
+            If True, the index will be written once it was altered. Otherwise the
+            changes only exist in memory and are not available to git commands.
 
         :param write_extension_data:
             If True, extension data will be written back to the index. This can lead to
             issues in case it is containing the 'TREE' extension, which will cause the
-            `git commit` command to write an old tree, instead of a new one representing
-            the now changed index.
+            ``git commit`` command to write an old tree, instead of a new one
+            representing the now changed index.
 
             This doesn't matter if you use :meth:`IndexFile.commit`, which ignores the
-            `TREE` extension altogether. You should set it to True if you intend to use
+            'TREE' extension altogether. You should set it to True if you intend to use
             :meth:`IndexFile.commit` exclusively while maintaining support for
             third-party extensions. Besides that, you can usually safely ignore the
             built-in extensions when using GitPython on repositories that are not
@@ -843,18 +871,20 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             http://opensource.apple.com/source/Git/Git-26/src/git-htmldocs/technical/index-format.txt
 
         :return:
-            List(BaseIndexEntries) representing the entries just actually added.
+            List of :class:`~git.index.typ.BaseIndexEntry`\s representing the entries
+            just actually added.
 
         :raise OSError:
-            If a supplied Path did not exist. Please note that BaseIndexEntry
-            Objects that do not have a null sha will be added even if their paths
-            do not exist.
+            If a supplied Path did not exist. Please note that
+            :class:`~git.index.typ.BaseIndexEntry` objects that do not have a null sha
+            will be added even if their paths do not exist.
         """
-        # Sort the entries into strings and Entries. Blobs are converted to entries automatically.
+        # Sort the entries into strings and Entries.
+        # Blobs are converted to entries automatically.
         # Paths can be git-added. For everything else we use git-update-index.
         paths, entries = self._preprocess_add_items(items)
         entries_added: List[BaseIndexEntry] = []
-        # This code needs a working tree, therefore we try not to run it unless required.
+        # This code needs a working tree, so we try not to run it unless required.
         # That way, we are OK on a bare repository as well.
         # If there are no paths, the rewriter has nothing to do either.
         if paths:
@@ -897,7 +927,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             # END null_entry handling
 
             # REWRITE PATHS
-            # If we have to rewrite the entries, do so now, after we have generated all object sha's.
+            # If we have to rewrite the entries, do so now, after we have generated all
+            # object sha's.
             if path_rewriter:
                 for i, e in enumerate(entries):
                     entries[i] = BaseIndexEntry((e.mode, e.binsha, e.stage, path_rewriter(e)))
@@ -955,26 +986,28 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         working_tree: bool = False,
         **kwargs: Any,
     ) -> List[str]:
-        """Remove the given items from the index and optionally from
-        the working tree as well.
+        R"""Remove the given items from the index and optionally from the working tree
+        as well.
 
         :param items:
             Multiple types of items are supported which may be be freely mixed.
 
             - path string
+
                 Remove the given path at all stages. If it is a directory, you must
-                specify the r=True keyword argument to remove all file entries
-                below it. If absolute paths are given, they will be converted
-                to a path relative to the git repository directory containing
-                the working tree
+                specify the ``r=True`` keyword argument to remove all file entries below
+                it. If absolute paths are given, they will be converted to a path
+                relative to the git repository directory containing the working tree
 
-                The path string may include globs, such as \\*.c.
+                The path string may include globs, such as \*.c.
 
-            - Blob Object
+            - :class:~`git.objects.blob.Blob` object
+
                 Only the path portion is used in this case.
 
-            - BaseIndexEntry or compatible type
-                The only relevant information here Yis the path. The stage is ignored.
+            - :class:`~git.index.typ.BaseIndexEntry` or compatible type
+
+                The only relevant information here is the path. The stage is ignored.
 
         :param working_tree:
             If True, the entry will also be removed from the working tree, physically
@@ -982,14 +1015,15 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             in it.
 
         :param kwargs:
-            Additional keyword arguments to be passed to git-rm, such
-            as 'r' to allow recursive removal of
+            Additional keyword arguments to be passed to ``git rm``, such as ``r`` to
+            allow recursive removal.
 
         :return:
-            List(path_string, ...) list of repository relative paths that have
-            been removed effectively.
-            This is interesting to know in case you have provided a directory or
-            globs. Paths are relative to the repository.
+            List(path_string, ...) list of repository relative paths that have been
+            removed effectively.
+
+            This is interesting to know in case you have provided a directory or globs.
+            Paths are relative to the repository.
         """
         args = []
         if not working_tree:
@@ -1013,28 +1047,38 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         **kwargs: Any,
     ) -> List[Tuple[str, str]]:
         """Rename/move the items, whereas the last item is considered the destination of
-        the move operation. If the destination is a file, the first item (of two)
-        must be a file as well. If the destination is a directory, it may be preceded
-        by one or more directories or files.
+        the move operation.
+
+        If the destination is a file, the first item (of two) must be a file as well.
+
+        If the destination is a directory, it may be preceded by one or more directories
+        or files.
 
         The working tree will be affected in non-bare repositories.
 
-        :parma items:
+        :param items:
             Multiple types of items are supported, please see the :meth:`remove` method
             for reference.
+
         :param skip_errors:
-            If True, errors such as ones resulting from missing source files will
-            be skipped.
+            If True, errors such as ones resulting from missing source files will be
+            skipped.
+
         :param kwargs:
-            Additional arguments you would like to pass to git-mv, such as dry_run
-            or force.
+            Additional arguments you would like to pass to ``git mv``, such as
+            ``dry_run`` or ``force``.
 
-        :return: List(tuple(source_path_string, destination_path_string), ...)
-            A list of pairs, containing the source file moved as well as its
-            actual destination. Relative to the repository root.
+        :return:
+            List(tuple(source_path_string, destination_path_string), ...)
 
-        :raise ValueError: If only one item was given
-        :raise GitCommandError: If git could not handle your request
+            A list of pairs, containing the source file moved as well as its actual
+            destination. Relative to the repository root.
+
+        :raise ValueError:
+            If only one item was given.
+
+        :raise GitCommandError:
+            If git could not handle your request.
         """
         args = []
         if skip_errors:
@@ -1047,13 +1091,13 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         was_dry_run = kwargs.pop("dry_run", kwargs.pop("n", None))
         kwargs["dry_run"] = True
 
-        # First execute rename in dryrun so the command tells us what it actually does
+        # First execute rename in dry run so the command tells us what it actually does
         # (for later output).
         out = []
         mvlines = self.repo.git.mv(args, paths, **kwargs).splitlines()
 
-        # Parse result - first 0:n/2 lines are 'checking ', the remaining ones
-        # are the 'renaming' ones which we parse.
+        # Parse result - first 0:n/2 lines are 'checking ', the remaining ones are the
+        # 'renaming' ones which we parse.
         for ln in range(int(len(mvlines) / 2), len(mvlines)):
             tokens = mvlines[ln].split(" to ")
             assert len(tokens) == 2, "Too many tokens in %s" % mvlines[ln]
@@ -1066,7 +1110,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         # Either prepare for the real run, or output the dry-run result.
         if was_dry_run:
             return out
-        # END handle dryrun
+        # END handle dry run
 
         # Now apply the actual operation.
         kwargs.pop("dry_run")
@@ -1085,17 +1129,22 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         commit_date: Union[datetime.datetime, str, None] = None,
         skip_hooks: bool = False,
     ) -> Commit:
-        """Commit the current default index file, creating a Commit object.
+        """Commit the current default index file, creating a
+        :class:`~git.objects.commit.Commit` object.
 
         For more information on the arguments, see
         :meth:`Commit.create_from_tree <git.objects.commit.Commit.create_from_tree>`.
 
-        :note: If you have manually altered the :attr:`entries` member of this instance,
-               don't forget to :meth:`write` your changes to disk beforehand.
-               Passing ``skip_hooks=True`` is the equivalent of using ``-n``
-               or ``--no-verify`` on the command line.
+        :note:
+            If you have manually altered the :attr:`entries` member of this instance,
+            don't forget to :meth:`write` your changes to disk beforehand.
 
-        :return: :class:`Commit` object representing the new commit
+        :note:
+            Passing ``skip_hooks=True`` is the equivalent of using ``-n`` or
+            ``--no-verify`` on the command line.
+
+        :return:
+            :class:`~git.objects.commit.Commit` object representing the new commit
         """
         if not skip_hooks:
             run_commit_hook("pre-commit", self)
@@ -1160,44 +1209,49 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         """Check out the given paths or all files from the version known to the index
         into the working tree.
 
-        :note: Be sure you have written pending changes using the :meth:`write` method
-            in case you have altered the entries dictionary directly.
+        :note:
+            Be sure you have written pending changes using the :meth:`write` method in
+            case you have altered the entries dictionary directly.
 
         :param paths:
             If None, all paths in the index will be checked out. Otherwise an iterable
-            of relative or absolute paths or a single path pointing to files or directories
-            in the index is expected.
+            of relative or absolute paths or a single path pointing to files or
+            directories in the index is expected.
 
         :param force:
-            If True, existing files will be overwritten even if they contain local modifications.
-            If False, these will trigger a :class:`CheckoutError`.
+            If True, existing files will be overwritten even if they contain local
+            modifications.
+            If False, these will trigger a :class:`~git.exc.CheckoutError`.
 
         :param fprogress:
-            see :func:`IndexFile.add` for signature and explanation.
+            See :meth:`IndexFile.add` for signature and explanation.
+
             The provided progress information will contain None as path and item if no
-            explicit paths are given. Otherwise progress information will be send
-            prior and after a file has been checked out.
+            explicit paths are given. Otherwise progress information will be send prior
+            and after a file has been checked out.
 
         :param kwargs:
-            Additional arguments to be passed to git-checkout-index.
+            Additional arguments to be passed to ``git checkout-index``.
 
         :return:
-            iterable yielding paths to files which have been checked out and are
+            Iterable yielding paths to files which have been checked out and are
             guaranteed to match the version stored in the index.
 
-        :raise exc.CheckoutError:
-            If at least one file failed to be checked out. This is a summary,
-            hence it will checkout as many files as it can anyway.
-            If one of files or directories do not exist in the index
-            ( as opposed to the  original git command who ignores them ).
-            Raise GitCommandError if error lines could not be parsed - this truly is
-            an exceptional state.
+        :raise git.exc.CheckoutError:
+            If at least one file failed to be checked out. This is a summary, hence it
+            will checkout as many files as it can anyway.
+            If one of files or directories do not exist in the index (as opposed to the
+            original git command, which ignores them).
 
-        .. note:: The checkout is limited to checking out the files in the
-            index. Files which are not in the index anymore and exist in
-            the working tree will not be deleted. This behaviour is fundamentally
-            different to *head.checkout*, i.e. if you want git-checkout like behaviour,
-            use head.checkout instead of index.checkout.
+        :raise git.exc.GitCommandError:
+            If error lines could not be parsed - this truly is an exceptional state.
+
+        :note:
+            The checkout is limited to checking out the files in the index. Files which
+            are not in the index anymore and exist in the working tree will not be
+            deleted. This behaviour is fundamentally different to ``head.checkout``,
+            i.e. if you want ``git checkout`` like behaviour, use ``head.checkout``
+            instead of ``index.checkout``.
         """
         args = ["--index"]
         if force:
@@ -1276,9 +1330,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             if isinstance(paths, str):
                 paths = [paths]
 
-            # Make sure we have our entries loaded before we start checkout_index,
-            # which will hold a lock on it. We try to get the lock as well during
-            # our entries initialization.
+            # Make sure we have our entries loaded before we start checkout_index, which
+            # will hold a lock on it. We try to get the lock as well during our entries
+            # initialization.
             self.entries
 
             args.append("--stdin")
@@ -1339,40 +1393,50 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         head: bool = False,
         **kwargs: Any,
     ) -> "IndexFile":
-        """Reset the index to reflect the tree at the given commit. This will not
-        adjust our HEAD reference as opposed to HEAD.reset by default.
+        """Reset the index to reflect the tree at the given commit. This will not adjust
+        our ``HEAD`` reference by default, as opposed to
+        :meth:`HEAD.reset <git.refs.head.HEAD.reset>`.
 
         :param commit:
-            Revision, Reference or Commit specifying the commit we should represent.
-            If you want to specify a tree only, use IndexFile.from_tree and overwrite
-            the default index.
+            Revision, :class:`~git.refs.reference.Reference` or
+            :class:`~git.objects.commit.Commit` specifying the commit we should
+            represent.
+
+            If you want to specify a tree only, use :meth:`IndexFile.from_tree` and
+            overwrite the default index.
 
         :param working_tree:
             If True, the files in the working tree will reflect the changed index.
-            If False, the working tree will not be touched
+            If False, the working tree will not be touched.
             Please note that changes to the working copy will be discarded without
-            warning !
+            warning!
 
         :param head:
             If True, the head will be set to the given commit. This is False by default,
-            but if True, this method behaves like HEAD.reset.
+            but if True, this method behaves like
+            :meth:`HEAD.reset <git.refs.head.HEAD.reset>`.
 
-        :param paths: if given as an iterable of absolute or repository-relative paths,
-            only these will be reset to their state at the given commit-ish.
+        :param paths:
+            If given as an iterable of absolute or repository-relative paths, only these
+            will be reset to their state at the given commit-ish.
             The paths need to exist at the commit, otherwise an exception will be
             raised.
 
         :param kwargs:
-            Additional keyword arguments passed to git-reset
+            Additional keyword arguments passed to ``git reset``.
 
-        .. note:: IndexFile.reset, as opposed to HEAD.reset, will not delete any files
-            in order to maintain a consistent working tree. Instead, it will just
-            check out the files according to their state in the index.
-            If you want git-reset like behaviour, use *HEAD.reset* instead.
+        :note:
+            :meth:`IndexFile.reset`, as opposed to
+            :meth:`HEAD.reset <git.refs.head.HEAD.reset>`, will not delete any files in
+            order to maintain a consistent working tree. Instead, it will just check out
+            the files according to their state in the index.
+            If you want ``git reset``-like behaviour, use
+            :meth:`HEAD.reset <git.refs.head.HEAD.reset>` instead.
 
-        :return: self"""
-        # What we actually want to do is to merge the tree into our existing
-        # index, which is what git-read-tree does.
+        :return: self
+        """
+        # What we actually want to do is to merge the tree into our existing index,
+        # which is what git-read-tree does.
         new_inst = type(self).from_tree(self.repo, commit)
         if not paths:
             self.entries = new_inst.entries
@@ -1413,14 +1477,15 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         create_patch: bool = False,
         **kwargs: Any,
     ) -> git_diff.DiffIndex:
-        """Diff this index against the working copy or a Tree or Commit object.
+        """Diff this index against the working copy or a :class:`~git.objects.tree.Tree`
+        or :class:`~git.objects.commit.Commit` object.
 
         For documentation of the parameters and return values, see
         :meth:`Diffable.diff <git.diff.Diffable.diff>`.
 
         :note:
-            Will only work with indices that represent the default git index as
-            they have not been initialized with a stream.
+            Will only work with indices that represent the default git index as they
+            have not been initialized with a stream.
         """
 
         # Only run if we are the default repository index.
@@ -1430,9 +1495,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         if other is self.Index:
             return git_diff.DiffIndex()
 
-        # Index against anything but None is a reverse diff with the respective
-        # item. Handle existing -R flags properly. Transform strings to the object
-        # so that we can call diff on it.
+        # Index against anything but None is a reverse diff with the respective item.
+        # Handle existing -R flags properly.
+        # Transform strings to the object so that we can call diff on it.
         if isinstance(other, str):
             other = self.repo.rev_parse(other)
         # END object conversion

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -88,7 +88,7 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
     :param args:
         Arguments passed to hook file.
 
-    :raises HookExecutionError:
+    :raise HookExecutionError:
     """
     hp = hook_path(name, index.repo.git_dir)
     if not os.access(hp, os.X_OK):

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -88,7 +88,7 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
     :param args:
         Arguments passed to hook file.
 
-    :raise HookExecutionError:
+    :raise git.exc.HookExecutionError:
     """
     hp = hook_path(name, index.repo.git_dir)
     if not os.access(hp, os.X_OK):

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -1,7 +1,8 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-"""Standalone functions to accompany the index implementation and make it more versatile."""
+"""Standalone functions to accompany the index implementation and make it more
+versatile."""
 
 from io import BytesIO
 import os
@@ -78,9 +79,15 @@ def _has_file_extension(path: str) -> str:
 def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
     """Run the commit hook of the given name. Silently ignore hooks that do not exist.
 
-    :param name: name of hook, like 'pre-commit'
-    :param index: IndexFile instance
-    :param args: Arguments passed to hook file
+    :param name:
+        Name of hook, like ``pre-commit``.
+
+    :param index:
+        :class:`~git.index.base.IndexFile` instance.
+
+    :param args:
+        Arguments passed to hook file.
+
     :raises HookExecutionError:
     """
     hp = hook_path(name, index.repo.git_dir)
@@ -121,8 +128,8 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
 
 
 def stat_mode_to_index_mode(mode: int) -> int:
-    """Convert the given mode from a stat call to the corresponding index mode
-    and return it."""
+    """Convert the given mode from a stat call to the corresponding index mode and
+    return it."""
     if S_ISLNK(mode):  # symlinks
         return S_IFLNK
     if S_ISDIR(mode) or S_IFMT(mode) == S_IFGITLINK:  # submodules
@@ -138,16 +145,19 @@ def write_cache(
 ) -> None:
     """Write the cache represented by entries to a stream.
 
-    :param entries: **sorted** list of entries
+    :param entries:
+        **Sorted** list of entries.
 
-    :param stream: stream to wrap into the AdapterStreamCls - it is used for
-        final output.
+    :param stream:
+        Stream to wrap into the AdapterStreamCls - it is used for final output.
 
-    :param ShaStreamCls: Type to use when writing to the stream. It produces a sha
-        while writing to it, before the data is passed on to the wrapped stream
+    :param ShaStreamCls:
+        Type to use when writing to the stream. It produces a sha while writing to it,
+        before the data is passed on to the wrapped stream.
 
-    :param extension_data: any kind of data to write as a trailer, it must begin
-        a 4 byte identifier, followed by its size (4 bytes).
+    :param extension_data:
+        Any kind of data to write as a trailer, it must begin a 4 byte identifier,
+        followed by its size (4 bytes).
     """
     # Wrap the stream into a compatible writer.
     stream_sha = ShaStreamCls(stream)
@@ -197,7 +207,7 @@ def write_cache(
 
 
 def read_header(stream: IO[bytes]) -> Tuple[int, int]:
-    """Return tuple(version_long, num_entries) from the given stream"""
+    """Return tuple(version_long, num_entries) from the given stream."""
     type_id = stream.read(4)
     if type_id != b"DIRC":
         raise AssertionError("Invalid index file header: %r" % type_id)
@@ -210,9 +220,13 @@ def read_header(stream: IO[bytes]) -> Tuple[int, int]:
 
 
 def entry_key(*entry: Union[BaseIndexEntry, PathLike, int]) -> Tuple[PathLike, int]:
-    """:return: Key suitable to be used for the index.entries dictionary
+    """
+    :return:
+        Key suitable to be used for the :attr:`index.entries
+        <git.index.base.IndexFile.entries>` dictionary.
 
-    :param entry: One instance of type BaseIndexEntry or the path and the stage
+    :param entry:
+        One instance of type BaseIndexEntry or the path and the stage.
     """
 
     # def is_entry_key_tup(entry_key: Tuple) -> TypeGuard[Tuple[PathLike, int]]:
@@ -234,12 +248,14 @@ def read_cache(
 ) -> Tuple[int, Dict[Tuple[PathLike, int], "IndexEntry"], bytes, bytes]:
     """Read a cache file from the given stream.
 
-    :return: tuple(version, entries_dict, extension_data, content_sha)
+    :return:
+        tuple(version, entries_dict, extension_data, content_sha)
 
-      * version is the integer version number.
-      * entries dict is a dictionary which maps IndexEntry instances to a path at a stage.
-      * extension_data is '' or 4 bytes of type + 4 bytes of size + size bytes.
-      * content_sha is a 20 byte sha on all cache file contents.
+        * *version* is the integer version number.
+        * *entries_dict* is a dictionary which maps IndexEntry instances to a path at a
+          stage.
+        * *extension_data* is ``""`` or 4 bytes of type + 4 bytes of size + size bytes.
+        * *content_sha* is a 20 byte sha on all cache file contents.
     """
     version, num_entries = read_header(stream)
     count = 0
@@ -285,15 +301,25 @@ def read_cache(
 def write_tree_from_cache(
     entries: List[IndexEntry], odb: "GitCmdObjectDB", sl: slice, si: int = 0
 ) -> Tuple[bytes, List["TreeCacheTup"]]:
-    """Create a tree from the given sorted list of entries and put the respective
+    R"""Create a tree from the given sorted list of entries and put the respective
     trees into the given object database.
 
-    :param entries: **Sorted** list of IndexEntries
-    :param odb: Object database to store the trees in
-    :param si: Start index at which we should start creating subtrees
-    :param sl: Slice indicating the range we should process on the entries list
-    :return: tuple(binsha, list(tree_entry, ...)) a tuple of a sha and a list of
-        tree entries being a tuple of hexsha, mode, name
+    :param entries:
+        **Sorted** list of :class:`~git.index.typ.IndexEntry`\s.
+
+    :param odb:
+        Object database to store the trees in.
+
+    :param si:
+        Start index at which we should start creating subtrees.
+
+    :param sl:
+        Slice indicating the range we should process on the entries list.
+
+    :return:
+        tuple(binsha, list(tree_entry, ...))
+
+        A tuple of a sha and a list of tree entries being a tuple of hexsha, mode, name.
     """
     tree_items: List["TreeCacheTup"] = []
 
@@ -346,15 +372,17 @@ def _tree_entry_to_baseindexentry(tree_entry: "TreeCacheTup", stage: int) -> Bas
 
 
 def aggressive_tree_merge(odb: "GitCmdObjectDB", tree_shas: Sequence[bytes]) -> List[BaseIndexEntry]:
-    """
-    :return: List of BaseIndexEntries representing the aggressive merge of the given
-        trees. All valid entries are on stage 0, whereas the conflicting ones are left
-        on stage 1, 2 or 3, whereas stage 1 corresponds to the common ancestor tree,
-        2 to our tree and 3 to 'their' tree.
+    R"""
+    :return:
+        List of :class:`~git.index.typ.BaseIndexEntry`\s representing the aggressive
+        merge of the given trees. All valid entries are on stage 0, whereas the
+        conflicting ones are left on stage 1, 2 or 3, whereas stage 1 corresponds to the
+        common ancestor tree, 2 to our tree and 3 to 'their' tree.
 
-    :param tree_shas: 1, 2 or 3 trees as identified by their binary 20 byte shas.
-        If 1 or two, the entries will effectively correspond to the last given tree.
-        If 3 are given, a 3 way merge is performed.
+    :param tree_shas:
+        1, 2 or 3 trees as identified by their binary 20 byte shas. If 1 or two, the
+        entries will effectively correspond to the last given tree. If 3 are given, a 3
+        way merge is performed.
     """
     out: List[BaseIndexEntry] = []
 

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -222,8 +222,8 @@ def read_header(stream: IO[bytes]) -> Tuple[int, int]:
 def entry_key(*entry: Union[BaseIndexEntry, PathLike, int]) -> Tuple[PathLike, int]:
     """
     :return:
-        Key suitable to be used for the :attr:`index.entries
-        <git.index.base.IndexFile.entries>` dictionary.
+        Key suitable to be used for the
+        :attr:`index.entries <git.index.base.IndexFile.entries>` dictionary.
 
     :param entry:
         One instance of type BaseIndexEntry or the path and the stage.

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -36,9 +36,9 @@ CE_STAGESHIFT = 12
 
 
 class BlobFilter:
-    """
-    Predicate to be used by iter_blobs allowing to filter only return blobs which
-    match the given list of directories or files.
+    """Predicate to be used by
+    :meth:`IndexFile.iter_blobs <git.index.base.IndexFile.iter_blobs>` allowing to
+    filter only return blobs which match the given list of directories or files.
 
     The given paths are given relative to the repository.
     """
@@ -48,8 +48,8 @@ class BlobFilter:
     def __init__(self, paths: Sequence[PathLike]) -> None:
         """
         :param paths:
-            Tuple or list of paths which are either pointing to directories or
-            to files relative to the current repository
+            Tuple or list of paths which are either pointing to directories or to files
+            relative to the current repository.
         """
         self.paths = paths
 
@@ -70,7 +70,7 @@ class BlobFilter:
 
 
 class BaseIndexEntryHelper(NamedTuple):
-    """Typed named tuple to provide named attribute access for BaseIndexEntry.
+    """Typed named tuple to provide named attribute access for :class:`BaseIndexEntry`.
 
     This is needed to allow overriding ``__new__`` in child class to preserve backwards
     compatibility.
@@ -90,12 +90,12 @@ class BaseIndexEntryHelper(NamedTuple):
 
 
 class BaseIndexEntry(BaseIndexEntryHelper):
-    """Small brother of an index entry which can be created to describe changes
+    R"""Small brother of an index entry which can be created to describe changes
     done to the index in which case plenty of additional information is not required.
 
-    As the first 4 data members match exactly to the IndexEntry type, methods
-    expecting a BaseIndexEntry can also handle full IndexEntries even if they
-    use numeric indices for performance reasons.
+    As the first 4 data members match exactly to the :class:`IndexEntry` type, methods
+    expecting a :class:`BaseIndexEntry` can also handle full :class:`IndexEntry`\s even
+    if they use numeric indices for performance reasons.
     """
 
     def __new__(
@@ -127,9 +127,11 @@ class BaseIndexEntry(BaseIndexEntryHelper):
             * 0 = default stage
             * 1 = stage before a merge or common ancestor entry in case of a 3 way merge
             * 2 = stage of entries from the 'left' side of the merge
-            * 3 = stage of entries from the right side of the merge
+            * 3 = stage of entries from the 'right' side of the merge
 
-        :note: For more information, see http://www.kernel.org/pub/software/scm/git/docs/git-read-tree.html
+        :note:
+            For more information, see:
+            http://www.kernel.org/pub/software/scm/git/docs/git-read-tree.html
         """
         return (self.flags & CE_STAGEMASK) >> CE_STAGESHIFT
 
@@ -144,7 +146,8 @@ class BaseIndexEntry(BaseIndexEntryHelper):
 
 
 class IndexEntry(BaseIndexEntry):
-    """Allows convenient access to IndexEntry data without completely unpacking it.
+    """Allows convenient access to index entry data as defined in
+    :class:`BaseIndexEntry` without completely unpacking it.
 
     Attributes usually accessed often are cached in the tuple whereas others are
     unpacked on demand.
@@ -163,17 +166,18 @@ class IndexEntry(BaseIndexEntry):
 
     @property
     def mtime(self) -> Tuple[int, int]:
-        """See ctime property, but returns modification time."""
+        """See :attr:`ctime` property, but returns modification time."""
         return cast(Tuple[int, int], unpack(">LL", self.mtime_bytes))
 
     @classmethod
     def from_base(cls, base: "BaseIndexEntry") -> "IndexEntry":
         """
         :return:
-            Minimal entry as created from the given BaseIndexEntry instance.
+            Minimal entry as created from the given :class:`BaseIndexEntry` instance.
             Missing values will be set to null-like values.
 
-        :param base: Instance of type :class:`BaseIndexEntry`
+        :param base:
+            Instance of type :class:`BaseIndexEntry`.
         """
         time = pack(">LL", 0, 0)
         return IndexEntry((base.mode, base.binsha, base.flags, base.path, time, time, 0, 0, 0, 0, 0))

--- a/git/index/typ.py
+++ b/git/index/typ.py
@@ -58,7 +58,8 @@ class BlobFilter:
         blob_path: Path = blob_pathlike if isinstance(blob_pathlike, Path) else Path(blob_pathlike)
         for pathlike in self.paths:
             path: Path = pathlike if isinstance(pathlike, Path) else Path(pathlike)
-            # TODO: Change to use `PosixPath.is_relative_to` once Python 3.8 is no longer supported.
+            # TODO: Change to use `PosixPath.is_relative_to` once Python 3.8 is no
+            # longer supported.
             filter_parts: List[str] = path.parts
             blob_parts: List[str] = blob_path.parts
             if len(filter_parts) > len(blob_parts):
@@ -69,8 +70,11 @@ class BlobFilter:
 
 
 class BaseIndexEntryHelper(NamedTuple):
-    """Typed namedtuple to provide named attribute access for BaseIndexEntry.
-    Needed to allow overriding __new__ in child class to preserve backwards compat."""
+    """Typed named tuple to provide named attribute access for BaseIndexEntry.
+
+    This is needed to allow overriding ``__new__`` in child class to preserve backwards
+    compatibility.
+    """
 
     mode: int
     binsha: bytes
@@ -101,7 +105,8 @@ class BaseIndexEntry(BaseIndexEntryHelper):
             Tuple[int, bytes, int, PathLike, bytes, bytes, int, int, int, int, int],
         ],
     ) -> "BaseIndexEntry":
-        """Override __new__ to allow construction from a tuple for backwards compatibility"""
+        """Override ``__new__`` to allow construction from a tuple for backwards
+        compatibility."""
         return super().__new__(cls, *inp_tuple)
 
     def __str__(self) -> str:

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -70,8 +70,8 @@ def post_clear_cache(func: Callable[..., _T]) -> Callable[..., _T]:
     to allow it to be lazily reread later.
 
     :note:
-        This decorator will not be required once all functions are implemented natively
-        which in fact is possible, but probably not feasible performance wise.
+        This decorator is required because not all functions related to
+        :class:`~git.index.base.IndexFile` are implemented natively.
     """
 
     @wraps(func)

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -65,13 +65,10 @@ class TemporaryFileSwap:
 
 
 def post_clear_cache(func: Callable[..., _T]) -> Callable[..., _T]:
-    """Decorator for functions that alter the index using the git command. This would
-    invalidate our possibly existing entries dictionary which is why it must be deleted
-    to allow it to be lazily reread later.
+    """Decorator for functions that alter the index using the git command.
 
-    :note:
-        This decorator is required because not all functions related to
-        :class:`~git.index.base.IndexFile` are implemented natively.
+    When a git command alters the index, this invalidates our possibly existing entries
+    dictionary, which is why it must be deleted to allow it to be lazily reread later.
     """
 
     @wraps(func)

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -34,8 +34,8 @@ unpack = struct.unpack
 
 
 class TemporaryFileSwap:
-    """Utility class moving a file to a temporary location within the same directory
-    and moving it back on to where on object deletion."""
+    """Utility class moving a file to a temporary location within the same directory and
+    moving it back on to where on object deletion."""
 
     __slots__ = ("file_path", "tmp_file_path")
 
@@ -66,12 +66,12 @@ class TemporaryFileSwap:
 
 def post_clear_cache(func: Callable[..., _T]) -> Callable[..., _T]:
     """Decorator for functions that alter the index using the git command. This would
-    invalidate our possibly existing entries dictionary which is why it must be
-    deleted to allow it to be lazily reread later.
+    invalidate our possibly existing entries dictionary which is why it must be deleted
+    to allow it to be lazily reread later.
 
     :note:
-        This decorator will not be required once all functions are implemented
-        natively which in fact is possible, but probably not feasible performance wise.
+        This decorator will not be required once all functions are implemented natively
+        which in fact is possible, but probably not feasible performance wise.
     """
 
     @wraps(func)

--- a/git/objects/__init__.py
+++ b/git/objects/__init__.py
@@ -14,8 +14,8 @@ from .submodule.root import *  # noqa: F403
 from .tag import *  # noqa: F403
 from .tree import *  # noqa: F403
 
-# Fix import dependency - add IndexObject to the util module, so that it can be
-# imported by the submodule.base.
+# Fix import dependency - add IndexObject to the util module, so that it can be imported
+# by the submodule.base.
 smutil.IndexObject = IndexObject  # type: ignore[attr-defined]  # noqa: F405
 smutil.Object = Object  # type: ignore[attr-defined]  # noqa: F405
 del smutil

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -226,7 +226,8 @@ class IndexObject(Object):
             Absolute path to this index object in the file system (as opposed to the
             :attr:`path` field which is a path relative to the git repository).
 
-            The returned path will be native to the system and contains '\' on Windows.
+            The returned path will be native to the system and contains ``\`` on
+            Windows.
         """
         if self.repo.working_tree_dir is not None:
             return join_path_native(self.repo.working_tree_dir, self.path)

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -98,7 +98,7 @@ class Object(LazyMixin):
             New object instance of a type appropriate to represent the given binary sha1
 
         :param sha1:
-            20 byte binary sha1
+            20 byte binary sha1.
         """
         if sha1 == cls.NULL_BIN_SHA:
             # The NULL binsha is always the root commit.

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -58,7 +58,7 @@ class Object(LazyMixin):
     def __init__(self, repo: "Repo", binsha: bytes):
         """Initialize an object by identifying it by its binary sha.
 
-        All keyword arguments will be set on demand if None.
+        All keyword arguments will be set on demand if ``None``.
 
         :param repo:
             Repository this object is located in.
@@ -83,7 +83,7 @@ class Object(LazyMixin):
             input id may have been a `~git.refs.reference.Reference` or rev-spec.
 
         :param id:
-            :class:`~git.refs.reference.Reference`, rev-spec, or hexsha
+            :class:`~git.refs.reference.Reference`, rev-spec, or hexsha.
 
         :note:
             This cannot be a ``__new__`` method as it would always call :meth:`__init__`
@@ -119,13 +119,13 @@ class Object(LazyMixin):
             super()._set_cache_(attr)
 
     def __eq__(self, other: Any) -> bool:
-        """:return: True if the objects have the same SHA1"""
+        """:return: ``True`` if the objects have the same SHA1"""
         if not hasattr(other, "binsha"):
             return False
         return self.binsha == other.binsha
 
     def __ne__(self, other: Any) -> bool:
-        """:return: True if the objects do not have the same SHA1"""
+        """:return: ``True`` if the objects do not have the same SHA1"""
         if not hasattr(other, "binsha"):
             return True
         return self.binsha != other.binsha
@@ -199,8 +199,8 @@ class IndexObject(Object):
             20 byte sha1.
 
         :param mode:
-            The stat compatible file mode as int, use the :mod:`stat` module to evaluate
-            the information.
+            The stat-compatible file mode as :class:`int`.
+            Use the :mod:`stat` module to evaluate the information.
 
         :param path:
             The path to the file in the file system, relative to the git repository

--- a/git/objects/base.py
+++ b/git/objects/base.py
@@ -37,7 +37,9 @@ __all__ = ("Object", "IndexObject")
 
 
 class Object(LazyMixin):
-    """An Object which may be Blobs, Trees, Commits and Tags."""
+    """An Object which may be :class:`~git.objects.blob.Blob`,
+    :class:`~git.objects.tree.Tree`, :class:`~git.objects.commit.Commit` or
+    `~git.objects.tag.TagObject`."""
 
     NULL_HEX_SHA = "0" * 40
     NULL_BIN_SHA = b"\0" * 20
@@ -55,11 +57,14 @@ class Object(LazyMixin):
 
     def __init__(self, repo: "Repo", binsha: bytes):
         """Initialize an object by identifying it by its binary sha.
+
         All keyword arguments will be set on demand if None.
 
-        :param repo: repository this object is located in
+        :param repo:
+            Repository this object is located in.
 
-        :param binsha: 20 byte SHA1
+        :param binsha:
+            20 byte SHA1
         """
         super().__init__()
         self.repo = repo
@@ -72,24 +77,28 @@ class Object(LazyMixin):
     @classmethod
     def new(cls, repo: "Repo", id: Union[str, "Reference"]) -> Commit_ish:
         """
-        :return: New :class:`Object`` instance of a type appropriate to the object type
-            behind `id`. The id of the newly created object will be a binsha even though
-            the input id may have been a Reference or Rev-Spec.
+        :return:
+            New :class:`Object` instance of a type appropriate to the object type behind
+            `id`. The id of the newly created object will be a binsha even though the
+            input id may have been a `~git.refs.reference.Reference` or rev-spec.
 
-        :param id: reference, rev-spec, or hexsha
+        :param id:
+            :class:`~git.refs.reference.Reference`, rev-spec, or hexsha
 
-        :note: This cannot be a ``__new__`` method as it would always call
-            :meth:`__init__` with the input id which is not necessarily a binsha.
+        :note:
+            This cannot be a ``__new__`` method as it would always call :meth:`__init__`
+            with the input id which is not necessarily a binsha.
         """
         return repo.rev_parse(str(id))
 
     @classmethod
     def new_from_sha(cls, repo: "Repo", sha1: bytes) -> Commit_ish:
         """
-        :return: new object instance of a type appropriate to represent the given
-            binary sha1
+        :return:
+            New object instance of a type appropriate to represent the given binary sha1
 
-        :param sha1: 20 byte binary sha1
+        :param sha1:
+            20 byte binary sha1
         """
         if sha1 == cls.NULL_BIN_SHA:
             # The NULL binsha is always the root commit.
@@ -126,11 +135,11 @@ class Object(LazyMixin):
         return hash(self.binsha)
 
     def __str__(self) -> str:
-        """:return: string of our SHA1 as understood by all git commands"""
+        """:return: String of our SHA1 as understood by all git commands"""
         return self.hexsha
 
     def __repr__(self) -> str:
-        """:return: string with pythonic representation of our object"""
+        """:return: String with pythonic representation of our object"""
         return '<git.%s "%s">' % (self.__class__.__name__, self.hexsha)
 
     @property
@@ -142,17 +151,22 @@ class Object(LazyMixin):
     @property
     def data_stream(self) -> "OStream":
         """
-        :return: File Object compatible stream to the uncompressed raw data of the object
+        :return:
+            File-object compatible stream to the uncompressed raw data of the object
 
-        :note: Returned streams must be read in order.
+        :note:
+            Returned streams must be read in order.
         """
         return self.repo.odb.stream(self.binsha)
 
     def stream_data(self, ostream: "OStream") -> "Object":
         """Write our data directly to the given output stream.
 
-        :param ostream: File object compatible stream object.
-        :return: self
+        :param ostream:
+            File-object compatible stream object.
+
+        :return:
+            self
         """
         istream = self.repo.odb.stream(self.binsha)
         stream_copy(istream, ostream)
@@ -160,8 +174,9 @@ class Object(LazyMixin):
 
 
 class IndexObject(Object):
-    """Base for all objects that can be part of the index file, namely Tree, Blob and
-    SubModule objects."""
+    """Base for all objects that can be part of the index file, namely
+    :class:`~git.objects.tree.Tree`, :class:`~git.objects.blob.Blob` and
+    :class:`~git.objects.submodule.base.Submodule` objects."""
 
     __slots__ = ("path", "mode")
 
@@ -175,16 +190,22 @@ class IndexObject(Object):
         mode: Union[None, int] = None,
         path: Union[None, PathLike] = None,
     ) -> None:
-        """Initialize a newly instanced IndexObject.
+        """Initialize a newly instanced :class:`IndexObject`.
 
-        :param repo: The :class:`~git.repo.base.Repo` we are located in.
-        :param binsha: 20 byte sha1.
+        :param repo:
+            The :class:`~git.repo.base.Repo` we are located in.
+
+        :param binsha:
+            20 byte sha1.
+
         :param mode:
             The stat compatible file mode as int, use the :mod:`stat` module to evaluate
             the information.
+
         :param path:
             The path to the file in the file system, relative to the git repository
             root, like ``file.ext`` or ``folder/other.ext``.
+
         :note:
             Path may not be set if the index object has been created directly, as it
             cannot be retrieved without knowing the parent tree.
@@ -198,8 +219,8 @@ class IndexObject(Object):
     def __hash__(self) -> int:
         """
         :return:
-            Hash of our path as index items are uniquely identifiable by path, not
-            by their data!
+            Hash of our path as index items are uniquely identifiable by path, not by
+            their data!
         """
         return hash(self.path)
 

--- a/git/objects/blob.py
+++ b/git/objects/blob.py
@@ -29,7 +29,8 @@ class Blob(base.IndexObject):
         """
         :return: String describing the mime type of this file (based on the filename)
 
-        :note: Defaults to 'text/plain' in case the actual file type is unknown.
+        :note:
+            Defaults to ``text/plain`` in case the actual file type is unknown.
         """
         guesses = None
         if self.path:

--- a/git/objects/blob.py
+++ b/git/objects/blob.py
@@ -27,7 +27,8 @@ class Blob(base.IndexObject):
     @property
     def mime_type(self) -> str:
         """
-        :return: String describing the mime type of this file (based on the filename)
+        :return:
+            String describing the mime type of this file (based on the filename)
 
         :note:
             Defaults to ``text/plain`` in case the actual file type is unknown.

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -108,11 +108,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         encoding: Union[str, None] = None,
         gpgsig: Union[str, None] = None,
     ) -> None:
-        R"""Instantiate a new :class:`Commit`. All keyword arguments taking None as
+        R"""Instantiate a new :class:`Commit`. All keyword arguments taking ``None`` as
         default will be implicitly set on first query.
 
         :param binsha:
-            20 byte sha1
+            20 byte sha1.
 
         :param parents: tuple(Commit, ...)
             A tuple of commit ids or actual :class:`Commit`\s.
@@ -120,8 +120,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         :param tree:
             A :class:`~git.objects.tree.Tree` object.
 
-        :param author: :class:`~git.util.Actor`
-            The author Actor object
+        :param author:
+            The author :class:`~git.util.Actor` object.
 
         :param authored_date: int_seconds_since_epoch
             The authored DateTime - use :func:`time.gmtime` to convert it into a
@@ -130,8 +130,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         :param author_tz_offset: int_seconds_west_of_utc
             The timezone that the `authored_date` is in.
 
-        :param committer: :class:`~git.util.Actor`
-            The committer string.
+        :param committer:
+            The committer string, as an :class:`~git.util.Actor` object.
 
         :param committed_date: int_seconds_since_epoch
             The committed DateTime - use :func:`time.gmtime` to convert it into a
@@ -209,7 +209,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         return istream.binsha
 
     def replace(self, **kwargs: Any) -> "Commit":
-        """Create new commit object from existing commit object.
+        """Create new commit object from an existing commit object.
 
         Any values provided as keyword arguments will replace the corresponding
         attribute in the new object.
@@ -295,7 +295,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         R"""Find all commits matching the given criteria.
 
         :param repo:
-            The Repo
+            The :class:`~git.repo.base.Repo`.
 
         :param rev:
             Revision specifier, see git-rev-parse for viable options.
@@ -378,7 +378,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     @property
     def trailers(self) -> Dict[str, str]:
-        """Get the trailers of the message as a dictionary
+        """Deprecated. Get the trailers of the message as a dictionary.
 
         :note: This property is deprecated, please use either :attr:`trailers_list` or
             :attr:`trailers_dict``.
@@ -396,7 +396,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         Git messages can contain trailer information that are similar to RFC 822 e-mail
         headers (see: https://git-scm.com/docs/git-interpret-trailers).
 
-        This functions calls ``git interpret-trailers --parse`` onto the message to
+        This function calls ``git interpret-trailers --parse`` onto the message to
         extract the trailer information, returns the raw trailer data as a list.
 
         Valid message with trailer::
@@ -444,7 +444,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         Git messages can contain trailer information that are similar to RFC 822 e-mail
         headers (see: https://git-scm.com/docs/git-interpret-trailers).
 
-        This functions calls ``git interpret-trailers --parse`` onto the message to
+        This function calls ``git interpret-trailers --parse`` onto the message to
         extract the trailer information. The key value pairs are stripped of leading and
         trailing whitespaces before they get saved into a dictionary.
 
@@ -481,7 +481,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def _iter_from_process_or_stream(cls, repo: "Repo", proc_or_stream: Union[Popen, IO]) -> Iterator["Commit"]:
         """Parse out commit information into a list of :class:`Commit` objects.
 
-        We expect one-line per commit, and parse the actual commit information directly
+        We expect one line per commit, and parse the actual commit information directly
         from our lighting fast object database.
 
         :param proc:
@@ -555,11 +555,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         :param parent_commits:
             Optional :class:`Commit` objects to use as parents for the new commit. If
             empty list, the commit will have no parents at all and become a root commit.
-            If None, the current head commit will be the parent of the new commit
+            If ``None``, the current head commit will be the parent of the new commit
             object.
 
         :param head:
-            If True, the HEAD will be advanced to the new commit automatically.
+            If ``True``, the HEAD will be advanced to the new commit automatically.
             Otherwise the HEAD will remain pointing on the previous commit. This could
             lead to undesired results when diffing files.
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -58,11 +58,11 @@ __all__ = ("Commit",)
 
 
 class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
+    """Wraps a git commit object.
 
-    """Wraps a git Commit object.
-
-    This class will act lazily on some of its attributes and will query the
-    value on demand only if it involves calling the git binary."""
+    This class will act lazily on some of its attributes and will query the value on
+    demand only if it involves calling the git binary.
+    """
 
     # ENVIRONMENT VARIABLES
     # Read when creating new commits.
@@ -108,41 +108,55 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         encoding: Union[str, None] = None,
         gpgsig: Union[str, None] = None,
     ) -> None:
-        """Instantiate a new Commit. All keyword arguments taking None as default will
-        be implicitly set on first query.
+        R"""Instantiate a new :class:`Commit`. All keyword arguments taking None as
+        default will be implicitly set on first query.
 
-        :param binsha: 20 byte sha1
+        :param binsha:
+            20 byte sha1
+
         :param parents: tuple(Commit, ...)
-            A tuple of commit ids or actual Commits
-        :param tree: Tree object
-        :param author: Actor
-            The author Actor object
-        :param authored_date: int_seconds_since_epoch
-            The authored DateTime - use time.gmtime() to convert it into a
-            different format
-        :param author_tz_offset: int_seconds_west_of_utc
-            The timezone that the authored_date is in
-        :param committer: Actor
-            The committer string
-        :param committed_date: int_seconds_since_epoch
-            The committed DateTime - use time.gmtime() to convert it into a
-            different format
-        :param committer_tz_offset: int_seconds_west_of_utc
-            The timezone that the committed_date is in
-        :param message: string
-            The commit message
-        :param encoding: string
-            Encoding of the message, defaults to UTF-8
-        :param parents:
-            List or tuple of Commit objects which are our parent(s) in the commit
-            dependency graph
+            A tuple of commit ids or actual :class:`Commit`\s.
 
-        :return: git.Commit
+        :param tree:
+            A :class:`~git.objects.tree.Tree` object.
+
+        :param author: :class:`~git.util.Actor`
+            The author Actor object
+
+        :param authored_date: int_seconds_since_epoch
+            The authored DateTime - use :func:`time.gmtime` to convert it into a
+            different format.
+
+        :param author_tz_offset: int_seconds_west_of_utc
+            The timezone that the `authored_date` is in.
+
+        :param committer: :class:`~git.util.Actor`
+            The committer string.
+
+        :param committed_date: int_seconds_since_epoch
+            The committed DateTime - use :func:`time.gmtime` to convert it into a
+            different format.
+
+        :param committer_tz_offset: int_seconds_west_of_utc
+            The timezone that the `committed_date` is in.
+
+        :param message: string
+            The commit message.
+
+        :param encoding: string
+            Encoding of the message, defaults to UTF-8.
+
+        :param parents:
+            List or tuple of :class:`Commit` objects which are our parent(s) in the
+            commit dependency graph.
+
+        :return:
+            :class:`Commit`
 
         :note:
-            Timezone information is in the same format and in the same sign
-            as what time.altzone returns. The sign is inverted compared to git's
-            UTC timezone.
+            Timezone information is in the same format and in the same sign as what
+            :func:`time.altzone` returns. The sign is inverted compared to git's UTC
+            timezone.
         """
         super().__init__(repo, binsha)
         self.binsha = binsha
@@ -179,8 +193,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def _calculate_sha_(cls, repo: "Repo", commit: "Commit") -> bytes:
         """Calculate the sha of a commit.
 
-        :param repo: Repo object the commit should be part of
-        :param commit: Commit object for which to generate the sha
+        :param repo:
+            :class:`~git.repo.base.Repo` object the commit should be part of.
+
+        :param commit:
+            :class:`Commit` object for which to generate the sha.
         """
 
         stream = BytesIO()
@@ -194,8 +211,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def replace(self, **kwargs: Any) -> "Commit":
         """Create new commit object from existing commit object.
 
-        Any values provided as keyword arguments will replace the
-        corresponding attribute in the new object.
+        Any values provided as keyword arguments will replace the corresponding
+        attribute in the new object.
         """
 
         attrs = {k: getattr(self, k) for k in self.__slots__}
@@ -239,17 +256,18 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """Count the number of commits reachable from this commit.
 
         :param paths:
-            An optional path or a list of paths restricting the return value
-            to commits actually containing the paths.
+            An optional path or a list of paths restricting the return value to commits
+            actually containing the paths.
 
         :param kwargs:
-            Additional options to be passed to git-rev-list. They must not alter
-            the output style of the command, or parsing will yield incorrect results.
+            Additional options to be passed to ``git rev-list``. They must not alter the
+            output style of the command, or parsing will yield incorrect results.
 
-        :return: An int defining the number of reachable commits
+        :return:
+            An int defining the number of reachable commits
         """
-        # Yes, it makes a difference whether empty paths are given or not in our case
-        # as the empty paths version will ignore merge commits for some reason.
+        # Yes, it makes a difference whether empty paths are given or not in our case as
+        # the empty paths version will ignore merge commits for some reason.
         if paths:
             return len(self.repo.git.rev_list(self.hexsha, "--", paths, **kwargs).splitlines())
         return len(self.repo.git.rev_list(self.hexsha, **kwargs).splitlines())
@@ -258,8 +276,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def name_rev(self) -> str:
         """
         :return:
-            String describing the commits hex sha based on the closest Reference.
-            Mostly useful for UI purposes
+            String describing the commits hex sha based on the closest
+            `~git.refs.reference.Reference`.
+
+        :note:
+            Mostly useful for UI purposes.
         """
         return self.repo.git.name_rev(self)
 
@@ -271,24 +292,27 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         paths: Union[PathLike, Sequence[PathLike]] = "",
         **kwargs: Any,
     ) -> Iterator["Commit"]:
-        """Find all commits matching the given criteria.
+        R"""Find all commits matching the given criteria.
 
-        :param repo: The Repo
+        :param repo:
+            The Repo
 
-        :param rev: Revision specifier, see git-rev-parse for viable options.
+        :param rev:
+            Revision specifier, see git-rev-parse for viable options.
 
         :param paths:
-            An optional path or list of paths, if set only Commits that include the path
-            or paths will be considered.
+            An optional path or list of paths. If set only :class:`Commit`\s that
+            include the path or paths will be considered.
 
         :param kwargs:
             Optional keyword arguments to ``git rev-list`` where:
 
-            * ``max_count`` is the maximum number of commits to fetch
-            * ``skip`` is the number of commits to skip
-            * ``since`` all commits since e.g. '1970-01-01'
+            * ``max_count`` is the maximum number of commits to fetch.
+            * ``skip`` is the number of commits to skip.
+            * ``since`` all commits since e.g. '1970-01-01'.
 
-        :return: Iterator yielding :class:`Commit` items.
+        :return:
+            Iterator yielding :class:`Commit` items.
         """
         if "pretty" in kwargs:
             raise ValueError("--pretty cannot be used as parsing expects single sha's only")
@@ -313,13 +337,17 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         return cls._iter_from_process_or_stream(repo, proc)
 
     def iter_parents(self, paths: Union[PathLike, Sequence[PathLike]] = "", **kwargs: Any) -> Iterator["Commit"]:
-        """Iterate _all_ parents of this commit.
+        R"""Iterate _all_ parents of this commit.
 
         :param paths:
-            Optional path or list of paths limiting the Commits to those that
-            contain at least one of the paths
-        :param kwargs: All arguments allowed by git-rev-list
-        :return: Iterator yielding Commit objects which are parents of self
+            Optional path or list of paths limiting the :class:`Commit`\s to those that
+            contain at least one of the paths.
+
+        :param kwargs:
+            All arguments allowed by ``git rev-list``.
+
+        :return:
+            Iterator yielding :class:`Commit` objects which are parents of ``self``
         """
         # skip ourselves
         skip = kwargs.get("skip", 1)
@@ -334,7 +362,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         """Create a git stat from changes between this commit and its first parent
         or from all changes done if this is the very first commit.
 
-        :return: git.Stats
+        :return:
+            :class:`Stats`
         """
         if not self.parents:
             text = self.repo.git.diff_tree(self.hexsha, "--", numstat=True, no_renames=True, root=True)
@@ -364,11 +393,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def trailers_list(self) -> List[Tuple[str, str]]:
         """Get the trailers of the message as a list.
 
-        Git messages can contain trailer information that are similar to RFC 822
-        e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
+        Git messages can contain trailer information that are similar to RFC 822 e-mail
+        headers (see: https://git-scm.com/docs/git-interpret-trailers).
 
-        This functions calls ``git interpret-trailers --parse`` onto the message
-        to extract the trailer information, returns the raw trailer data as a list.
+        This functions calls ``git interpret-trailers --parse`` onto the message to
+        extract the trailer information, returns the raw trailer data as a list.
 
         Valid message with trailer::
 
@@ -382,7 +411,6 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             key1: value1.2
             key2 :    value 2 with inner spaces
 
-
         Returned list will look like this::
 
             [
@@ -390,7 +418,6 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 ("key1", "value1.2"),
                 ("key2", "value 2 with inner spaces"),
             ]
-
 
         :return:
             List containing key-value tuples of whitespace stripped trailer information.
@@ -414,12 +441,12 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def trailers_dict(self) -> Dict[str, List[str]]:
         """Get the trailers of the message as a dictionary.
 
-        Git messages can contain trailer information that are similar to RFC 822
-        e-mail headers (see: https://git-scm.com/docs/git-interpret-trailers).
+        Git messages can contain trailer information that are similar to RFC 822 e-mail
+        headers (see: https://git-scm.com/docs/git-interpret-trailers).
 
-        This functions calls ``git interpret-trailers --parse`` onto the message
-        to extract the trailer information. The key value pairs are stripped of
-        leading and trailing whitespaces before they get saved into a dictionary.
+        This functions calls ``git interpret-trailers --parse`` onto the message to
+        extract the trailer information. The key value pairs are stripped of leading and
+        trailing whitespaces before they get saved into a dictionary.
 
         Valid message with trailer::
 
@@ -433,7 +460,6 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             key1: value1.2
             key2 :    value 2 with inner spaces
 
-
         Returned dictionary will look like this::
 
             {
@@ -443,8 +469,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
 
         :return:
-            Dictionary containing whitespace stripped trailer information.
-            Mapping trailer keys to a list of their corresponding values.
+            Dictionary containing whitespace stripped trailer information, mapping
+            trailer keys to a list of their corresponding values.
         """
         d = defaultdict(list)
         for key, val in self.trailers_list:
@@ -453,13 +479,16 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     @classmethod
     def _iter_from_process_or_stream(cls, repo: "Repo", proc_or_stream: Union[Popen, IO]) -> Iterator["Commit"]:
-        """Parse out commit information into a list of Commit objects.
+        """Parse out commit information into a list of :class:`Commit` objects.
 
         We expect one-line per commit, and parse the actual commit information directly
         from our lighting fast object database.
 
-        :param proc: git-rev-list process instance - one sha per line
-        :return: iterator supplying :class:`Commit` objects
+        :param proc:
+            ``git rev-list`` process instance - one sha per line.
+
+        :return:
+            Iterator supplying :class:`Commit` objects
         """
 
         # def is_proc(inp) -> TypeGuard[Popen]:
@@ -491,8 +520,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             yield cls(repo, hex_to_bin(hexsha))
         # END for each line in stream
 
-        # TODO: Review this - it seems process handling got a bit out of control
-        # due to many developers trying to fix the open file handles issue.
+        # TODO: Review this - it seems process handling got a bit out of control due to
+        # many developers trying to fix the open file handles issue.
         if hasattr(proc_or_stream, "wait"):
             proc_or_stream = cast(Popen, proc_or_stream)
             finalize_process(proc_or_stream)
@@ -512,33 +541,49 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     ) -> "Commit":
         """Commit the given tree, creating a commit object.
 
-        :param repo: Repo object the commit should be part of
-        :param tree: Tree object or hex or bin sha. The tree of the new commit.
-        :param message: Commit message. It may be an empty string if no message is
-            provided. It will be converted to a string, in any case.
+        :param repo:
+            :class:`~git.repo.base.Repo` object the commit should be part of.
+
+        :param tree:
+            :class:`~git.objects.tree.Tree` object or hex or bin sha.
+            The tree of the new commit.
+
+        :param message:
+            Commit message. It may be an empty string if no message is provided. It will
+            be converted to a string, in any case.
+
         :param parent_commits:
-            Optional :class:`Commit` objects to use as parents for the new commit.
-            If empty list, the commit will have no parents at all and become
-            a root commit.
-            If None, the current head commit will be the parent of the
-            new commit object.
+            Optional :class:`Commit` objects to use as parents for the new commit. If
+            empty list, the commit will have no parents at all and become a root commit.
+            If None, the current head commit will be the parent of the new commit
+            object.
+
         :param head:
             If True, the HEAD will be advanced to the new commit automatically.
             Otherwise the HEAD will remain pointing on the previous commit. This could
             lead to undesired results when diffing files.
-        :param author: The name of the author, optional. If unset, the repository
-            configuration is used to obtain this value.
-        :param committer: The name of the committer, optional. If unset, the
-            repository configuration is used to obtain this value.
-        :param author_date: The timestamp for the author field.
-        :param commit_date: The timestamp for the committer field.
 
-        :return: Commit object representing the new commit.
+        :param author:
+            The name of the author, optional.
+            If unset, the repository configuration is used to obtain this value.
+
+        :param committer:
+            The name of the committer, optional.
+            If unset, the repository configuration is used to obtain this value.
+
+        :param author_date:
+            The timestamp for the author field.
+
+        :param commit_date:
+            The timestamp for the committer field.
+
+        :return:
+            :class:`Commit` object representing the new commit.
 
         :note:
-            Additional information about the committer and Author are taken from the
-            environment or from the git configuration, see git-commit-tree for
-            more information.
+            Additional information about the committer and author are taken from the
+            environment or from the git configuration. See git-commit-tree for more
+            information.
         """
         if parent_commits is None:
             try:
@@ -595,8 +640,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         if not isinstance(conf_encoding, str):
             raise TypeError("conf_encoding could not be coerced to str")
 
-        # If the tree is no object, make sure we create one - otherwise
-        # the created commit object is invalid.
+        # If the tree is no object, make sure we create one - otherwise the created
+        # commit object is invalid.
         if isinstance(tree, str):
             tree = repo.tree(tree)
         # END tree conversion
@@ -620,8 +665,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         new_commit.binsha = cls._calculate_sha_(repo, new_commit)
 
         if head:
-            # Need late import here, importing git at the very beginning throws
-            # as well...
+            # Need late import here, importing git at the very beginning throws as
+            # well...
             import git.refs
 
             try:
@@ -718,7 +763,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         # END for each parent line
         self.parents = tuple(self.parents)
 
-        # We don't know actual author encoding before we have parsed it, so keep the lines around.
+        # We don't know actual author encoding before we have parsed it, so keep the
+        # lines around.
         author_line = next_line
         committer_line = readline()
 
@@ -730,7 +776,8 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
                 next_line = readline()
         # END skip mergetags
 
-        # Now we can have the encoding line, or an empty line followed by the optional message.
+        # Now we can have the encoding line, or an empty line followed by the optional
+        # message.
         self.encoding = self.default_encoding
         self.gpgsig = ""
 
@@ -808,12 +855,13 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
     @property
     def co_authors(self) -> List[Actor]:
-        """
-        Search the commit message for any co-authors of this commit.
+        """Search the commit message for any co-authors of this commit.
 
-        Details on co-authors: https://github.blog/2018-01-29-commit-together-with-co-authors/
+        Details on co-authors:
+        https://github.blog/2018-01-29-commit-together-with-co-authors/
 
-        :return: List of co-authors for this commit (as Actor objects).
+        :return:
+            List of co-authors for this commit (as :class:`~git.util.Actor` objects).
         """
         co_authors = []
 

--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -298,7 +298,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
             The :class:`~git.repo.base.Repo`.
 
         :param rev:
-            Revision specifier, see git-rev-parse for viable options.
+            Revision specifier. See git-rev-parse for viable options.
 
         :param paths:
             An optional path or list of paths. If set only :class:`Commit`\s that
@@ -309,7 +309,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
 
             * ``max_count`` is the maximum number of commits to fetch.
             * ``skip`` is the number of commits to skip.
-            * ``since`` all commits since e.g. '1970-01-01'.
+            * ``since`` selects all commits since some date, e.g. ``"1970-01-01"``.
 
         :return:
             Iterator yielding :class:`Commit` items.
@@ -380,12 +380,13 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
     def trailers(self) -> Dict[str, str]:
         """Deprecated. Get the trailers of the message as a dictionary.
 
-        :note: This property is deprecated, please use either :attr:`trailers_list` or
-            :attr:`trailers_dict``.
+        :note:
+            This property is deprecated, please use either :attr:`trailers_list` or
+            :attr:`trailers_dict`.
 
         :return:
-            Dictionary containing whitespace stripped trailer information. Only contains
-            the latest instance of each trailer key.
+            Dictionary containing whitespace stripped trailer information.
+            Only contains the latest instance of each trailer key.
         """
         return {k: v[0] for k, v in self.trailers_dict.items()}
 
@@ -539,7 +540,7 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         author_date: Union[None, str, datetime.datetime] = None,
         commit_date: Union[None, str, datetime.datetime] = None,
     ) -> "Commit":
-        """Commit the given tree, creating a commit object.
+        """Commit the given tree, creating a :class:`Commit` object.
 
         :param repo:
             :class:`~git.repo.base.Repo` object the commit should be part of.

--- a/git/objects/fun.py
+++ b/git/objects/fun.py
@@ -186,8 +186,8 @@ def traverse_trees_recursive(
         given tree.
 
     :param tree_shas:
-        Iterable of shas pointing to trees. All trees must be on the same level. A
-        tree-sha may be ``None`` in which case ``None``.
+        Iterable of shas pointing to trees. All trees must be on the same level.
+        A tree-sha may be ``None``, in which case ``None``.
 
     :param path_prefix:
         A prefix to be added to the returned paths on this level.

--- a/git/objects/fun.py
+++ b/git/objects/fun.py
@@ -128,7 +128,7 @@ def tree_entries_from_data(data: bytes) -> List[EntryTup]:
 
 
 def _find_by_name(tree_data: MutableSequence[EntryTupOrNone], name: str, is_dir: bool, start_at: int) -> EntryTupOrNone:
-    """Return data entry matching the given name and tree mode or None.
+    """Return data entry matching the given name and tree mode or ``None``.
 
     Before the item is returned, the respective data item is set None in the `tree_data`
     list to mark it done.
@@ -172,7 +172,8 @@ def traverse_trees_recursive(
     odb: "GitCmdObjectDB", tree_shas: Sequence[Union[bytes, None]], path_prefix: str
 ) -> List[Tuple[EntryTupOrNone, ...]]:
     """
-    :return: list of list with entries according to the given binary tree-shas.
+    :return:
+        List of list with entries according to the given binary tree-shas.
 
         The result is encoded in a list
         of n tuple|None per blob/commit, (n == len(tree_shas)), where:
@@ -181,12 +182,12 @@ def traverse_trees_recursive(
         * [1] == mode as int
         * [2] == path relative to working tree root
 
-        The entry tuple is None if the respective blob/commit did not exist in the given
-        tree.
+        The entry tuple is ``None`` if the respective blob/commit did not exist in the
+        given tree.
 
     :param tree_shas:
         Iterable of shas pointing to trees. All trees must be on the same level. A
-        tree-sha may be None in which case None.
+        tree-sha may be ``None`` in which case ``None``.
 
     :param path_prefix:
         A prefix to be added to the returned paths on this level.
@@ -257,7 +258,8 @@ def traverse_trees_recursive(
 
 def traverse_tree_recursive(odb: "GitCmdObjectDB", tree_sha: bytes, path_prefix: str) -> List[EntryTup]:
     """
-    :return: list of entries of the tree pointed to by the binary `tree_sha`.
+    :return:
+        List of entries of the tree pointed to by the binary `tree_sha`.
 
         An entry has the following format:
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -266,8 +266,8 @@ class Submodule(IndexObject, TraversableIterableObj):
     def _sio_modules(cls, parent_commit: Commit_ish) -> BytesIO:
         """
         :return:
-            Configuration file as BytesIO - we only access it through the respective
-            blob's data
+            Configuration file as :class:`~io.BytesIO` - we only access it through the
+            respective blob's data
         """
         sio = BytesIO(parent_commit.tree[cls.k_modules_file].data_stream.read())
         sio.name = cls.k_modules_file
@@ -354,7 +354,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         """:return: a path guaranteed to be relative to the given parent repository
 
         :raise ValueError:
-            If path is not contained in the parent repository's working tree
+            If path is not contained in the parent repository's working tree.
         """
         path = to_native_path_linux(path)
         if path.endswith("/"):
@@ -378,8 +378,8 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _write_git_file_and_module_config(cls, working_tree_dir: PathLike, module_abspath: PathLike) -> None:
-        """Write a .git file containing a (preferably) relative path to the actual git
-        module repository.
+        """Write a ``.git`` file containing a (preferably) relative path to the actual
+        git module repository.
 
         It is an error if the `module_abspath` cannot be made into a relative path,
         relative to the `working_tree_dir`.
@@ -430,10 +430,10 @@ class Submodule(IndexObject, TraversableIterableObj):
         allow_unsafe_options: bool = False,
         allow_unsafe_protocols: bool = False,
     ) -> "Submodule":
-        """Add a new submodule to the given repository. This will alter the index
-        as well as the ``.gitmodules`` file, but will not create a new commit.
-        If the submodule already exists, no matter if the configuration differs
-        from the one provided, the existing submodule will be returned.
+        """Add a new submodule to the given repository. This will alter the index as
+        well as the ``.gitmodules`` file, but will not create a new commit. If the
+        submodule already exists, no matter if the configuration differs from the one
+        provided, the existing submodule will be returned.
 
         :param repo:
             Repository instance which should receive the submodule.
@@ -448,23 +448,23 @@ class Submodule(IndexObject, TraversableIterableObj):
 
         :param url:
             git-clone compatible URL, see git-clone reference for more information.
-            If None, the repository is assumed to exist, and the url of the first remote
-            is taken instead. This is useful if you want to make an existing repository
-            a submodule of another one.
+            If ``None```, the repository is assumed to exist, and the url of the first
+            remote is taken instead. This is useful if you want to make an existing
+            repository a submodule of another one.
 
         :param branch:
             Name of branch at which the submodule should (later) be checked out. The
             given branch must exist in the remote repository, and will be checked out
             locally as a tracking branch.
-            It will only be written into the configuration if it not None, which is when
-            the checked out branch will be the one the remote HEAD pointed to.
+            It will only be written into the configuration if it not ``None``, which is
+            when the checked out branch will be the one the remote HEAD pointed to.
             The result you get in these situation is somewhat fuzzy, and it is
             recommended to specify at least ``master`` here.
             Examples are ``master`` or ``feature/new``.
 
         :param no_checkout:
-            If True, and if the repository has to be cloned manually, no checkout will
-            be performed.
+            If ``True``, and if the repository has to be cloned manually, no checkout
+            will be performed.
 
         :param depth:
             Create a shallow clone with a history truncated to the specified number of
@@ -479,7 +479,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             want to unset some variable, consider providing an empty string as its
             value.
 
-        :param clone_multi_options: A list of Clone options. Please see
+        :param clone_multi_options:
+            A list of clone options. Please see
             :meth:`Repo.clone <git.repo.base.Repo.clone>` for details.
 
         :param allow_unsafe_protocols:
@@ -632,44 +633,49 @@ class Submodule(IndexObject, TraversableIterableObj):
         with the binsha of this instance.
 
         :param recursive:
-            If True, we will operate recursively and update child modules as well.
+            If ``True``, we will operate recursively and update child modules as well.
 
         :param init:
-            If True, the module repository will be cloned into place if necessary.
+            If ``True``, the module repository will be cloned into place if necessary.
 
         :param to_latest_revision:
-            If True, the submodule's sha will be ignored during checkout. Instead, the
-            remote will be fetched, and the local tracking branch updated. This only
+            If ``True``, the submodule's sha will be ignored during checkout. Instead,
+            the remote will be fetched, and the local tracking branch updated. This only
             works if we have a local tracking branch, which is the case if the remote
-            repository had a master branch, or of the 'branch' option was specified for
-            this submodule and the branch existed remotely.
+            repository had a master branch, or of the ``branch`` option was specified
+            for this submodule and the branch existed remotely.
 
         :param progress:
-            :class:`UpdateProgress` instance, or None if no progress should be shown.
+            :class:`UpdateProgress` instance, or ``None`` if no progress should be
+            shown.
 
         :param dry_run:
-            If True, the operation will only be simulated, but not performed.
+            If ``True``, the operation will only be simulated, but not performed.
             All performed operations are read-only.
 
         :param force:
-            If True, we may reset heads even if the repository in question is dirty.
+            If ``True``, we may reset heads even if the repository in question is dirty.
             Additionally we will be allowed to set a tracking branch which is ahead of
             its remote branch back into the past or the location of the remote branch.
             This will essentially 'forget' commits.
-            If False, local tracking branches that are in the future of their respective
-            remote branches will simply not be moved.
+
+            If ``False``, local tracking branches that are in the future of their
+            respective remote branches will simply not be moved.
 
         :param keep_going:
-            If True, we will ignore but log all errors, and keep going recursively.
+            If ``True``, we will ignore but log all errors, and keep going recursively.
             Unless `dry_run` is set as well, `keep_going` could cause
             subsequent/inherited errors you wouldn't see otherwise.
             In conjunction with `dry_run`, it can be useful to anticipate all errors
             when updating submodules.
 
-        :param env: Optional dictionary containing the desired environment variables.
+        :param env:
+            Optional dictionary containing the desired environment variables.
+
             Note: Provided variables will be used to update the execution environment
             for ``git``. If some variable is not specified in `env` and is defined in
             attr:`os.environ`, value from attr:`os.environ` will be used.
+
             If you want to unset some variable, consider providing the empty string as
             its value.
 
@@ -688,7 +694,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             Does nothing in bare repositories.
 
         :note:
-            This method is definitely not atomic if `recursive` is True.
+            This method is definitely not atomic if `recursive` is ``True``.
 
         :return:
             self
@@ -950,18 +956,18 @@ class Submodule(IndexObject, TraversableIterableObj):
 
         :param module_path:
             The path to which to move our module in the parent repository's working
-            tree, given as repository - relative or absolute path. Intermediate
+            tree, given as repository-relative or absolute path. Intermediate
             directories will be created accordingly. If the path already exists, it must
             be empty. Trailing (back)slashes are removed automatically.
 
         :param configuration:
-            If True, the configuration will be adjusted to let the submodule point to
-            the given path.
+            If ``True``, the configuration will be adjusted to let the submodule point
+            to the given path.
 
         :param module:
-            If True, the repository managed by this submodule will be moved as well. If
-            False, we don't move the submodule's checkout, which may leave the parent
-            repository in an inconsistent state.
+            If ``True``, the repository managed by this submodule will be moved as well.
+            If ``False``, we don't move the submodule's checkout, which may leave the
+            parent repository in an inconsistent state.
 
         :return:
             self
@@ -1074,12 +1080,13 @@ class Submodule(IndexObject, TraversableIterableObj):
         from the ``.gitmodules`` file and the entry in the ``.git/config`` file.
 
         :param module:
-            If True, the checked out module we point to will be deleted as well. If that
-            module is currently on a commit outside any branch in the remote, or if it
-            is ahead of its tracking branch, or if there are modified or untracked files
-            in its working tree, then the removal will fail. In case the removal of the
-            repository fails for these reasons, the submodule status will not have been
-            altered.
+            If ``True``, the checked out module we point to will be deleted as well. If
+            that module is currently on a commit outside any branch in the remote, or if
+            it is ahead of its tracking branch, or if there are modified or untracked
+            files in its working tree, then the removal will fail. In case the removal
+            of the repository fails for these reasons, the submodule status will not
+            have been altered.
+
             If this submodule has child modules of its own, these will be deleted prior
             to touching the direct submodule.
 
@@ -1088,12 +1095,12 @@ class Submodule(IndexObject, TraversableIterableObj):
             This basically enforces a brute-force file system based deletion.
 
         :param configuration:
-            If True, the submodule is deleted from the configuration, otherwise it
+            If ``True``, the submodule is deleted from the configuration, otherwise it
             isn't. Although this should be enabled most of the time, this flag enables
             you to safely delete the repository of your submodule.
 
         :param dry_run:
-            If True, we will not actually do anything, but throw the errors we would
+            If ``True``, we will not actually do anything, but throw the errors we would
             usually throw.
 
         :return:
@@ -1239,12 +1246,12 @@ class Submodule(IndexObject, TraversableIterableObj):
         contain the ``.gitmodules`` blob.
 
         :param commit:
-            Commit-ish reference pointing at the root_tree, or None to always point to
-            the most recent commit
+            Commit-ish reference pointing at the root_tree, or ``None`` to always point
+            to the most recent commit.
 
         :param check:
-            If True, relatively expensive checks will be performed to verify validity of
-            the submodule.
+            If ``True``, relatively expensive checks will be performed to verify
+            validity of the submodule.
 
         :raise ValueError:
             If the commit's tree didn't contain the ``.gitmodules`` blob.
@@ -1297,8 +1304,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             to this submodule into the ``.gitmodules`` file.
 
         :param index:
-            If not None, an IndexFile instance which should be written.
-            Defaults to the index of the Submodule's parent repository.
+            If not ``None``, an :class:`~git.index.base.IndexFile` instance which should
+            be written. Defaults to the index of the :class:`Submodule`'s parent
+            repository.
 
         :param write:
             If True, the index will be written each time a configuration value changes.
@@ -1380,7 +1388,9 @@ class Submodule(IndexObject, TraversableIterableObj):
     @unbare_repo
     def module(self) -> "Repo":
         """
-        :return: Repo instance initialized from the repository at our submodule path
+        :return:
+            :class:`~git.repo.base.Repo` instance initialized from the repository at our
+            submodule path
 
         :raise git.exc.InvalidGitRepositoryError:
             If a repository was not available.
@@ -1401,7 +1411,7 @@ class Submodule(IndexObject, TraversableIterableObj):
     def module_exists(self) -> bool:
         """
         :return:
-            True if our module exists and is a valid git repository.
+            ``True`` if our module exists and is a valid git repository.
             See the :meth:`module` method.
         """
         try:
@@ -1414,7 +1424,7 @@ class Submodule(IndexObject, TraversableIterableObj):
     def exists(self) -> bool:
         """
         :return:
-            True if the submodule exists, False otherwise.
+            ``True`` if the submodule exists, ``False`` otherwise.
             Please note that a submodule may exist (in the ``.gitmodules`` file) even
             though its module doesn't exist on disk.
         """
@@ -1480,14 +1490,15 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @property
     def url(self) -> str:
-        """:return: The url to the repository which our module - repository refers to"""
+        """:return: The url to the repository our submodule's repository refers to"""
         return self._url
 
     @property
     def parent_commit(self) -> "Commit_ish":
         """
         :return:
-            Commit instance with the tree containing the ``.gitmodules`` file
+            :class:`~git.objects.commit.Commit` instance with the tree containing the
+            ``.gitmodules`` file
 
         :note:
             Will always point to the current head's commit if it was not set explicitly.
@@ -1531,8 +1542,9 @@ class Submodule(IndexObject, TraversableIterableObj):
     def children(self) -> IterableList["Submodule"]:
         """
         :return:
-            IterableList(Submodule, ...) An iterable list of submodules instances which
-            are children of this submodule or 0 if the submodule is not checked out.
+            IterableList(Submodule, ...) An iterable list of :class:`Submodule`
+            instances which are children of this submodule or 0 if the submodule is not
+            checked out.
         """
         return self._get_intermediate_items(self)
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -133,8 +133,9 @@ class Submodule(IndexObject, TraversableIterableObj):
         :param url:
             The URL to the remote repository which is the submodule.
 
-        :param branch_path: Complete relative path to ref to checkout when cloning the
-            remote repository.
+        :param branch_path:
+            Complete relative path to ref to checkout when cloning the remote
+            repository.
         """
         super().__init__(repo, binsha, mode, path)
         self.size = 0
@@ -214,10 +215,12 @@ class Submodule(IndexObject, TraversableIterableObj):
         cls, repo: "Repo", parent_commit: Union[Commit_ish, None], read_only: bool
     ) -> SubmoduleConfigParser:
         """
-        :return: Config Parser constrained to our submodule in read or write mode
+        :return:
+            Config parser constrained to our submodule in read or write mode
 
-        :raise IOError: If the .gitmodules file cannot be found, either locally or in
-            the repository at the given parent commit. Otherwise the exception would be
+        :raise IOError:
+            If the ``.gitmodules`` file cannot be found, either locally or in the
+            repository at the given parent commit. Otherwise the exception would be
             delayed until the first access of the config parser.
         """
         parent_matches_head = True
@@ -225,7 +228,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             try:
                 parent_matches_head = repo.head.commit == parent_commit
             except ValueError:
-                # We are most likely in an empty repository, so the HEAD doesn't point to a valid ref.
+                # We are most likely in an empty repository, so the HEAD doesn't point
+                # to a valid ref.
                 pass
         # END handle parent_commit
         fp_module: Union[str, BytesIO]
@@ -260,13 +264,17 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _sio_modules(cls, parent_commit: Commit_ish) -> BytesIO:
-        """:return: Configuration file as BytesIO - we only access it through the respective blob's data"""
+        """
+        :return:
+            Configuration file as BytesIO - we only access it through the respective
+            blob's data
+        """
         sio = BytesIO(parent_commit.tree[cls.k_modules_file].data_stream.read())
         sio.name = cls.k_modules_file
         return sio
 
     def _config_parser_constrained(self, read_only: bool) -> SectionConstraint:
-        """:return: Config Parser constrained to our submodule in read or write mode"""
+        """:return: Config parser constrained to our submodule in read or write mode"""
         try:
             pc: Union["Commit_ish", None] = self.parent_commit
         except ValueError:
@@ -296,14 +304,29 @@ class Submodule(IndexObject, TraversableIterableObj):
         **kwargs: Any,
     ) -> "Repo":
         """
-        :return: Repo instance of newly cloned repository
-        :param repo: Our parent repository
-        :param url: URL to clone from
-        :param path: Repository - relative path to the submodule checkout location
-        :param name: Canonical name of the submodule
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :param kwargs: Additional arguments given to git.clone
+        :return:
+            :class:`~git.repo.base.Repo` instance of newly cloned repository.
+
+        :param repo:
+            Our parent repository.
+
+        :param url:
+            URL to clone from.
+
+        :param path:
+            Repository-relative path to the submodule checkout location.
+
+        :param name:
+            Canonical name of the submodule.
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
+
+        :param kwargs:
+            Additional arguments given to ``git clone``
         """
         module_abspath = cls._module_abspath(repo, path, name)
         module_checkout_path = module_abspath
@@ -328,8 +351,11 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _to_relative_path(cls, parent_repo: "Repo", path: PathLike) -> PathLike:
-        """:return: a path guaranteed  to be relative to the given parent - repository
-        :raise ValueError: if path is not contained in the parent repository's working tree"""
+        """:return: a path guaranteed to be relative to the given parent repository
+
+        :raise ValueError:
+            If path is not contained in the parent repository's working tree
+        """
         path = to_native_path_linux(path)
         if path.endswith("/"):
             path = path[:-1]
@@ -352,16 +378,26 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _write_git_file_and_module_config(cls, working_tree_dir: PathLike, module_abspath: PathLike) -> None:
-        """Write a .git file containing a(preferably) relative path to the actual git module repository.
+        """Write a .git file containing a (preferably) relative path to the actual git
+        module repository.
 
-        It is an error if the module_abspath cannot be made into a relative path, relative to the working_tree_dir
+        It is an error if the `module_abspath` cannot be made into a relative path,
+        relative to the `working_tree_dir`.
 
-        :note: This will overwrite existing files!
-        :note: as we rewrite both the git file as well as the module configuration, we might fail on the configuration
-            and will not roll back changes done to the git file. This should be a non - issue, but may easily be fixed
-            if it becomes one.
-        :param working_tree_dir: Directory to write the .git file into
-        :param module_abspath: Absolute path to the bare repository
+        :note:
+            This will overwrite existing files!
+
+        :note:
+            As we rewrite both the git file as well as the module configuration, we
+            might fail on the configuration and will not roll back changes done to the
+            git file. This should be a non-issue, but may easily be fixed if it becomes
+            one.
+
+        :param working_tree_dir:
+            Directory to write the ``.git`` file into.
+
+        :param module_abspath:
+            Absolute path to the bare repository.
         """
         git_file = osp.join(working_tree_dir, ".git")
         rela_path = osp.relpath(module_abspath, start=working_tree_dir)
@@ -395,54 +431,77 @@ class Submodule(IndexObject, TraversableIterableObj):
         allow_unsafe_protocols: bool = False,
     ) -> "Submodule":
         """Add a new submodule to the given repository. This will alter the index
-        as well as the .gitmodules file, but will not create a new commit.
+        as well as the ``.gitmodules`` file, but will not create a new commit.
         If the submodule already exists, no matter if the configuration differs
         from the one provided, the existing submodule will be returned.
 
-        :param repo: Repository instance which should receive the submodule.
-        :param name: The name/identifier for the submodule.
-        :param path: Repository-relative or absolute path at which the submodule
-            should be located.
+        :param repo:
+            Repository instance which should receive the submodule.
+
+        :param name:
+            The name/identifier for the submodule.
+
+        :param path:
+            Repository-relative or absolute path at which the submodule should be
+            located.
             It will be created as required during the repository initialization.
-        :param url: git-clone compatible URL, see git-clone reference for more information.
-            If None, the repository is assumed to exist, and the url of the first
-            remote is taken instead. This is useful if you want to make an existing
-            repository a submodule of another one.
-        :param branch: name of branch at which the submodule should (later) be checked out.
-            The given branch must exist in the remote repository, and will be checked
-            out locally as a tracking branch.
-            It will only be written into the configuration if it not None, which is
-            when the checked out branch will be the one the remote HEAD pointed to.
-            The result you get in these situation is somewhat fuzzy, and it is recommended
-            to specify at least 'master' here.
-            Examples are 'master' or 'feature/new'.
-        :param no_checkout: If True, and if the repository has to be cloned manually,
-            no checkout will be performed.
-        :param depth: Create a shallow clone with a history truncated to the
-            specified number of commits.
-        :param env: Optional dictionary containing the desired environment variables.
+
+        :param url:
+            git-clone compatible URL, see git-clone reference for more information.
+            If None, the repository is assumed to exist, and the url of the first remote
+            is taken instead. This is useful if you want to make an existing repository
+            a submodule of another one.
+
+        :param branch:
+            Name of branch at which the submodule should (later) be checked out. The
+            given branch must exist in the remote repository, and will be checked out
+            locally as a tracking branch.
+            It will only be written into the configuration if it not None, which is when
+            the checked out branch will be the one the remote HEAD pointed to.
+            The result you get in these situation is somewhat fuzzy, and it is
+            recommended to specify at least ``master`` here.
+            Examples are ``master`` or ``feature/new``.
+
+        :param no_checkout:
+            If True, and if the repository has to be cloned manually, no checkout will
+            be performed.
+
+        :param depth:
+            Create a shallow clone with a history truncated to the specified number of
+            commits.
+
+        :param env:
+            Optional dictionary containing the desired environment variables.
+
             Note: Provided variables will be used to update the execution environment
             for ``git``. If some variable is not specified in `env` and is defined in
             attr:`os.environ`, the value from attr:`os.environ` will be used. If you
             want to unset some variable, consider providing an empty string as its
             value.
+
         :param clone_multi_options: A list of Clone options. Please see
             :meth:`Repo.clone <git.repo.base.Repo.clone>` for details.
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :return: The newly created submodule instance.
-        :note: Works atomically, such that no change will be done if the repository
-            update fails for instance.
-        """
 
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
+
+        :return:
+            The newly created :class:`Submodule` instance.
+
+        :note:
+            Works atomically, such that no change will be done if, for example, the
+            repository update fails.
+        """
         if repo.bare:
             raise InvalidGitRepositoryError("Cannot add submodules to bare repositories")
         # END handle bare repos
 
         path = cls._to_relative_path(repo, path)
 
-        # Ensure we never put backslashes into the URL, as some operating systems
-        # like it...
+        # Ensure we never put backslashes into the URL, as might happen on Windows.
         if url is not None:
             url = to_native_path_linux(url)
         # END ensure URL correctness
@@ -569,24 +628,29 @@ class Submodule(IndexObject, TraversableIterableObj):
         allow_unsafe_options: bool = False,
         allow_unsafe_protocols: bool = False,
     ) -> "Submodule":
-        """Update the repository of this submodule to point to the checkout
-        we point at with the binsha of this instance.
+        """Update the repository of this submodule to point to the checkout we point at
+        with the binsha of this instance.
 
         :param recursive:
             If True, we will operate recursively and update child modules as well.
+
         :param init:
             If True, the module repository will be cloned into place if necessary.
+
         :param to_latest_revision:
             If True, the submodule's sha will be ignored during checkout. Instead, the
             remote will be fetched, and the local tracking branch updated. This only
             works if we have a local tracking branch, which is the case if the remote
             repository had a master branch, or of the 'branch' option was specified for
             this submodule and the branch existed remotely.
+
         :param progress:
-            UpdateProgress instance or None if no progress should be shown.
+            :class:`UpdateProgress` instance, or None if no progress should be shown.
+
         :param dry_run:
             If True, the operation will only be simulated, but not performed.
             All performed operations are read-only.
+
         :param force:
             If True, we may reset heads even if the repository in question is dirty.
             Additionally we will be allowed to set a tracking branch which is ahead of
@@ -594,31 +658,40 @@ class Submodule(IndexObject, TraversableIterableObj):
             This will essentially 'forget' commits.
             If False, local tracking branches that are in the future of their respective
             remote branches will simply not be moved.
+
         :param keep_going:
             If True, we will ignore but log all errors, and keep going recursively.
-            Unless dry_run is set as well, keep_going could cause subsequent / inherited
-            errors you wouldn't see otherwise.
-            In conjunction with dry_run, it can be useful to anticipate all errors when
-            updating submodules.
+            Unless `dry_run` is set as well, `keep_going` could cause
+            subsequent/inherited errors you wouldn't see otherwise.
+            In conjunction with `dry_run`, it can be useful to anticipate all errors
+            when updating submodules.
+
         :param env: Optional dictionary containing the desired environment variables.
             Note: Provided variables will be used to update the execution environment
             for ``git``. If some variable is not specified in `env` and is defined in
             attr:`os.environ`, value from attr:`os.environ` will be used.
             If you want to unset some variable, consider providing the empty string as
             its value.
+
         :param clone_multi_options:
-            List of Clone options.
+            List of ``git clone`` options.
             Please see :meth:`Repo.clone <git.repo.base.Repo.clone>` for details.
             They only take effect with the `init` option.
+
         :param allow_unsafe_protocols:
-            Allow unsafe protocols to be used, like ext.
+            Allow unsafe protocols to be used, like ``ext``.
+
         :param allow_unsafe_options:
-            Allow unsafe options to be used, like --upload-pack.
+            Allow unsafe options to be used, like ``--upload-pack``.
 
-        :note: Does nothing in bare repositories.
-        :note: This method is definitely not atomic if `recursive` is True.
+        :note:
+            Does nothing in bare repositories.
 
-        :return: self
+        :note:
+            This method is definitely not atomic if `recursive` is True.
+
+        :return:
+            self
         """
         if self.repo.bare:
             return self
@@ -742,9 +815,10 @@ class Submodule(IndexObject, TraversableIterableObj):
                     # END handle tracking branch
 
                     # NOTE: Have to write the repo config file as well, otherwise the
-                    # default implementation will be offended and not update the repository.
-                    # Maybe this is a good way to ensure it doesn't get into our way, but
-                    # we want to stay backwards compatible too... It's so redundant!
+                    # default implementation will be offended and not update the
+                    # repository. Maybe this is a good way to ensure it doesn't get into
+                    # our way, but we want to stay backwards compatible too... It's so
+                    # redundant!
                     with self.repo.config_writer() as writer:
                         writer.set_value(sm_section(self.name), "url", self.url)
                 # END handle dry_run
@@ -755,7 +829,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             binsha = self.binsha
             hexsha = self.hexsha
             if mrepo is not None:
-                # mrepo is only set if we are not in dry-run mode or if the module existed.
+                # mrepo is only set if we are not in dry-run mode or if the module
+                # existed.
                 is_detached = mrepo.head.is_detached
             # END handle dry_run
 
@@ -782,10 +857,12 @@ class Submodule(IndexObject, TraversableIterableObj):
             # Update the working tree.
             # Handles dry_run.
             if mrepo is not None and mrepo.head.commit.binsha != binsha:
-                # We must ensure that our destination sha (the one to point to) is in the future of our current head.
-                # Otherwise, we will reset changes that might have been done on the submodule, but were not yet pushed.
-                # We also handle the case that history has been rewritten, leaving no merge-base. In that case
-                # we behave conservatively, protecting possible changes the user had done.
+                # We must ensure that our destination sha (the one to point to) is in
+                # the future of our current head. Otherwise, we will reset changes that
+                # might have been done on the submodule, but were not yet pushed. We
+                # also handle the case that history has been rewritten, leaving no
+                # merge-base. In that case we behave conservatively, protecting possible
+                # changes the user had done.
                 may_reset = True
                 if mrepo.head.commit.binsha != self.NULL_BIN_SHA:
                     base_commit = mrepo.merge_base(mrepo.head.commit, hexsha)
@@ -822,10 +899,10 @@ class Submodule(IndexObject, TraversableIterableObj):
 
                 if not dry_run and may_reset:
                     if is_detached:
-                        # NOTE: For now we force. The user is not supposed to change detached
-                        # submodules anyway. Maybe at some point this becomes an option, to
-                        # properly handle user modifications - see below for future options
-                        # regarding rebase and merge.
+                        # NOTE: For now we force. The user is not supposed to change
+                        # detached submodules anyway. Maybe at some point this becomes
+                        # an option, to properly handle user modifications - see below
+                        # for future options regarding rebase and merge.
                         mrepo.git.checkout(hexsha, force=force)
                     else:
                         mrepo.head.reset(hexsha, index=True, working_tree=True)
@@ -871,19 +948,30 @@ class Submodule(IndexObject, TraversableIterableObj):
         the repository at our current path, changing the configuration, as well as
         adjusting our index entry accordingly.
 
-        :param module_path: The path to which to move our module in the parent
-            repository's working tree, given as repository - relative or absolute path.
-            Intermediate directories will be created accordingly. If the path already
-            exists, it must be empty. Trailing (back)slashes are removed automatically.
-        :param configuration: If True, the configuration will be adjusted to let
-            the submodule point to the given path.
-        :param module: If True, the repository managed by this submodule
-            will be moved as well. If False, we don't move the submodule's checkout,
-            which may leave the parent repository in an inconsistent state.
-        :return: self
-        :raise ValueError: If the module path existed and was not empty, or was a file.
-        :note: Currently the method is not atomic, and it could leave the repository
-            in an inconsistent state if a sub-step fails for some reason.
+        :param module_path:
+            The path to which to move our module in the parent repository's working
+            tree, given as repository - relative or absolute path. Intermediate
+            directories will be created accordingly. If the path already exists, it must
+            be empty. Trailing (back)slashes are removed automatically.
+
+        :param configuration:
+            If True, the configuration will be adjusted to let the submodule point to
+            the given path.
+
+        :param module:
+            If True, the repository managed by this submodule will be moved as well. If
+            False, we don't move the submodule's checkout, which may leave the parent
+            repository in an inconsistent state.
+
+        :return:
+            self
+
+        :raise ValueError:
+            If the module path existed and was not empty, or was a file.
+
+        :note:
+            Currently the method is not atomic, and it could leave the repository in an
+            inconsistent state if a sub-step fails for some reason.
         """
         if module + configuration < 1:
             raise ValueError("You must specify to move at least the module or the configuration of the submodule")
@@ -940,8 +1028,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             # END handle git file rewrite
         # END move physical module
 
-        # Rename the index entry - we have to manipulate the index directly as
-        # git-mv cannot be used on submodules... yeah.
+        # Rename the index entry - we have to manipulate the index directly as git-mv
+        # cannot be used on submodules... yeah.
         previous_sm_path = self.path
         try:
             if configuration:
@@ -967,7 +1055,8 @@ class Submodule(IndexObject, TraversableIterableObj):
             raise
         # END handle undo rename
 
-        # Auto-rename submodule if its name was 'default', that is, the checkout directory.
+        # Auto-rename submodule if its name was 'default', that is, the checkout
+        # directory.
         if previous_sm_path == self.name:
             self.rename(module_checkout_path)
 
@@ -982,30 +1071,46 @@ class Submodule(IndexObject, TraversableIterableObj):
         dry_run: bool = False,
     ) -> "Submodule":
         """Remove this submodule from the repository. This will remove our entry
-        from the .gitmodules file and the entry in the .git/config file.
+        from the ``.gitmodules`` file and the entry in the ``.git/config`` file.
 
-        :param module: If True, the checked out module we point to will be deleted as
-            well. If that module is currently on a commit outside any branch in the
-            remote, or if it is ahead of its tracking branch, or if there are modified
-            or untracked files in its working tree, then the removal will fail. In case
-            the removal of the repository fails for these reasons, the submodule status
-            will not have been altered.
+        :param module:
+            If True, the checked out module we point to will be deleted as well. If that
+            module is currently on a commit outside any branch in the remote, or if it
+            is ahead of its tracking branch, or if there are modified or untracked files
+            in its working tree, then the removal will fail. In case the removal of the
+            repository fails for these reasons, the submodule status will not have been
+            altered.
             If this submodule has child modules of its own, these will be deleted prior
             to touching the direct submodule.
-        :param force: Enforces the deletion of the module even though it contains
-            modifications. This basically enforces a brute-force file system based
-            deletion.
-        :param configuration: If True, the submodule is deleted from the configuration,
-            otherwise it isn't. Although this should be enabled most of the time, this
-            flag enables you to safely delete the repository of your submodule.
-        :param dry_run: If True, we will not actually do anything, but throw the errors
-            we would usually throw.
-        :return: self
-        :note: Doesn't work in bare repositories.
-        :note: Doesn't work atomically, as failure to remove any part of the submodule
-            will leave an inconsistent state.
-        :raise InvalidGitRepositoryError: Thrown if the repository cannot be deleted.
-        :raise OSError: If directories or files could not be removed.
+
+        :param force:
+            Enforces the deletion of the module even though it contains modifications.
+            This basically enforces a brute-force file system based deletion.
+
+        :param configuration:
+            If True, the submodule is deleted from the configuration, otherwise it
+            isn't. Although this should be enabled most of the time, this flag enables
+            you to safely delete the repository of your submodule.
+
+        :param dry_run:
+            If True, we will not actually do anything, but throw the errors we would
+            usually throw.
+
+        :return:
+            self
+
+        :note:
+            Doesn't work in bare repositories.
+
+        :note:
+            Doesn't work atomically, as failure to remove any part of the submodule will
+            leave an inconsistent state.
+
+        :raise InvalidGitRepositoryError:
+            Thrown if the repository cannot be deleted.
+
+        :raise OSError:
+            If directories or files could not be removed.
         """
         if not (module or configuration):
             raise ValueError("Need to specify to delete at least the module, or the configuration")
@@ -1019,8 +1124,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             del csm
 
         if configuration and not dry_run and nc > 0:
-            # Ensure we don't leave the parent repository in a dirty state, and commit our changes.
-            # It's important for recursive, unforced, deletions to work as expected.
+            # Ensure we don't leave the parent repository in a dirty state, and commit
+            # our changes. It's important for recursive, unforced, deletions to work as
+            # expected.
             self.module().index.commit("Removed at least one of child-modules of '%s'" % self.name)
         # END handle recursion
 
@@ -1031,8 +1137,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             git_dir = mod.git_dir
             if force:
                 # Take the fast lane and just delete everything in our module path.
-                # TODO: If we run into permission problems, we have a highly inconsistent
-                # state. Delete the .git folders last, start with the submodules first.
+                # TODO: If we run into permission problems, we have a highly
+                # inconsistent state. Delete the .git folders last, start with the
+                # submodules first.
                 mp = self.abspath
                 method: Union[None, Callable[[PathLike], None]] = None
                 if osp.islink(mp):
@@ -1129,18 +1236,24 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     def set_parent_commit(self, commit: Union[Commit_ish, None], check: bool = True) -> "Submodule":
         """Set this instance to use the given commit whose tree is supposed to
-        contain the .gitmodules blob.
+        contain the ``.gitmodules`` blob.
 
         :param commit:
             Commit-ish reference pointing at the root_tree, or None to always point to
             the most recent commit
+
         :param check:
-            If True, relatively expensive checks will be performed to verify
-            validity of the submodule.
-        :raise ValueError: If the commit's tree didn't contain the .gitmodules blob.
+            If True, relatively expensive checks will be performed to verify validity of
+            the submodule.
+
+        :raise ValueError:
+            If the commit's tree didn't contain the ``.gitmodules`` blob.
+
         :raise ValueError:
             If the parent commit didn't store this submodule under the current path.
-        :return: self
+
+        :return:
+            self
         """
         if commit is None:
             self._parent_commit = None
@@ -1179,21 +1292,28 @@ class Submodule(IndexObject, TraversableIterableObj):
         self, index: Union["IndexFile", None] = None, write: bool = True
     ) -> SectionConstraint["SubmoduleConfigParser"]:
         """
-        :return: A config writer instance allowing you to read and write the data
-            belonging to this submodule into the .gitmodules file.
+        :return:
+            A config writer instance allowing you to read and write the data belonging
+            to this submodule into the ``.gitmodules`` file.
 
-        :param index: If not None, an IndexFile instance which should be written.
+        :param index:
+            If not None, an IndexFile instance which should be written.
             Defaults to the index of the Submodule's parent repository.
-        :param write: If True, the index will be written each time a configuration
-            value changes.
 
-        :note: The parameters allow for a more efficient writing of the index,
-            as you can pass in a modified index on your own, prevent automatic writing,
-            and write yourself once the whole operation is complete.
+        :param write:
+            If True, the index will be written each time a configuration value changes.
 
-        :raise ValueError: If trying to get a writer on a parent_commit which does not
-            match the current head commit.
-        :raise IOError: If the .gitmodules file/blob could not be read
+        :note:
+            The parameters allow for a more efficient writing of the index, as you can
+            pass in a modified index on your own, prevent automatic writing, and write
+            yourself once the whole operation is complete.
+
+        :raise ValueError:
+            If trying to get a writer on a parent_commit which does not match the
+            current head commit.
+
+        :raise IOError:
+            If the ``.gitmodules`` file/blob could not be read.
         """
         writer = self._config_parser_constrained(read_only=False)
         if index is not None:
@@ -1208,22 +1328,24 @@ class Submodule(IndexObject, TraversableIterableObj):
         :note:
             This method takes care of renaming the submodule in various places, such as:
 
-            * $parent_git_dir / config
-            * $working_tree_dir / .gitmodules
+            * ``$parent_git_dir / config``
+            * ``$working_tree_dir / .gitmodules``
             * (git >= v1.8.0: move submodule repository to new name)
 
-        As .gitmodules will be changed, you would need to make a commit afterwards. The
-        changed .gitmodules file will already be added to the index.
+        As ``.gitmodules`` will be changed, you would need to make a commit afterwards.
+        The changed ``.gitmodules`` file will already be added to the index.
 
-        :return: This submodule instance
+        :return:
+            This :class:`Submodule` instance
         """
         if self.name == new_name:
             return self
 
         # .git/config
         with self.repo.config_writer() as pw:
-            # As we ourselves didn't write anything about submodules into the parent .git/config,
-            # we will not require it to exist, and just ignore missing entries.
+            # As we ourselves didn't write anything about submodules into the parent
+            # .git/config, we will not require it to exist, and just ignore missing
+            # entries.
             if pw.has_section(sm_section(self.name)):
                 pw.rename_section(sm_section(self.name), sm_section(new_name))
 
@@ -1260,8 +1382,9 @@ class Submodule(IndexObject, TraversableIterableObj):
         """
         :return: Repo instance initialized from the repository at our submodule path
 
-        :raise InvalidGitRepositoryError: If a repository was not available. This could
-            also mean that it was not yet initialized.
+        :raise InvalidGitRepositoryError:
+            If a repository was not available.
+            This could also mean that it was not yet initialized.
         """
         module_checkout_abspath = self.abspath
         try:
@@ -1276,7 +1399,11 @@ class Submodule(IndexObject, TraversableIterableObj):
         # END handle exceptions
 
     def module_exists(self) -> bool:
-        """:return: True if our module exists and is a valid git repository. See module() method."""
+        """
+        :return:
+            True if our module exists and is a valid git repository.
+            See the :meth:`module` method.
+        """
         try:
             self.module()
             return True
@@ -1286,9 +1413,10 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     def exists(self) -> bool:
         """
-        :return: True if the submodule exists, False otherwise. Please note that
-            a submodule may exist (in the .gitmodules file) even though its module
-            doesn't exist on disk.
+        :return:
+            True if the submodule exists, False otherwise.
+            Please note that a submodule may exist (in the ``.gitmodules`` file) even
+            though its module doesn't exist on disk.
         """
         # Keep attributes for later, and restore them if we have no valid data.
         # This way we do not actually alter the state of the object.
@@ -1299,7 +1427,8 @@ class Submodule(IndexObject, TraversableIterableObj):
                     loc[attr] = getattr(self, attr)
                 # END if we have the attribute cache
             except (cp.NoSectionError, ValueError):
-                # On PY3, this can happen apparently... don't know why this doesn't happen on PY2.
+                # On PY3, this can happen apparently... don't know why this doesn't
+                # happen on PY2.
                 pass
         # END for each attr
         self._clear_cache()
@@ -1333,8 +1462,9 @@ class Submodule(IndexObject, TraversableIterableObj):
     @property
     def branch_path(self) -> PathLike:
         """
-        :return: Complete relative path as string to the branch we would checkout
-            from the remote and track
+        :return:
+            Complete relative path as string to the branch we would checkout from the
+            remote and track
         """
         return self._branch_path
 
@@ -1344,8 +1474,8 @@ class Submodule(IndexObject, TraversableIterableObj):
         :return:
             The name of the branch, which is the shortest possible branch name
         """
-        # Use an instance method, for this we create a temporary Head instance
-        # which uses a repository that is available at least (it makes no difference).
+        # Use an instance method, for this we create a temporary Head instance which
+        # uses a repository that is available at least (it makes no difference).
         return git.Head(self.repo, self._branch_path).name
 
     @property
@@ -1420,7 +1550,8 @@ class Submodule(IndexObject, TraversableIterableObj):
     ) -> Iterator["Submodule"]:
         """
         :return:
-            Iterator yielding Submodule instances available in the given repository
+            Iterator yielding :class:`Submodule` instances available in the given
+            repository
         """
         try:
             pc = repo.commit(parent_commit)  # Parent commit instance

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -60,7 +60,8 @@ _logger = logging.getLogger(__name__)
 
 class UpdateProgress(RemoteProgress):
     """Class providing detailed progress information to the caller who should
-    derive from it and implement the ``update(...)`` message."""
+    derive from it and implement the
+    :meth:`update(...) <git.util.RemoteProgress.update>` message."""
 
     CLONE, FETCH, UPDWKTREE = [1 << x for x in range(RemoteProgress._num_op_codes, RemoteProgress._num_op_codes + 3)]
     _num_op_codes: int = RemoteProgress._num_op_codes + 3
@@ -76,8 +77,8 @@ UPDWKTREE = UpdateProgress.UPDWKTREE
 
 
 # IndexObject comes via the util module. It's a 'hacky' fix thanks to Python's import
-# mechanism, which causes plenty of trouble if the only reason for packages and
-# modules is refactoring - subpackages shouldn't depend on parent packages.
+# mechanism, which causes plenty of trouble if the only reason for packages and modules
+# is refactoring - subpackages shouldn't depend on parent packages.
 class Submodule(IndexObject, TraversableIterableObj):
     """Implements access to a git submodule. They are special in that their sha
     represents a commit in the submodule's repository which is to be checked out
@@ -119,11 +120,19 @@ class Submodule(IndexObject, TraversableIterableObj):
         We only document the parameters that differ from
         :class:`~git.objects.base.IndexObject`.
 
-        :param repo: Our parent repository.
-        :param binsha: Binary sha referring to a commit in the remote repository. See
-            the ``url`` parameter.
-        :param parent_commit: See :meth:`set_parent_commit`.
-        :param url: The URL to the remote repository which is the submodule.
+        :param repo:
+            Our parent repository.
+
+        :param binsha:
+            Binary sha referring to a commit in the remote repository.
+            See the `url` parameter.
+
+        :param parent_commit:
+            See :meth:`set_parent_commit`.
+
+        :param url:
+            The URL to the remote repository which is the submodule.
+
         :param branch_path: Complete relative path to ref to checkout when cloning the
             remote repository.
         """
@@ -1313,9 +1322,11 @@ class Submodule(IndexObject, TraversableIterableObj):
     @property
     def branch(self) -> "Head":
         """
-        :return: The branch instance that we are to checkout
+        :return:
+            The branch instance that we are to checkout
 
-        :raise InvalidGitRepositoryError: If our module is not yet checked out
+        :raise InvalidGitRepositoryError:
+            If our module is not yet checked out.
         """
         return mkhead(self.module(), self._branch_path)
 
@@ -1329,7 +1340,10 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @property
     def branch_name(self) -> str:
-        """:return: The name of the branch, which is the shortest possible branch name"""
+        """
+        :return:
+            The name of the branch, which is the shortest possible branch name
+        """
         # Use an instance method, for this we create a temporary Head instance
         # which uses a repository that is available at least (it makes no difference).
         return git.Head(self.repo, self._branch_path).name
@@ -1342,9 +1356,11 @@ class Submodule(IndexObject, TraversableIterableObj):
     @property
     def parent_commit(self) -> "Commit_ish":
         """
-        :return: Commit instance with the tree containing the .gitmodules file
+        :return:
+            Commit instance with the tree containing the ``.gitmodules`` file
 
-        :note: Will always point to the current head's commit if it was not set explicitly.
+        :note:
+            Will always point to the current head's commit if it was not set explicitly.
         """
         if self._parent_commit is None:
             return self.repo.commit()
@@ -1353,33 +1369,40 @@ class Submodule(IndexObject, TraversableIterableObj):
     @property
     def name(self) -> str:
         """
-        :return: The name of this submodule. It is used to identify it within the
-            .gitmodules file.
+        :return:
+            The name of this submodule. It is used to identify it within the
+            ``.gitmodules`` file.
 
-        :note: By default, this is the name is the path at which to find the submodule,
-            but in GitPython it should be a unique identifier similar to the identifiers
+        :note:
+            By default, this is the name is the path at which to find the submodule, but
+            in GitPython it should be a unique identifier similar to the identifiers
             used for remotes, which allows to change the path of the submodule easily.
         """
         return self._name
 
     def config_reader(self) -> SectionConstraint[SubmoduleConfigParser]:
         """
-        :return: ConfigReader instance which allows you to query the configuration
-            values of this submodule, as provided by the .gitmodules file.
+        :return:
+            ConfigReader instance which allows you to query the configuration values of
+            this submodule, as provided by the ``.gitmodules`` file.
 
-        :note: The config reader will actually read the data directly from the
-            repository and thus does not need nor care about your working tree.
+        :note:
+            The config reader will actually read the data directly from the repository
+            and thus does not need nor care about your working tree.
 
-        :note: Should be cached by the caller and only kept as long as needed.
+        :note:
+            Should be cached by the caller and only kept as long as needed.
 
-        :raise IOError: If the .gitmodules file/blob could not be read.
+        :raise IOError:
+            If the ``.gitmodules`` file/blob could not be read.
         """
         return self._config_parser_constrained(read_only=True)
 
     def children(self) -> IterableList["Submodule"]:
         """
-        :return: IterableList(Submodule, ...) an iterable list of submodules instances
-            which are children of this submodule or 0 if the submodule is not checked out.
+        :return:
+            IterableList(Submodule, ...) An iterable list of submodules instances which
+            are children of this submodule or 0 if the submodule is not checked out.
         """
         return self._get_intermediate_items(self)
 
@@ -1395,7 +1418,10 @@ class Submodule(IndexObject, TraversableIterableObj):
         *Args: Any,
         **kwargs: Any,
     ) -> Iterator["Submodule"]:
-        """:return: Iterator yielding Submodule instances available in the given repository"""
+        """
+        :return:
+            Iterator yielding Submodule instances available in the given repository
+        """
         try:
             pc = repo.commit(parent_commit)  # Parent commit instance
             parser = cls._config_parser(repo, pc, read_only=True)
@@ -1423,8 +1449,8 @@ class Submodule(IndexObject, TraversableIterableObj):
                     entry = index.entries[index.entry_key(p, 0)]
                     sm = Submodule(repo, entry.binsha, entry.mode, entry.path)
                 except KeyError:
-                    # The submodule doesn't exist, probably it wasn't
-                    # removed from the .gitmodules file.
+                    # The submodule doesn't exist, probably it wasn't removed from the
+                    # .gitmodules file.
                     continue
                 # END handle keyerror
             # END handle critical error

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -1106,7 +1106,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             Doesn't work atomically, as failure to remove any part of the submodule will
             leave an inconsistent state.
 
-        :raise InvalidGitRepositoryError:
+        :raise git.exc.InvalidGitRepositoryError:
             Thrown if the repository cannot be deleted.
 
         :raise OSError:
@@ -1382,7 +1382,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         """
         :return: Repo instance initialized from the repository at our submodule path
 
-        :raise InvalidGitRepositoryError:
+        :raise git.exc.InvalidGitRepositoryError:
             If a repository was not available.
             This could also mean that it was not yet initialized.
         """
@@ -1454,7 +1454,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         :return:
             The branch instance that we are to checkout
 
-        :raise InvalidGitRepositoryError:
+        :raise git.exc.InvalidGitRepositoryError:
             If our module is not yet checked out.
         """
         return mkhead(self.module(), self._branch_path)

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -134,7 +134,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             The URL to the remote repository which is the submodule.
 
         :param branch_path:
-            Complete relative path to ref to checkout when cloning the remote
+            Full repository-relative path to ref to checkout when cloning the remote
             repository.
         """
         super().__init__(repo, binsha, mode, path)
@@ -1473,8 +1473,8 @@ class Submodule(IndexObject, TraversableIterableObj):
     def branch_path(self) -> PathLike:
         """
         :return:
-            Complete relative path as string to the branch we would checkout from the
-            remote and track
+            Full repository-relative path as string to the branch we would checkout from
+            the remote and track
         """
         return self._branch_path
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -172,7 +172,7 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _get_intermediate_items(cls, item: "Submodule") -> IterableList["Submodule"]:
-        """:return: all the submodules of our module repository"""
+        """:return: All the submodules of our module repository"""
         try:
             return cls.list_items(item.module())
         except InvalidGitRepositoryError:
@@ -326,7 +326,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             Allow unsafe options to be used, like ``--upload-pack``.
 
         :param kwargs:
-            Additional arguments given to ``git clone``
+            Additional arguments given to ``git clone``.
         """
         module_abspath = cls._module_abspath(repo, path, name)
         module_checkout_path = module_abspath
@@ -351,7 +351,7 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _to_relative_path(cls, parent_repo: "Repo", path: PathLike) -> PathLike:
-        """:return: a path guaranteed to be relative to the given parent repository
+        """:return: A path guaranteed to be relative to the given parent repository
 
         :raise ValueError:
             If path is not contained in the parent repository's working tree.
@@ -642,7 +642,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             If ``True``, the submodule's sha will be ignored during checkout. Instead,
             the remote will be fetched, and the local tracking branch updated. This only
             works if we have a local tracking branch, which is the case if the remote
-            repository had a master branch, or of the ``branch`` option was specified
+            repository had a master branch, or if the ``branch`` option was specified
             for this submodule and the branch existed remotely.
 
         :param progress:
@@ -1309,7 +1309,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             repository.
 
         :param write:
-            If True, the index will be written each time a configuration value changes.
+            If ``True``, the index will be written each time a configuration value changes.
 
         :note:
             The parameters allow for a more efficient writing of the index, as you can

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -124,7 +124,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             the ``url`` parameter.
         :param parent_commit: See :meth:`set_parent_commit`.
         :param url: The URL to the remote repository which is the submodule.
-        :param branch_path: Full (relative) path to ref to checkout when cloning the
+        :param branch_path: Complete relative path to ref to checkout when cloning the
             remote repository.
         """
         super().__init__(repo, binsha, mode, path)
@@ -1322,7 +1322,7 @@ class Submodule(IndexObject, TraversableIterableObj):
     @property
     def branch_path(self) -> PathLike:
         """
-        :return: Full (relative) path as string to the branch we would checkout
+        :return: Complete relative path as string to the branch we would checkout
             from the remote and track
         """
         return self._branch_path

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -89,9 +89,9 @@ class RootModule(Submodule):
     ) -> "RootModule":
         """Update the submodules of this repository to the current HEAD commit.
 
-        This method behaves smartly by determining changes of the path of a submodules
+        This method behaves smartly by determining changes of the path of a submodule's
         repository, next to changes to the to-be-checked-out commit or the branch to be
-        checked out. This works if the submodules ID does not change.
+        checked out. This works if the submodule's ID does not change.
 
         Additionally it will detect addition and removal of submodules, which will be
         handled gracefully.
@@ -99,11 +99,11 @@ class RootModule(Submodule):
         :param previous_commit:
             If set to a commit-ish, the commit we should use as the previous commit the
             HEAD pointed to before it was set to the commit it points to now.
-            If None, it defaults to ``HEAD@{1}`` otherwise.
+            If ``None``, it defaults to ``HEAD@{1}`` otherwise.
 
         :param recursive:
-            If True, the children of submodules will be updated as well using the same
-            technique.
+            If ``True``, the children of submodules will be updated as well using the
+            same technique.
 
         :param force_remove:
             If submodules have been deleted, they will be forcibly removed. Otherwise
@@ -116,28 +116,30 @@ class RootModule(Submodule):
             If we encounter a new module which would need to be initialized, then do it.
 
         :param to_latest_revision:
-            If True, instead of checking out the revision pointed to by this submodule's
-            sha, the checked out tracking branch will be merged with the latest remote
-            branch fetched from the repository's origin.
+            If ``True``, instead of checking out the revision pointed to by this
+            submodule's sha, the checked out tracking branch will be merged with the
+            latest remote branch fetched from the repository's origin.
+
             Unless `force_reset` is specified, a local tracking branch will never be
             reset into its past, therefore the remote branch must be in the future for
             this to have an effect.
 
         :param force_reset:
-            If True, submodules may checkout or reset their branch even if the
+            If ``True``, submodules may checkout or reset their branch even if the
             repository has pending changes that would be overwritten, or if the local
             tracking branch is in the future of the remote tracking branch and would be
             reset into its past.
 
         :param progress:
-            :class:`RootUpdateProgress` instance or None if no progress should be sent.
+            :class:`RootUpdateProgress` instance, or ``None`` if no progress should be
+            sent.
 
         :param dry_run:
-            If True, operations will not actually be performed. Progress messages will
-            change accordingly to indicate the WOULD DO state of the operation.
+            If ``True``, operations will not actually be performed. Progress messages
+            will change accordingly to indicate the WOULD DO state of the operation.
 
         :param keep_going:
-            If True, we will ignore but log all errors, and keep going recursively.
+            If ``True``, we will ignore but log all errors, and keep going recursively.
             Unless `dry_run` is set as well, `keep_going` could cause
             subsequent/inherited errors you wouldn't see otherwise.
             In conjunction with `dry_run`, this can be useful to anticipate all errors

--- a/git/objects/submodule/root.py
+++ b/git/objects/submodule/root.py
@@ -26,7 +26,8 @@ _logger = logging.getLogger(__name__)
 
 
 class RootUpdateProgress(UpdateProgress):
-    """Utility class which adds more opcodes to the UpdateProgress."""
+    """Utility class which adds more opcodes to
+    :class:`~git.objects.submodule.base.UpdateProgress`."""
 
     REMOVE, PATHCHANGE, BRANCHCHANGE, URLCHANGE = [
         1 << x for x in range(UpdateProgress._num_op_codes, UpdateProgress._num_op_codes + 4)
@@ -91,43 +92,59 @@ class RootModule(Submodule):
         This method behaves smartly by determining changes of the path of a submodules
         repository, next to changes to the to-be-checked-out commit or the branch to be
         checked out. This works if the submodules ID does not change.
+
         Additionally it will detect addition and removal of submodules, which will be
         handled gracefully.
 
-        :param previous_commit: If set to a commit-ish, the commit we should use as the
-            previous commit the HEAD pointed to before it was set to the commit it
-            points to now.
-            If None, it defaults to ``HEAD@{1}`` otherwise
-        :param recursive: if True, the children of submodules will be updated as well
-            using the same technique.
-        :param force_remove: If submodules have been deleted, they will be forcibly
-            removed. Otherwise the update may fail if a submodule's repository cannot be
-            deleted as changes have been made to it.
+        :param previous_commit:
+            If set to a commit-ish, the commit we should use as the previous commit the
+            HEAD pointed to before it was set to the commit it points to now.
+            If None, it defaults to ``HEAD@{1}`` otherwise.
+
+        :param recursive:
+            If True, the children of submodules will be updated as well using the same
+            technique.
+
+        :param force_remove:
+            If submodules have been deleted, they will be forcibly removed. Otherwise
+            the update may fail if a submodule's repository cannot be deleted as changes
+            have been made to it.
             (See :meth:`Submodule.update <git.objects.submodule.base.Submodule.update>`
             for more information.)
-        :param init: If we encounter a new module which would need to be initialized,
-            then do it.
-        :param to_latest_revision: If True, instead of checking out the revision pointed
-            to by this submodule's sha, the checked out tracking branch will be merged
-            with the latest remote branch fetched from the repository's origin.
+
+        :param init:
+            If we encounter a new module which would need to be initialized, then do it.
+
+        :param to_latest_revision:
+            If True, instead of checking out the revision pointed to by this submodule's
+            sha, the checked out tracking branch will be merged with the latest remote
+            branch fetched from the repository's origin.
             Unless `force_reset` is specified, a local tracking branch will never be
             reset into its past, therefore the remote branch must be in the future for
             this to have an effect.
-        :param force_reset: If True, submodules may checkout or reset their branch even
-            if the repository has pending changes that would be overwritten, or if the
-            local tracking branch is in the future of the remote tracking branch and
-            would be reset into its past.
-        :param progress: :class:`RootUpdateProgress` instance or None if no progress
-            should be sent.
-        :param dry_run: If True, operations will not actually be performed. Progress
-            messages will change accordingly to indicate the WOULD DO state of the
-            operation.
-        :param keep_going: If True, we will ignore but log all errors, and keep going
-            recursively. Unless `dry_run` is set as well, `keep_going` could cause
+
+        :param force_reset:
+            If True, submodules may checkout or reset their branch even if the
+            repository has pending changes that would be overwritten, or if the local
+            tracking branch is in the future of the remote tracking branch and would be
+            reset into its past.
+
+        :param progress:
+            :class:`RootUpdateProgress` instance or None if no progress should be sent.
+
+        :param dry_run:
+            If True, operations will not actually be performed. Progress messages will
+            change accordingly to indicate the WOULD DO state of the operation.
+
+        :param keep_going:
+            If True, we will ignore but log all errors, and keep going recursively.
+            Unless `dry_run` is set as well, `keep_going` could cause
             subsequent/inherited errors you wouldn't see otherwise.
             In conjunction with `dry_run`, this can be useful to anticipate all errors
             when updating submodules.
-        :return: self
+
+        :return:
+            self
         """
         if self.repo.bare:
             raise InvalidGitRepositoryError("Cannot update submodules in bare repositories")
@@ -234,13 +251,14 @@ class RootModule(Submodule):
                     ###################
                     if sm.url != psm.url:
                         # Add the new remote, remove the old one.
-                        # This way, if the url just changes, the commits will not
-                        # have to be re-retrieved.
+                        # This way, if the url just changes, the commits will not have
+                        # to be re-retrieved.
                         nn = "__new_origin__"
                         smm = sm.module()
                         rmts = smm.remotes
 
-                        # Don't do anything if we already have the url we search in place.
+                        # Don't do anything if we already have the url we search in
+                        # place.
                         if len([r for r in rmts if r.url == sm.url]) == 0:
                             progress.update(
                                 BEGIN | URLCHANGE,
@@ -272,17 +290,17 @@ class RootModule(Submodule):
                                     # END if urls match
                                 # END for each remote
 
-                                # If we didn't find a matching remote, but have exactly one,
-                                # we can safely use this one.
+                                # If we didn't find a matching remote, but have exactly
+                                # one, we can safely use this one.
                                 if rmt_for_deletion is None:
                                     if len(rmts) == 1:
                                         rmt_for_deletion = rmts[0]
                                     else:
-                                        # If we have not found any remote with the original URL
-                                        # we may not have a name. This is a special case,
-                                        # and its okay to fail here.
-                                        # Alternatively we could just generate a unique name and
-                                        # leave all existing ones in place.
+                                        # If we have not found any remote with the
+                                        # original URL we may not have a name. This is a
+                                        # special case, and its okay to fail here.
+                                        # Alternatively we could just generate a unique
+                                        # name and leave all existing ones in place.
                                         raise InvalidGitRepositoryError(
                                             "Couldn't find original remote-repo at url %r" % psm.url
                                         )
@@ -292,19 +310,19 @@ class RootModule(Submodule):
                                 orig_name = rmt_for_deletion.name
                                 smm.delete_remote(rmt_for_deletion)
                                 # NOTE: Currently we leave tags from the deleted remotes
-                                # as well as separate tracking branches in the possibly totally
-                                # changed repository (someone could have changed the url to
-                                # another project). At some point, one might want to clean
-                                # it up, but the danger is high to remove stuff the user
-                                # has added explicitly.
+                                # as well as separate tracking branches in the possibly
+                                # totally changed repository (someone could have changed
+                                # the url to another project). At some point, one might
+                                # want to clean it up, but the danger is high to remove
+                                # stuff the user has added explicitly.
 
                                 # Rename the new remote back to what it was.
                                 smr.rename(orig_name)
 
-                                # Early on, we verified that the our current tracking branch
-                                # exists in the remote. Now we have to ensure that the
-                                # sha we point to is still contained in the new remote
-                                # tracking branch.
+                                # Early on, we verified that the our current tracking
+                                # branch exists in the remote. Now we have to ensure
+                                # that the sha we point to is still contained in the new
+                                # remote tracking branch.
                                 smsha = sm.binsha
                                 found = False
                                 rref = smr.refs[self.branch_name]
@@ -316,10 +334,11 @@ class RootModule(Submodule):
                                 # END for each commit
 
                                 if not found:
-                                    # Adjust our internal binsha to use the one of the remote
-                                    # this way, it will be checked out in the next step.
-                                    # This will change the submodule relative to us, so
-                                    # the user will be able to commit the change easily.
+                                    # Adjust our internal binsha to use the one of the
+                                    # remote this way, it will be checked out in the
+                                    # next step. This will change the submodule relative
+                                    # to us, so the user will be able to commit the
+                                    # change easily.
                                     _logger.warning(
                                         "Current sha %s was not contained in the tracking\
              branch at the new remote, setting it the the remote's tracking branch",
@@ -328,7 +347,8 @@ class RootModule(Submodule):
                                     sm.binsha = rref.commit.binsha
                                 # END reset binsha
 
-                                # NOTE: All checkout is performed by the base implementation of update.
+                                # NOTE: All checkout is performed by the base
+                                # implementation of update.
                             # END handle dry_run
                             progress.update(
                                 END | URLCHANGE,
@@ -342,7 +362,8 @@ class RootModule(Submodule):
                     # HANDLE PATH CHANGES
                     #####################
                     if sm.branch_path != psm.branch_path:
-                        # Finally, create a new tracking branch which tracks the new remote branch.
+                        # Finally, create a new tracking branch which tracks the new
+                        # remote branch.
                         progress.update(
                             BEGIN | BRANCHCHANGE,
                             i,
@@ -354,8 +375,8 @@ class RootModule(Submodule):
                         if not dry_run:
                             smm = sm.module()
                             smmr = smm.remotes
-                            # As the branch might not exist yet, we will have to fetch all remotes
-                            # to be sure...
+                            # As the branch might not exist yet, we will have to fetch
+                            # all remotes to be sure...
                             for remote in smmr:
                                 remote.fetch(progress=progress)
                             # END for each remote
@@ -372,11 +393,12 @@ class RootModule(Submodule):
                             # END ensure tracking branch exists
 
                             tbr.set_tracking_branch(find_first_remote_branch(smmr, sm.branch_name))
-                            # NOTE: All head-resetting is done in the base implementation of update
-                            # but we will have to checkout the new branch here. As it still points
-                            # to the currently checked out commit, we don't do any harm.
-                            # As we don't want to update working-tree or index, changing the ref is
-                            # all there is to do.
+                            # NOTE: All head-resetting is done in the base
+                            # implementation of update but we will have to checkout the
+                            # new branch here. As it still points to the currently
+                            # checked out commit, we don't do any harm.
+                            # As we don't want to update working-tree or index, changing
+                            # the ref is all there is to do.
                             smm.head.reference = tbr
                         # END handle dry_run
 
@@ -409,10 +431,10 @@ class RootModule(Submodule):
                 keep_going=keep_going,
             )
 
-            # Update recursively depth first - question is which inconsistent
-            # state will be better in case it fails somewhere. Defective branch
-            # or defective depth. The RootSubmodule type will never process itself,
-            # which was done in the previous expression.
+            # Update recursively depth first - question is which inconsistent state will
+            # be better in case it fails somewhere. Defective branch or defective depth.
+            # The RootSubmodule type will never process itself, which was done in the
+            # previous expression.
             if recursive:
                 # The module would exist by now if we are not in dry_run mode.
                 if sm.module_exists():

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -35,7 +35,7 @@ __all__ = (
 
 
 def sm_section(name: str) -> str:
-    """:return: Section title used in .gitmodules configuration file"""
+    """:return: Section title used in ``.gitmodules`` configuration file"""
     return f'submodule "{name}"'
 
 
@@ -51,7 +51,8 @@ def mkhead(repo: "Repo", path: PathLike) -> "Head":
 
 
 def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "RemoteReference":
-    """Find the remote branch matching the name of the given branch or raise InvalidGitRepositoryError."""
+    """Find the remote branch matching the name of the given branch or raise
+    :class:`git.exc.InvalidGitRepositoryError`."""
     for remote in remotes:
         try:
             return remote.refs[branch_name]
@@ -69,11 +70,11 @@ def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "
 
 
 class SubmoduleConfigParser(GitConfigParser):
-    """Catches calls to _write, and updates the .gitmodules blob in the index
+    """Catches calls to _write, and updates the ``.gitmodules`` blob in the index
     with the new data, if we have written into a stream.
 
-    Otherwise it would add the local file to the index to make it correspond
-    with the working tree. Additionally, the cache must be cleared.
+    Otherwise it would add the local file to the index to make it correspond with the
+    working tree. Additionally, the cache must be cleared.
 
     Please note that no mutating method will work in bare mode.
     """
@@ -86,8 +87,8 @@ class SubmoduleConfigParser(GitConfigParser):
 
     # { Interface
     def set_submodule(self, submodule: "Submodule") -> None:
-        """Set this instance's submodule. It must be called before
-        the first write operation begins."""
+        """Set this instance's submodule. It must be called before the first write
+        operation begins."""
         self._smref = weakref.ref(submodule)
 
     def flush_to_index(self) -> None:

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -52,7 +52,7 @@ def mkhead(repo: "Repo", path: PathLike) -> "Head":
 
 def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "RemoteReference":
     """Find the remote branch matching the name of the given branch or raise
-    :class:`git.exc.InvalidGitRepositoryError`."""
+    :class:`~git.exc.InvalidGitRepositoryError`."""
     for remote in remotes:
         try:
             return remote.refs[branch_name]

--- a/git/objects/submodule/util.py
+++ b/git/objects/submodule/util.py
@@ -70,8 +70,9 @@ def find_first_remote_branch(remotes: Sequence["Remote"], branch_name: str) -> "
 
 
 class SubmoduleConfigParser(GitConfigParser):
-    """Catches calls to _write, and updates the ``.gitmodules`` blob in the index
-    with the new data, if we have written into a stream.
+    """Catches calls to :meth:`~git.config.GitConfigParser.write`, and updates the
+    ``.gitmodules`` blob in the index with the new data, if we have written into a
+    stream.
 
     Otherwise it would add the local file to the index to make it correspond with the
     working tree. Additionally, the cache must be cleared.

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -59,8 +59,8 @@ class TagObject(base.Object):
         :param tagged_date: int_seconds_since_epoch
             The :class:`DateTime` of the tag creation.
             Use :func:`time.gmtime` to convert it into a different format.
-        :param tagged_tz_offset: int_seconds_west_of_utc
-            The timezone that the authored_date is in, in a format similar
+        :param tagger_tz_offset: int_seconds_west_of_utc
+            The timezone that the tagged_date is in, in a format similar
             to :attr:`time.altzone`.
         """
         super().__init__(repo, binsha)

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -68,7 +68,7 @@ class TagObject(base.Object):
             :class:`~git.util.Actor` identifying the tagger.
 
         :param tagged_date: int_seconds_since_epoch
-            The :class:`DateTime` of the tag creation.
+            The DateTime of the tag creation.
             Use :func:`time.gmtime` to convert it into a different format.
 
         :param tagger_tz_offset: int_seconds_west_of_utc

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -3,7 +3,11 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-"""Object-based types."""
+"""Provides an :class:`git.objects.base.Object`-based type for annotated tags.
+
+This defines the :class:`TagReference` class, which represents annotated tags.
+For lightweight tags, see the :mod:`git.refs.tag` module.
+"""
 
 from . import base
 from .util import get_object_type_by_name, parse_actor_and_date
@@ -25,8 +29,8 @@ __all__ = ("TagObject",)
 
 
 class TagObject(base.Object):
-    """Non-lightweight tag carrying additional information about an object we are
-    pointing to."""
+    """Annotated (i.e. non-lightweight) tag carrying additional information about an
+    object we are pointing to."""
 
     type: Literal["tag"] = "tag"
 

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -3,7 +3,7 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-"""Provides an :class:`git.objects.base.Object`-based type for annotated tags.
+"""Provides an :class:`~git.objects.base.Object`-based type for annotated tags.
 
 This defines the :class:`TagReference` class, which represents annotated tags.
 For lightweight tags, see the :mod:`git.refs.tag` module.

--- a/git/objects/tag.py
+++ b/git/objects/tag.py
@@ -25,7 +25,8 @@ __all__ = ("TagObject",)
 
 
 class TagObject(base.Object):
-    """Non-lightweight tag carrying additional information about an object we are pointing to."""
+    """Non-lightweight tag carrying additional information about an object we are
+    pointing to."""
 
     type: Literal["tag"] = "tag"
 
@@ -51,17 +52,28 @@ class TagObject(base.Object):
     ) -> None:  # @ReservedAssignment
         """Initialize a tag object with additional data.
 
-        :param repo: Repository this object is located in
-        :param binsha: 20 byte SHA1
-        :param object: Object instance of object we are pointing to
-        :param tag: Name of this tag
-        :param tagger: Actor identifying the tagger
+        :param repo:
+            Repository this object is located in.
+
+        :param binsha:
+            20 byte SHA1.
+
+        :param object:
+            :class:`~git.objects.base.Object` instance of object we are pointing to.
+
+        :param tag:
+            Name of this tag.
+
+        :param tagger:
+            :class:`~git.util.Actor` identifying the tagger.
+
         :param tagged_date: int_seconds_since_epoch
             The :class:`DateTime` of the tag creation.
             Use :func:`time.gmtime` to convert it into a different format.
+
         :param tagger_tz_offset: int_seconds_west_of_utc
-            The timezone that the tagged_date is in, in a format similar
-            to :attr:`time.altzone`.
+            The timezone that the `tagged_date` is in, in a format similar to
+            :attr:`time.altzone`.
         """
         super().__init__(repo, binsha)
         if object is not None:

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -97,17 +97,17 @@ class TreeModifier:
 
         If an item with the given name already exists, nothing will be done, but a
         :class:`ValueError` will be raised if the sha and mode of the existing item do
-        not match the one you add, unless `force` is True.
+        not match the one you add, unless `force` is ``True``.
 
         :param sha:
             The 20 or 40 byte sha of the item to add.
 
         :param mode:
-            int representing the stat compatible mode of the item.
+            :class:`int` representing the stat-compatible mode of the item.
 
         :param force:
-            If True, an item with your name and information will overwrite any existing
-            item with the same name, no matter which information it has.
+            If ``True``, an item with your name and information will overwrite any
+            existing item with the same name, no matter which information it has.
 
         :return:
             self
@@ -164,11 +164,10 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     R"""Tree objects represent an ordered list of :class:`~git.objects.blob.Blob`\s and
     other :class:`~git.objects.tree.Tree`\s.
 
-    Tree as a list::
+    Tree as a list:
 
-        Access a specific blob using the ``tree['filename']`` notation.
-
-        You may likewise access by index, like ``blob = tree[0]``.
+    * Access a specific blob using the ``tree['filename']`` notation.
+    * You may likewise access by index, like ``blob = tree[0]``.
     """
 
     type: Literal["tree"] = "tree"
@@ -235,7 +234,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
             or :class:`~git.objects.submodule.base.Submodule`
 
         :raise KeyError:
-            If the given file or tree does not exist in tree.
+            If the given file or tree does not exist in this tree.
         """
         msg = "Blob or Tree named %r not found"
         if "/" in file:
@@ -275,12 +274,12 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
 
     @property
     def trees(self) -> List["Tree"]:
-        """:return: list(Tree, ...) list of trees directly below this tree"""
+        """:return: list(Tree, ...) List of trees directly below this tree"""
         return [i for i in self if i.type == "tree"]
 
     @property
     def blobs(self) -> List[Blob]:
-        """:return: list(Blob, ...) list of blobs directly below this tree"""
+        """:return: list(Blob, ...) List of blobs directly below this tree"""
         return [i for i in self if i.type == "blob"]
 
     @property
@@ -342,7 +341,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
             :class:`~git.util.IterableList`IterableList with the results of the
             traversal as produced by :meth:`traverse`
 
-            Tree -> IterableList[Union['Submodule', 'Tree', 'Blob']]
+            Tree -> IterableList[Union[Submodule, Tree, Blob]]
         """
         return super()._list_traverse(*args, **kwargs)
 

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -54,10 +54,12 @@ __all__ = ("TreeModifier", "Tree")
 
 
 class TreeModifier:
-    """A utility class providing methods to alter the underlying cache in a list-like fashion.
+    """A utility class providing methods to alter the underlying cache in a list-like
+    fashion.
 
-    Once all adjustments are complete, the _cache, which really is a reference to
-    the cache of a tree, will be sorted. This ensures it will be in a serializable state.
+    Once all adjustments are complete, the :attr:`_cache`, which really is a reference
+    to the cache of a tree, will be sorted. This ensures it will be in a serializable
+    state.
     """
 
     __slots__ = ("_cache",)
@@ -78,10 +80,11 @@ class TreeModifier:
     def set_done(self) -> "TreeModifier":
         """Call this method once you are done modifying the tree information.
 
-        This may be called several times, but be aware that each call will cause
-        a sort operation.
+        This may be called several times, but be aware that each call will cause a sort
+        operation.
 
-        :return self:
+        :return:
+            self
         """
         self._cache.sort(key=lambda x: (x[2] + "/") if x[1] == Tree.tree_id << 12 else x[2])
         return self
@@ -93,17 +96,21 @@ class TreeModifier:
         """Add the given item to the tree.
 
         If an item with the given name already exists, nothing will be done, but a
-        ValueError will be raised if the sha and mode of the existing item do not match
-        the one you add, unless force is True
+        :class:`ValueError` will be raised if the sha and mode of the existing item do
+        not match the one you add, unless `force` is True.
 
-        :param sha: The 20 or 40 byte sha of the item to add
+        :param sha:
+            The 20 or 40 byte sha of the item to add.
 
-        :param mode: int representing the stat compatible mode of the item
+        :param mode:
+            int representing the stat compatible mode of the item.
 
-        :param force: If True, an item with your name and information will overwrite any
-            existing item with the same name, no matter which information it has
+        :param force:
+            If True, an item with your name and information will overwrite any existing
+            item with the same name, no matter which information it has.
 
-        :return: self
+        :return:
+            self
         """
         if "/" in name:
             raise ValueError("Name must not contain '/' characters")
@@ -136,7 +143,8 @@ class TreeModifier:
 
         For more information on the parameters, see :meth:`add`.
 
-        :param binsha: 20 byte binary sha
+        :param binsha:
+            20 byte binary sha.
         """
         assert isinstance(binsha, bytes) and isinstance(mode, int) and isinstance(name, str)
         tree_cache = (binsha, mode, name)
@@ -153,15 +161,14 @@ class TreeModifier:
 
 
 class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
-    """Tree objects represent an ordered list of Blobs and other Trees.
+    R"""Tree objects represent an ordered list of :class:`~git.objects.blob.Blob`\s and
+    other :class:`~git.objects.tree.Tree`\s.
 
-    ``Tree as a list``::
+    Tree as a list::
 
-        Access a specific blob using the
-        tree['filename'] notation.
+        Access a specific blob using the ``tree['filename']`` notation.
 
-        You may as well access by index
-        blob = tree[0]
+        You may likewise access by index, like ``blob = tree[0]``.
     """
 
     type: Literal["tree"] = "tree"
@@ -223,8 +230,12 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     def join(self, file: str) -> IndexObjUnion:
         """Find the named object in this tree's contents.
 
-        :return: ``git.Blob`` or ``git.Tree`` or ``git.Submodule``
-        :raise KeyError: if given file or tree does not exist in tree
+        :return:
+            :class:`~git.objects.blob.Blob`, :class:`~git.objects.tree.Tree`,
+            or :class:`~git.objects.submodule.base.Submodule`
+
+        :raise KeyError:
+            If the given file or tree does not exist in tree.
         """
         msg = "Blob or Tree named %r not found"
         if "/" in file:
@@ -275,9 +286,13 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     @property
     def cache(self) -> TreeModifier:
         """
-        :return: An object allowing to modify the internal cache. This can be used
-            to change the tree's contents. When done, make sure you call ``set_done``
-            on the tree modifier, or serialization behaviour will be incorrect.
+        :return:
+            An object allowing modification of the internal cache. This can be used to
+            change the tree's contents. When done, make sure you call
+            :meth:`~TreeModifier.set_done` on the tree modifier, or serialization
+            behaviour will be incorrect.
+
+        :note:
             See :class:`TreeModifier` for more information on how to alter the cache.
         """
         return TreeModifier(self._cache)
@@ -292,12 +307,13 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
         ignore_self: int = 1,
         as_edge: bool = False,
     ) -> Union[Iterator[IndexObjUnion], Iterator[TraversedTreeTup]]:
-        """For documentation, see util.Traversable._traverse().
+        """For documentation, see
+        `Traversable._traverse() <git.objects.util.Traversable._traverse>`.
 
-        Trees are set to ``visit_once = False`` to gain more performance in the traversal.
+        Trees are set to ``visit_once = False`` to gain more performance in the
+        traversal.
         """
 
-        # """
         # # To typecheck instead of using cast.
         # import itertools
         # def is_tree_traversed(inp: Tuple) -> TypeGuard[Tuple[Iterator[Union['Tree', 'Blob', 'Submodule']]]]:
@@ -306,7 +322,8 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
         # ret = super().traverse(predicate, prune, depth, branch_first, visit_once, ignore_self)
         # ret_tup = itertools.tee(ret, 2)
         # assert is_tree_traversed(ret_tup), f"Type is {[type(x) for x in list(ret_tup[0])]}"
-        # return ret_tup[0]"""
+        # return ret_tup[0]
+
         return cast(
             Union[Iterator[IndexObjUnion], Iterator[TraversedTreeTup]],
             super()._traverse(
@@ -321,8 +338,10 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
 
     def list_traverse(self, *args: Any, **kwargs: Any) -> IterableList[IndexObjUnion]:
         """
-        :return: IterableList with the results of the traversal as produced by
-            traverse()
+        :return:
+            :class:`~git.util.IterableList`IterableList with the results of the
+            traversal as produced by :meth:`traverse`
+
             Tree -> IterableList[Union['Submodule', 'Tree', 'Blob']]
         """
         return super()._list_traverse(*args, **kwargs)
@@ -375,9 +394,10 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     def _serialize(self, stream: "BytesIO") -> "Tree":
         """Serialize this tree into the stream. Assumes sorted tree data.
 
-        .. note:: We will assume our tree data to be in a sorted state. If this is not
-            the case, serialization will not generate a correct tree representation as
-            these are assumed to be sorted by algorithms.
+        :note:
+            We will assume our tree data to be in a sorted state. If this is not the
+            case, serialization will not generate a correct tree representation as these
+            are assumed to be sorted by algorithms.
         """
         tree_to_stream(self._cache, stream.write)
         return self

--- a/git/objects/tree.py
+++ b/git/objects/tree.py
@@ -166,7 +166,7 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
 
     Tree as a list:
 
-    * Access a specific blob using the ``tree['filename']`` notation.
+    * Access a specific blob using the ``tree["filename"]`` notation.
     * You may likewise access by index, like ``blob = tree[0]``.
     """
 
@@ -215,8 +215,8 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
         # END handle attribute
 
     def _iter_convert_to_object(self, iterable: Iterable[TreeCacheTup]) -> Iterator[IndexObjUnion]:
-        """Iterable yields tuples of (binsha, mode, name), which will be converted
-        to the respective object representation.
+        """Iterable yields tuples of (binsha, mode, name), which will be converted to
+        the respective object representation.
         """
         for binsha, mode, name in iterable:
             path = join_path(self.path, name)
@@ -338,8 +338,8 @@ class Tree(IndexObject, git_diff.Diffable, util.Traversable, util.Serializable):
     def list_traverse(self, *args: Any, **kwargs: Any) -> IterableList[IndexObjUnion]:
         """
         :return:
-            :class:`~git.util.IterableList`IterableList with the results of the
-            traversal as produced by :meth:`traverse`
+            :class:`~git.util.IterableList` with the results of the traversal as
+            produced by :meth:`traverse`
 
             Tree -> IterableList[Union[Submodule, Tree, Blob]]
         """

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -95,9 +95,9 @@ def mode_str_to_int(modestr: Union[bytes, str]) -> int:
         used.
 
     :return:
-        String identifying a mode compatible to the mode methods ids of the stat module
-        regarding the rwx permissions for user, group and other, special flags and file
-        system flags, such as whether it is a symlink.
+        String identifying a mode compatible to the mode methods ids of the :mod:`stat`
+        module regarding the rwx permissions for user, group and other, special flags
+        and file system flags, such as whether it is a symlink.
     """
     mode = 0
     for iteration, char in enumerate(reversed(modestr[-6:])):
@@ -401,7 +401,7 @@ class Traversable(Protocol):
     def list_traverse(self, *args: Any, **kwargs: Any) -> Any:
         """Traverse self and collect all items found.
 
-        Calling this directly only the abstract base class, including via a ``super()``
+        Calling this directly on the abstract base class, including via a ``super()``
         proxy, is deprecated. Only overridden implementations should be called.
         """
         warnings.warn(
@@ -418,12 +418,13 @@ class Traversable(Protocol):
     ) -> IterableList[Union["Commit", "Submodule", "Tree", "Blob"]]:
         """Traverse self and collect all items found.
 
-        :return: :class:`~git.util.IterableList` with the results of the traversal as
+        :return:
+            :class:`~git.util.IterableList` with the results of the traversal as
             produced by :meth:`traverse`::
 
-                Commit -> IterableList["Commit"]
-                Submodule ->  IterableList["Submodule"]
-                Tree -> IterableList[Union["Submodule", "Tree", "Blob"]]
+                Commit -> IterableList[Commit]
+                Submodule ->  IterableList[Submodule]
+                Tree -> IterableList[Union[Submodule, Tree, Blob]]
         """
         # Commit and Submodule have id.__attribute__ as IterableObj.
         # Tree has id.__attribute__ inherited from IndexObject.
@@ -476,12 +477,12 @@ class Traversable(Protocol):
         """Iterator yielding items found when traversing self.
 
         :param predicate:
-            A function ``f(i,d)`` that returns False if item i at depth ``d`` should not
-            be included in the result.
+            A function ``f(i,d)`` that returns ``False`` if item i at depth ``d`` should
+            not be included in the result.
 
         :param prune:
-            A function ``f(i,d)`` that returns True if the search should stop at item
-            ``i`` at depth ``d``. Item ``i`` will not be returned.
+            A function ``f(i,d)`` that returns ``True`` if the search should stop at
+            item ``i`` at depth ``d``. Item ``i`` will not be returned.
 
         :param depth:
             Defines at which level the iteration should not go deeper if -1, there is no
@@ -489,19 +490,19 @@ class Traversable(Protocol):
             i.e. if 1, you would only get the first level of predecessors/successors.
 
         :param branch_first:
-            If True, items will be returned branch first, otherwise depth first.
+            If ``True``, items will be returned branch first, otherwise depth first.
 
         :param visit_once:
-            If True, items will only be returned once, although they might be
+            If ``True``, items will only be returned once, although they might be
             encountered several times. Loops are prevented that way.
 
         :param ignore_self:
-            If True, self will be ignored and automatically pruned from the result.
-            Otherwise it will be the first item to be returned. If `as_edge` is True, the
-            source of the first edge is None
+            If ``True``, self will be ignored and automatically pruned from the result.
+            Otherwise it will be the first item to be returned. If `as_edge` is
+            ``True``, the source of the first edge is ``None``.
 
         :param as_edge:
-            If True, return a pair of items, first being the source, second the
+            If ``True``, return a pair of items, first being the source, second the
             destination, i.e. tuple(src, dest) with the edge spanning from source to
             destination.
 

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -474,7 +474,7 @@ class Traversable(Protocol):
         ignore_self: int = 1,
         as_edge: bool = False,
     ) -> Union[Iterator[Union["Traversable", "Blob"]], Iterator[TraversedTup]]:
-        """Iterator yielding items found when traversing self.
+        """Iterator yielding items found when traversing `self`.
 
         :param predicate:
             A function ``f(i,d)`` that returns ``False`` if item i at depth ``d`` should
@@ -485,9 +485,10 @@ class Traversable(Protocol):
             item ``i`` at depth ``d``. Item ``i`` will not be returned.
 
         :param depth:
-            Defines at which level the iteration should not go deeper if -1, there is no
-            limit if 0, you would effectively only get self, the root of the iteration
-            i.e. if 1, you would only get the first level of predecessors/successors.
+            Defines at which level the iteration should not go deeper if -1. There is no
+            limit if 0, you would effectively only get `self`, the root of the
+            iteration. If 1, you would only get the first level of
+            predecessors/successors.
 
         :param branch_first:
             If ``True``, items will be returned branch first, otherwise depth first.
@@ -497,8 +498,8 @@ class Traversable(Protocol):
             encountered several times. Loops are prevented that way.
 
         :param ignore_self:
-            If ``True``, self will be ignored and automatically pruned from the result.
-            Otherwise it will be the first item to be returned. If `as_edge` is
+            If ``True``, `self` will be ignored and automatically pruned from the
+            result. Otherwise it will be the first item to be returned. If `as_edge` is
             ``True``, the source of the first edge is ``None``.
 
         :param as_edge:
@@ -507,7 +508,7 @@ class Traversable(Protocol):
             destination.
 
         :return:
-            Iterator yielding items found when traversing self::
+            Iterator yielding items found when traversing `self`::
 
                 Commit -> Iterator[Union[Commit, Tuple[Commit, Commit]] Submodule ->
                 Iterator[Submodule, Tuple[Submodule, Submodule]] Tree ->

--- a/git/objects/util.py
+++ b/git/objects/util.py
@@ -88,14 +88,16 @@ ZERO = timedelta(0)
 
 
 def mode_str_to_int(modestr: Union[bytes, str]) -> int:
-    """
+    """Convert mode bits from an octal mode string to an integer mode for git.
+
     :param modestr:
-        String like 755 or 644 or 100644 - only the last 6 chars will be used.
+        String like ``755`` or ``644`` or ``100644`` - only the last 6 chars will be
+        used.
 
     :return:
-        String identifying a mode compatible to the mode methods ids of the
-        stat module regarding the rwx permissions for user, group and other,
-        special flags and file system flags, such as whether it is a symlink.
+        String identifying a mode compatible to the mode methods ids of the stat module
+        regarding the rwx permissions for user, group and other, special flags and file
+        system flags, such as whether it is a symlink.
     """
     mode = 0
     for iteration, char in enumerate(reversed(modestr[-6:])):
@@ -108,13 +110,17 @@ def mode_str_to_int(modestr: Union[bytes, str]) -> int:
 def get_object_type_by_name(
     object_type_name: bytes,
 ) -> Union[Type["Commit"], Type["TagObject"], Type["Tree"], Type["Blob"]]:
-    """
-    :return: A type suitable to handle the given object type name.
-        Use the type to create new instances.
+    """Retrieve the Python class GitPython uses to represent a kind of Git object.
 
-    :param object_type_name: Member of TYPES
+    :return:
+        A type suitable to handle the given as `object_type_name`.
+        This type can be called create new instances.
 
-    :raise ValueError: If object_type_name is unknown
+    :param object_type_name:
+        Member of :attr:`Object.TYPES <git.objects.base.Object.TYPES>`.
+
+    :raise ValueError:
+        If `object_type_name` is unknown.
     """
     if object_type_name == b"commit":
         from . import commit
@@ -137,10 +143,11 @@ def get_object_type_by_name(
 
 
 def utctz_to_altz(utctz: str) -> int:
-    """Convert a git timezone offset into a timezone offset west of
-    UTC in seconds (compatible with :attr:`time.altzone`).
+    """Convert a git timezone offset into a timezone offset west of UTC in seconds
+    (compatible with :attr:`time.altzone`).
 
-    :param utctz: git utc timezone string, e.g. +0200
+    :param utctz:
+        git utc timezone string, e.g. +0200
     """
     int_utctz = int(utctz)
     seconds = (abs(int_utctz) // 100) * 3600 + (abs(int_utctz) % 100) * 60
@@ -148,9 +155,11 @@ def utctz_to_altz(utctz: str) -> int:
 
 
 def altz_to_utctz_str(altz: float) -> str:
-    """Convert a timezone offset west of UTC in seconds into a Git timezone offset string.
+    """Convert a timezone offset west of UTC in seconds into a Git timezone offset
+    string.
 
-    :param altz: Timezone offset in seconds west of UTC
+    :param altz:
+        Timezone offset in seconds west of UTC.
     """
     hours = abs(altz) // 3600
     minutes = (abs(altz) % 3600) // 60
@@ -160,9 +169,11 @@ def altz_to_utctz_str(altz: float) -> str:
 
 def verify_utctz(offset: str) -> str:
     """
-    :raise ValueError: If offset is incorrect
+    :raise ValueError:
+        If `offset` is incorrect.
 
-    :return: offset
+    :return:
+        `offset`
     """
     fmt_exc = ValueError("Invalid timezone offset format: %s" % offset)
     if len(offset) != 5:
@@ -197,7 +208,8 @@ utc = tzoffset(0, "UTC")
 
 
 def from_timestamp(timestamp: float, tz_offset: float) -> datetime:
-    """Convert a timestamp + tz_offset into an aware datetime instance."""
+    """Convert a `timestamp` + `tz_offset` into an aware :class:`~datetime.datetime`
+    instance."""
     utc_dt = datetime.fromtimestamp(timestamp, utc)
     try:
         local_dt = utc_dt.astimezone(tzoffset(tz_offset))
@@ -207,20 +219,22 @@ def from_timestamp(timestamp: float, tz_offset: float) -> datetime:
 
 
 def parse_date(string_date: Union[str, datetime]) -> Tuple[int, int]:
-    """
-    Parse the given date as one of the following:
+    """Parse the given date as one of the following:
 
         * Aware datetime instance
         * Git internal format: timestamp offset
-        * RFC 2822: Thu, 07 Apr 2005 22:13:13 +0200.
-        * ISO 8601 2005-04-07T22:13:13
+        * RFC 2822: ``Thu, 07 Apr 2005 22:13:13 +0200``
+        * ISO 8601: ``2005-04-07T22:13:13``
             The T can be a space as well.
 
-    :return: Tuple(int(timestamp_UTC), int(offset)), both in seconds since epoch
+    :return:
+        Tuple(int(timestamp_UTC), int(offset)), both in seconds since epoch
 
-    :raise ValueError: If the format could not be understood
+    :raise ValueError:
+        If the format could not be understood.
 
-    :note: Date can also be YYYY.MM.DD, MM/DD/YYYY and DD.MM.YYYY.
+    :note:
+        Date can also be ``YYYY.MM.DD``, ``MM/DD/YYYY`` and ``DD.MM.YYYY``.
     """
     if isinstance(string_date, datetime):
         if string_date.tzinfo:
@@ -314,7 +328,8 @@ def parse_actor_and_date(line: str) -> Tuple[Actor, int, int]:
 
         author Tom Preston-Werner <tom@mojombo.com> 1191999972 -0700
 
-    :return: [Actor, int_seconds_since_epoch, int_timezone_offset]
+    :return:
+        [Actor, int_seconds_since_epoch, int_timezone_offset]
     """
     actor, epoch, offset = "", "0", "0"
     m = _re_actor_epoch.search(line)
@@ -336,8 +351,8 @@ class ProcessStreamAdapter:
     """Class wiring all calls to the contained Process instance.
 
     Use this type to hide the underlying process to provide access only to a specified
-    stream. The process is usually wrapped into an AutoInterrupt class to kill
-    it if the instance goes out of scope.
+    stream. The process is usually wrapped into an :class:`~git.cmd.Git.AutoInterrupt`
+    class to kill it if the instance goes out of scope.
     """
 
     __slots__ = ("_proc", "_stream")
@@ -352,14 +367,18 @@ class ProcessStreamAdapter:
 
 @runtime_checkable
 class Traversable(Protocol):
-    """Simple interface to perform depth-first or breadth-first traversals
-    in one direction.
+    """Simple interface to perform depth-first or breadth-first traversals in one
+    direction.
 
     Subclasses only need to implement one function.
 
-    Instances of the Subclass must be hashable.
+    Instances of the subclass must be hashable.
 
-    Defined subclasses = [Commit, Tree, SubModule]
+    Defined subclasses:
+
+    * :class:`Commit <git.objects.Commit>`
+    * :class:`Tree <git.objects.tree.Tree>`
+    * :class:`Submodule <git.objects.submodule.base.Submodule>`
     """
 
     __slots__ = ()
@@ -368,7 +387,7 @@ class Traversable(Protocol):
     @abstractmethod
     def _get_intermediate_items(cls, item: Any) -> Sequence["Traversable"]:
         """
-        Returns:
+        :return:
             Tuple of items connected to the given item.
             Must be implemented in subclass.
 
@@ -399,20 +418,23 @@ class Traversable(Protocol):
     ) -> IterableList[Union["Commit", "Submodule", "Tree", "Blob"]]:
         """Traverse self and collect all items found.
 
-        :return: IterableList with the results of the traversal as produced by
-            :meth:`traverse`::
+        :return: :class:`~git.util.IterableList` with the results of the traversal as
+            produced by :meth:`traverse`::
 
-                Commit -> IterableList['Commit']
-                Submodule ->  IterableList['Submodule']
-                Tree -> IterableList[Union['Submodule', 'Tree', 'Blob']]
+                Commit -> IterableList["Commit"]
+                Submodule ->  IterableList["Submodule"]
+                Tree -> IterableList[Union["Submodule", "Tree", "Blob"]]
         """
         # Commit and Submodule have id.__attribute__ as IterableObj.
         # Tree has id.__attribute__ inherited from IndexObject.
         if isinstance(self, Has_id_attribute):
             id = self._id_attribute_
         else:
-            id = ""  # Shouldn't reach here, unless Traversable subclass created with no _id_attribute_.
-            # Could add _id_attribute_ to Traversable, or make all Traversable also Iterable?
+            # Shouldn't reach here, unless Traversable subclass created with no
+            # _id_attribute_.
+            id = ""
+            # Could add _id_attribute_ to Traversable, or make all Traversable also
+            # Iterable?
 
         if not as_edge:
             out: IterableList[Union["Commit", "Submodule", "Tree", "Blob"]] = IterableList(id)
@@ -453,46 +475,49 @@ class Traversable(Protocol):
     ) -> Union[Iterator[Union["Traversable", "Blob"]], Iterator[TraversedTup]]:
         """Iterator yielding items found when traversing self.
 
-        :param predicate: f(i,d) returns False if item i at depth d should not be
-            included in the result.
+        :param predicate:
+            A function ``f(i,d)`` that returns False if item i at depth ``d`` should not
+            be included in the result.
 
         :param prune:
-            f(i,d) return True if the search should stop at item i at depth d. Item i
-            will not be returned.
+            A function ``f(i,d)`` that returns True if the search should stop at item
+            ``i`` at depth ``d``. Item ``i`` will not be returned.
 
         :param depth:
             Defines at which level the iteration should not go deeper if -1, there is no
             limit if 0, you would effectively only get self, the root of the iteration
-            i.e. if 1, you would only get the first level of predecessors/successors
+            i.e. if 1, you would only get the first level of predecessors/successors.
 
         :param branch_first:
-            if True, items will be returned branch first, otherwise depth first
+            If True, items will be returned branch first, otherwise depth first.
 
         :param visit_once:
-            if True, items will only be returned once, although they might be
+            If True, items will only be returned once, although they might be
             encountered several times. Loops are prevented that way.
 
         :param ignore_self:
-            if True, self will be ignored and automatically pruned from the result.
-            Otherwise it will be the first item to be returned. If as_edge is True, the
+            If True, self will be ignored and automatically pruned from the result.
+            Otherwise it will be the first item to be returned. If `as_edge` is True, the
             source of the first edge is None
 
         :param as_edge:
-            if True, return a pair of items, first being the source, second the
+            If True, return a pair of items, first being the source, second the
             destination, i.e. tuple(src, dest) with the edge spanning from source to
-            destination
+            destination.
 
-        :return: Iterator yielding items found when traversing self::
+        :return:
+            Iterator yielding items found when traversing self::
 
-                Commit -> Iterator[Union[Commit, Tuple[Commit, Commit]]
-                Submodule -> Iterator[Submodule, Tuple[Submodule, Submodule]]
-                Tree -> Iterator[Union[Blob, Tree, Submodule,
-                                        Tuple[Union[Submodule, Tree], Union[Blob, Tree, Submodule]]]
+                Commit -> Iterator[Union[Commit, Tuple[Commit, Commit]] Submodule ->
+                Iterator[Submodule, Tuple[Submodule, Submodule]] Tree ->
+                Iterator[Union[Blob, Tree, Submodule,
+                                        Tuple[Union[Submodule, Tree], Union[Blob, Tree,
+                                        Submodule]]]
 
-                ignore_self=True is_edge=True -> Iterator[item]
-                ignore_self=True is_edge=False --> Iterator[item]
-                ignore_self=False is_edge=True -> Iterator[item] | Iterator[Tuple[src, item]]
-                ignore_self=False is_edge=False -> Iterator[Tuple[src, item]]
+                ignore_self=True is_edge=True -> Iterator[item] ignore_self=True
+                is_edge=False --> Iterator[item] ignore_self=False is_edge=True ->
+                Iterator[item] | Iterator[Tuple[src, item]] ignore_self=False
+                is_edge=False -> Iterator[Tuple[src, item]]
         """
 
         visited = set()
@@ -526,7 +551,9 @@ class Traversable(Protocol):
                 visited.add(item)
 
             rval: Union[TraversedTup, "Traversable", "Blob"]
-            if as_edge:  # If as_edge return (src, item) unless rrc is None (e.g. for first item).
+            if as_edge:
+                # If as_edge return (src, item) unless rrc is None
+                # (e.g. for first item).
                 rval = (src, item)
             else:
                 rval = item
@@ -549,7 +576,8 @@ class Traversable(Protocol):
 
 @runtime_checkable
 class Serializable(Protocol):
-    """Defines methods to serialize and deserialize objects from and into a data stream."""
+    """Defines methods to serialize and deserialize objects from and into a data
+    stream."""
 
     __slots__ = ()
 
@@ -557,11 +585,14 @@ class Serializable(Protocol):
     def _serialize(self, stream: "BytesIO") -> "Serializable":
         """Serialize the data of this object into the given data stream.
 
-        :note: A serialized object would :meth:`_deserialize` into the same object.
+        :note:
+            A serialized object would :meth:`_deserialize` into the same object.
 
-        :param stream: a file-like object
+        :param stream:
+            A file-like object.
 
-        :return: self
+        :return:
+            self
         """
         raise NotImplementedError("To be implemented in subclass")
 
@@ -569,9 +600,11 @@ class Serializable(Protocol):
     def _deserialize(self, stream: "BytesIO") -> "Serializable":
         """Deserialize all information regarding this object from the stream.
 
-        :param stream: a file-like object
+        :param stream:
+            A file-like object.
 
-        :return: self
+        :return:
+            self
         """
         raise NotImplementedError("To be implemented in subclass")
 

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -36,8 +36,8 @@ def strip_quotes(string: str) -> str:
 
 
 class HEAD(SymbolicReference):
-    """Special case of a SymbolicReference representing the repository's
-    HEAD reference."""
+    """Special case of a SymbolicReference representing the repository's HEAD
+    reference."""
 
     _HEAD_NAME = "HEAD"
     _ORIG_HEAD_NAME = "ORIG_HEAD"
@@ -66,22 +66,21 @@ class HEAD(SymbolicReference):
         paths: Union[PathLike, Sequence[PathLike], None] = None,
         **kwargs: Any,
     ) -> "HEAD":
-        """Reset our HEAD to the given commit optionally synchronizing
-        the index and working tree. The reference we refer to will be set to commit as
-        well.
+        """Reset our HEAD to the given commit optionally synchronizing the index and
+        working tree. The reference we refer to will be set to commit as well.
 
         :param commit:
             :class:`~git.objects.commit.Commit`, :class:`~git.refs.reference.Reference`,
             or string identifying a revision we should reset HEAD to.
 
         :param index:
-            If True, the index will be set to match the given commit.
+            If ``True``, the index will be set to match the given commit.
             Otherwise it will not be touched.
 
         :param working_tree:
-            If True, the working tree will be forcefully adjusted to match the given
+            If ``True``, the working tree will be forcefully adjusted to match the given
             commit, possibly overwriting uncommitted changes without warning.
-            If `working_tree` is True, `index` must be True as well.
+            If `working_tree` is ``True``, `index` must be ``True`` as well.
 
         :param paths:
             Single path or list of paths relative to the git root directory
@@ -90,7 +89,8 @@ class HEAD(SymbolicReference):
         :param kwargs:
             Additional arguments passed to ``git reset``.
 
-        :return: self
+        :return:
+            self
         """
         mode: Union[str, None]
         mode = "--soft"
@@ -151,8 +151,8 @@ class Head(Reference):
         """Delete the given heads.
 
         :param force:
-            If True, the heads will be deleted even if they are not yet merged into the
-            main development stream. Default False.
+            If ``True``, the heads will be deleted even if they are not yet merged into
+            the main development stream. Default ``False``.
         """
         flag = "-d"
         if force:
@@ -193,7 +193,7 @@ class Head(Reference):
     def tracking_branch(self) -> Union["RemoteReference", None]:
         """
         :return:
-            The remote reference we are tracking, or None if we are not a tracking
+            The remote reference we are tracking, or ``None`` if we are not a tracking
             branch.
         """
         from .remote import RemoteReference
@@ -219,14 +219,14 @@ class Head(Reference):
             The prefix ``refs/heads`` is implied.
 
         :param force:
-            If True, the rename will succeed even if a head with the target name
+            If ``True``, the rename will succeed even if a head with the target name
             already exists.
 
         :return:
             self
 
         :note:
-            Respects the ref log as git commands are used.
+            Respects the ref log, as git commands are used.
         """
         flag = "-m"
         if force:
@@ -244,8 +244,8 @@ class Head(Reference):
         The command will fail if changed working tree files would be overwritten.
 
         :param force:
-            If True, changes to the index and the working tree will be discarded.
-            If False, :class:`~git.exc.GitCommandError` will be raised in that
+            If ``True``, changes to the index and the working tree will be discarded.
+            If ``False``, :class:`~git.exc.GitCommandError` will be raised in that
             situation.
 
         :param kwargs:

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -52,8 +52,9 @@ class HEAD(SymbolicReference):
 
     def orig_head(self) -> SymbolicReference:
         """
-        :return: SymbolicReference pointing at the ORIG_HEAD, which is maintained
-            to contain the previous value of HEAD.
+        :return:
+            :class:`~git.refs.symbolic.SymbolicReference` pointing at the ORIG_HEAD,
+            which is maintained to contain the previous value of HEAD.
         """
         return SymbolicReference(self.repo, self._ORIG_HEAD_NAME)
 
@@ -66,16 +67,16 @@ class HEAD(SymbolicReference):
         **kwargs: Any,
     ) -> "HEAD":
         """Reset our HEAD to the given commit optionally synchronizing
-        the index and working tree. The reference we refer to will be set to
-        commit as well.
+        the index and working tree. The reference we refer to will be set to commit as
+        well.
 
         :param commit:
-            Commit object, Reference Object or string identifying a revision we
-            should reset HEAD to.
+            :class:`~git.objects.commit.Commit`, :class:`~git.refs.reference.Reference`,
+            or string identifying a revision we should reset HEAD to.
 
         :param index:
-            If True, the index will be set to match the given commit. Otherwise
-            it will not be touched.
+            If True, the index will be set to match the given commit.
+            Otherwise it will not be touched.
 
         :param working_tree:
             If True, the working tree will be forcefully adjusted to match the given
@@ -87,7 +88,7 @@ class HEAD(SymbolicReference):
             that are to be reset. This allows to partially reset individual files.
 
         :param kwargs:
-            Additional arguments passed to git-reset.
+            Additional arguments passed to ``git reset``.
 
         :return: self
         """
@@ -123,8 +124,8 @@ class HEAD(SymbolicReference):
 
 
 class Head(Reference):
-    """A Head is a named reference to a Commit. Every Head instance contains a name
-    and a Commit object.
+    """A Head is a named reference to a :class:`~git.objects.commit.Commit`. Every Head
+    instance contains a name and a :class:`~git.objects.commit.Commit` object.
 
     Examples::
 
@@ -150,9 +151,8 @@ class Head(Reference):
         """Delete the given heads.
 
         :param force:
-            If True, the heads will be deleted even if they are not yet merged into
-            the main development stream.
-            Default False
+            If True, the heads will be deleted even if they are not yet merged into the
+            main development stream. Default False.
         """
         flag = "-d"
         if force:
@@ -163,9 +163,11 @@ class Head(Reference):
         """Configure this branch to track the given remote reference. This will
         alter this branch's configuration accordingly.
 
-        :param remote_reference: The remote reference to track or None to untrack
-            any references.
-        :return: self
+        :param remote_reference:
+            The remote reference to track or None to untrack any references.
+
+        :return:
+            self
         """
         from .remote import RemoteReference
 
@@ -190,8 +192,10 @@ class Head(Reference):
 
     def tracking_branch(self) -> Union["RemoteReference", None]:
         """
-        :return: The remote_reference we are tracking, or None if we are
-            not a tracking branch."""
+        :return:
+            The remote reference we are tracking, or None if we are not a tracking
+            branch.
+        """
         from .remote import RemoteReference
 
         reader = self.config_reader()
@@ -211,16 +215,18 @@ class Head(Reference):
         """Rename self to a new path.
 
         :param new_path:
-            Either a simple name or a path, i.e. new_name or features/new_name.
-            The prefix refs/heads is implied.
+            Either a simple name or a path, e.g. ``new_name`` or ``features/new_name``.
+            The prefix ``refs/heads`` is implied.
 
         :param force:
             If True, the rename will succeed even if a head with the target name
             already exists.
 
-        :return: self
+        :return:
+            self
 
-        :note: Respects the ref log as git commands are used.
+        :note:
+            Respects the ref log as git commands are used.
         """
         flag = "-m"
         if force:
@@ -247,15 +253,15 @@ class Head(Reference):
             ``b="new_branch"`` to create a new branch at the given spot.
 
         :return:
-            The active branch after the checkout operation, usually self unless
-            a new branch has been created.
+            The active branch after the checkout operation, usually self unless a new
+            branch has been created.
             If there is no active branch, as the HEAD is now detached, the HEAD
             reference will be returned instead.
 
         :note:
-            By default it is only allowed to checkout heads - everything else
-            will leave the HEAD detached which is allowed and possible, but remains
-            a special state that some tools might not be able to handle.
+            By default it is only allowed to checkout heads - everything else will leave
+            the HEAD detached which is allowed and possible, but remains a special state
+            that some tools might not be able to handle.
         """
         kwargs["f"] = force
         if kwargs["f"] is False:
@@ -279,15 +285,17 @@ class Head(Reference):
 
     def config_reader(self) -> SectionConstraint[GitConfigParser]:
         """
-        :return: A configuration parser instance constrained to only read
-            this instance's values.
+        :return:
+            A configuration parser instance constrained to only read this instance's
+            values.
         """
         return self._config_parser(read_only=True)
 
     def config_writer(self) -> SectionConstraint[GitConfigParser]:
         """
-        :return: A configuration writer instance with read-and write access
-            to options of this head.
+        :return:
+            A configuration writer instance with read-and write access to options of
+            this head.
         """
         return self._config_parser(read_only=False)
 

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -104,7 +104,7 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
         tz_offset: int,
         message: str,
     ) -> "RefLogEntry":  # skipcq: PYL-W0621
-        """:return: New instance of a RefLogEntry"""
+        """:return: New instance of a :class:`RefLogEntry`"""
         if not isinstance(actor, Actor):
             raise ValueError("Need actor instance, got %s" % actor)
         # END check types
@@ -112,7 +112,7 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
 
     @classmethod
     def from_line(cls, line: bytes) -> "RefLogEntry":
-        """:return: New RefLogEntry instance from the given revlog line.
+        """:return: New :class:`RefLogEntry` instance from the given revlog line.
 
         :param line:
             Line bytes without trailing newline
@@ -311,7 +311,7 @@ class RefLog(List[RefLogEntry], Serializable):
         :param config_reader:
             Configuration reader of the repository - used to obtain user information.
             May also be an :class:`~git.util.Actor` instance identifying the committer
-            directly or None.
+            directly or ``None``.
 
         :param filepath:
             Full path to the log file.
@@ -326,7 +326,7 @@ class RefLog(List[RefLogEntry], Serializable):
             Message describing the change to the reference.
 
         :param write:
-            If True, the changes will be written right away.
+            If ``True``, the changes will be written right away.
             Otherwise the change will not be written.
 
         :return:

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -25,7 +25,8 @@ __all__ = ["Reference"]
 
 
 def require_remote_ref_path(func: Callable[..., _T]) -> Callable[..., _T]:
-    """A decorator raising a TypeError if we are not a valid remote, based on the path."""
+    """A decorator raising :class:`TypeError` if we are not a valid remote, based on the
+    path."""
 
     def wrapper(self: T_References, *args: Any) -> _T:
         if not self.is_remote():
@@ -56,11 +57,16 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
     def __init__(self, repo: "Repo", path: PathLike, check_path: bool = True) -> None:
         """Initialize this instance.
 
-        :param repo: Our parent repository.
-        :param path: Path relative to the .git/ directory pointing to the ref in
-            question, e.g. ``refs/heads/master``.
-        :param check_path: If False, you can provide any path. Otherwise the path must
-            start with the default path prefix of this type.
+        :param repo:
+            Our parent repository.
+
+        :param path:
+            Path relative to the ``.git/`` directory pointing to the ref in question,
+            e.g. ``refs/heads/master``.
+
+        :param check_path:
+            If False, you can provide any path.
+            Otherwise the path must start with the default path prefix of this type.
         """
         if check_path and not str(path).startswith(self._common_path_default + "/"):
             raise ValueError(f"Cannot instantiate {self.__class__.__name__!r} from path {path}")
@@ -80,7 +86,8 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
     ) -> "Reference":
         """Special version which checks if the head-log needs an update as well.
 
-        :return: self
+        :return:
+            self
         """
         oldbinsha = None
         if logmsg is not None:
@@ -115,7 +122,10 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
 
     @property
     def name(self) -> str:
-        """:return: (shortest) Name of this reference - it may contain path components"""
+        """
+        :return:
+            (shortest) Name of this reference - it may contain path components
+        """
         # The first two path tokens can be removed as they are
         # refs/heads or refs/tags or refs/remotes.
         tokens = self.path.split("/")
@@ -144,8 +154,8 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
     def remote_name(self) -> str:
         """
         :return:
-            Name of the remote we are a reference of, such as 'origin' for a reference
-            named 'origin/master'.
+            Name of the remote we are a reference of, such as ``origin`` for a reference
+            named ``origin/master``.
         """
         tokens = self.path.split("/")
         # /refs/remotes/<remote name>/<branch_name>
@@ -155,10 +165,12 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
     @require_remote_ref_path
     def remote_head(self) -> str:
         """
-        :return: Name of the remote head itself, e.g. master.
+        :return:
+            Name of the remote head itself, e.g. ``master``.
 
-        :note: The returned name is usually not qualified enough to uniquely identify
-            a branch.
+        :note:
+            The returned name is usually not qualified enough to uniquely identify a
+            branch.
         """
         tokens = self.path.split("/")
         return "/".join(tokens[3:])

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -65,7 +65,7 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
             e.g. ``refs/heads/master``.
 
         :param check_path:
-            If False, you can provide any path.
+            If ``False``, you can provide any path.
             Otherwise the path must start with the default path prefix of this type.
         """
         if check_path and not str(path).startswith(self._common_path_default + "/"):
@@ -141,8 +141,9 @@ class Reference(SymbolicReference, LazyMixin, IterableObj):
         *args: Any,
         **kwargs: Any,
     ) -> Iterator[T_References]:
-        """Equivalent to SymbolicReference.iter_items, but will return non-detached
-        references as well."""
+        """Equivalent to
+        :meth:`SymbolicReference.iter_items <git.refs.symbolic.SymbolicReference.iter_items>`,
+        but will return non-detached references as well."""
         return cls._iter_items(repo, common_path)
 
     # }END interface

--- a/git/refs/reference.py
+++ b/git/refs/reference.py
@@ -25,7 +25,7 @@ __all__ = ["Reference"]
 
 
 def require_remote_ref_path(func: Callable[..., _T]) -> Callable[..., _T]:
-    """A decorator raising :class:`TypeError` if we are not a valid remote, based on the
+    """A decorator raising :class:`ValueError` if we are not a valid remote, based on the
     path."""
 
     def wrapper(self: T_References, *args: Any) -> _T:

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -47,10 +47,10 @@ class RemoteReference(Head):
         # super is Reference
         return super().iter_items(repo, common_path)
 
-    # The Head implementation of delete also accepts strs, but this
-    # implementation does not.  mypy doesn't have a way of representing
-    # tightening the types of arguments in subclasses and recommends Any or
-    # "type: ignore".  (See https://github.com/python/typing/issues/241)
+    # The Head implementation of delete also accepts strs, but this implementation does
+    # not. mypy doesn't have a way of representing tightening the types of arguments in
+    # subclasses and recommends Any or "type: ignore".
+    # (See: https://github.com/python/typing/issues/241)
     @classmethod
     def delete(cls, repo: "Repo", *refs: "RemoteReference", **kwargs: Any) -> None:  # type: ignore
         """Delete the given remote references.
@@ -60,9 +60,9 @@ class RemoteReference(Head):
             should not narrow the signature.
         """
         repo.git.branch("-d", "-r", *refs)
-        # The official deletion method will ignore remote symbolic refs - these
-        # are generally ignored in the refs/ folder. We don't though
-        # and delete remainders manually.
+        # The official deletion method will ignore remote symbolic refs - these are
+        # generally ignored in the refs/ folder. We don't though and delete remainders
+        # manually.
         for ref in refs:
             try:
                 os.remove(os.path.join(repo.common_dir, ref.path))
@@ -76,5 +76,5 @@ class RemoteReference(Head):
 
     @classmethod
     def create(cls, *args: Any, **kwargs: Any) -> NoReturn:
-        """Raises TypeError. Defined so the create method is disabled."""
+        """Raise :class:`TypeError`. Defined so the ``create`` method is disabled."""
         raise TypeError("Cannot explicitly create remote references")

--- a/git/refs/remote.py
+++ b/git/refs/remote.py
@@ -56,7 +56,7 @@ class RemoteReference(Head):
         """Delete the given remote references.
 
         :note:
-            kwargs are given for comparability with the base class method as we
+            `kwargs` are given for comparability with the base class method as we
             should not narrow the signature.
         """
         repo.git.branch("-d", "-r", *refs)

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -225,10 +225,10 @@ class SymbolicReference:
     ) -> Union[Tuple[str, None], Tuple[None, str]]:
         """
         :return:
-            (str(sha), str(target_ref_path)) if available, the sha the file at rela_path
-            points to, or ``None``.
+            *(str(sha), str(target_ref_path))*, where:
 
-            target_ref_path is the reference we point to, or ``None``.
+            * *sha* is of the file at rela_path points to if available, or ``None``.
+            * *target_ref_path* is the reference we point to, or ``None``.
         """
         if ref_path:
             cls._check_ref_name_valid(ref_path)
@@ -270,10 +270,11 @@ class SymbolicReference:
     @classmethod
     def _get_ref_info(cls, repo: "Repo", ref_path: Union[PathLike, None]) -> Union[Tuple[str, None], Tuple[None, str]]:
         """
-        :return: (str(sha), str(target_ref_path)) if available, the sha the file at
-            rela_path points to, or None.
+        :return:
+            *(str(sha), str(target_ref_path))*, where:
 
-            target_ref_path is the reference we point to, or ``None``.
+            * *sha* is of the file at rela_path points to if available, or ``None``.
+            * *target_ref_path* is the reference we point to, or ``None``.
         """
         return cls._get_ref_info_helper(repo, ref_path)
 
@@ -290,9 +291,9 @@ class SymbolicReference:
     def _get_commit(self) -> "Commit":
         """
         :return:
-            Commit object we point to. This works for detached and non-detached
-            :class:`SymbolicReference` instances. The symbolic reference will be
-            dereferenced recursively.
+            :class:`~git.objects.commit.Commit` object we point to. This works for
+            detached and non-detached :class:`SymbolicReference` instances. The symbolic
+            reference will be dereferenced recursively.
         """
         obj = self._get_object()
         if obj.type == "tag":

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -100,8 +100,8 @@ class SymbolicReference:
     def name(self) -> str:
         """
         :return:
-            In case of symbolic references, the shortest assumable name
-            is the path itself.
+            In case of symbolic references, the shortest assumable name is the path
+            itself.
         """
         return str(self.path)
 
@@ -118,7 +118,8 @@ class SymbolicReference:
         """Return an iterator yielding pairs of sha1/path pairs (as strings)
         for the corresponding refs.
 
-        :note: The packed refs file will be kept open as long as we iterate.
+        :note:
+            The packed refs file will be kept open as long as we iterate.
         """
         try:
             with open(cls._get_packed_refs_path(repo), "rt", encoding="UTF-8") as fp:
@@ -155,10 +156,12 @@ class SymbolicReference:
     @classmethod
     def dereference_recursive(cls, repo: "Repo", ref_path: Union[PathLike, None]) -> str:
         """
-        :return: hexsha stored in the reference at the given ref_path, recursively dereferencing all
-            intermediate references as required
+        :return:
+            hexsha stored in the reference at the given `ref_path`, recursively
+            dereferencing all intermediate references as required
 
-        :param repo: The repository containing the reference at ref_path
+        :param repo:
+            The repository containing the reference at `ref_path`.
         """
 
         while True:
@@ -221,8 +224,9 @@ class SymbolicReference:
         cls, repo: "Repo", ref_path: Union[PathLike, None]
     ) -> Union[Tuple[str, None], Tuple[None, str]]:
         """
-        :return: (str(sha), str(target_ref_path)) if available, the sha the file at
-            rela_path points to, or None.
+        :return:
+            (str(sha), str(target_ref_path)) if available, the sha the file at rela_path
+            points to, or None.
 
             target_ref_path is the reference we point to, or None.
         """
@@ -276,8 +280,8 @@ class SymbolicReference:
     def _get_object(self) -> Commit_ish:
         """
         :return:
-            The object our ref currently refers to. Refs can be cached, they will
-            always point to the actual object as it gets re-created on each query.
+            The object our ref currently refers to. Refs can be cached, they will always
+            point to the actual object as it gets re-created on each query.
         """
         # We have to be dynamic here as we may be a tag which can point to anything.
         # Our path will be resolved to the hexsha which will be used accordingly.
@@ -305,11 +309,15 @@ class SymbolicReference:
         commit: Union[Commit, "SymbolicReference", str],
         logmsg: Union[str, None] = None,
     ) -> "SymbolicReference":
-        """As set_object, but restricts the type of object to be a Commit.
+        """Like :meth:`set_object`, but restricts the type of object to be a
+        :class:`~git.objects.commit.Commit`.
 
-        :raise ValueError: If commit is not a :class:`~git.objects.commit.Commit` object
-            or doesn't point to a commit
-        :return: self
+        :raise ValueError:
+            If `commit` is not a :class:`~git.objects.commit.Commit` object or doesn't
+            point to a commit.
+
+        :return:
+            self
         """
         # Check the type - assume the best if it is a base-string.
         invalid_type = False
@@ -339,18 +347,25 @@ class SymbolicReference:
         object: Union[Commit_ish, "SymbolicReference", str],
         logmsg: Union[str, None] = None,
     ) -> "SymbolicReference":
-        """Set the object we point to, possibly dereference our symbolic reference first.
-        If the reference does not exist, it will be created.
+        """Set the object we point to, possibly dereference our symbolic reference
+        first. If the reference does not exist, it will be created.
 
-        :param object: A refspec, a :class:`SymbolicReference` or an
-            :class:`~git.objects.base.Object` instance.
-            :class:`SymbolicReference` instances will be dereferenced beforehand to
-            obtain the object they point to.
-        :param logmsg: If not None, the message will be used in the reflog entry to be
-            written. Otherwise the reflog is not altered.
-        :note: Plain :class:`SymbolicReference` instances may not actually point to
-            objects by convention.
-        :return: self
+        :param object:
+            A refspec, a :class:`SymbolicReference` or an
+            :class:`~git.objects.base.Object` instance. :class:`SymbolicReference`
+            instances will be dereferenced beforehand to obtain the object they point
+            to.
+
+        :param logmsg:
+            If not None, the message will be used in the reflog entry to be written.
+            Otherwise the reflog is not altered.
+
+        :note:
+            Plain :class:`SymbolicReference` instances may not actually point to objects
+            by convention.
+
+        :return:
+            self
         """
         if isinstance(object, SymbolicReference):
             object = object.object  # @ReservedAssignment
@@ -374,10 +389,13 @@ class SymbolicReference:
 
     def _get_reference(self) -> "SymbolicReference":
         """
-        :return: Reference Object we point to
+        :return:
+            :class:`~git.refs.reference.Reference` object we point to
 
-        :raise TypeError: If this symbolic reference is detached, hence it doesn't point
-            to a reference, but to a commit"""
+        :raise TypeError:
+            If this symbolic reference is detached, hence it doesn't point to a
+            reference, but to a commit.
+        """
         sha, target_ref_path = self._get_ref_info(self.repo, self.path)
         if target_ref_path is None:
             raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
@@ -388,10 +406,13 @@ class SymbolicReference:
         ref: Union[Commit_ish, "SymbolicReference", str],
         logmsg: Union[str, None] = None,
     ) -> "SymbolicReference":
-        """Set ourselves to the given ref. It will stay a symbol if the ref is a Reference.
-        Otherwise an Object, given as Object instance or refspec, is assumed and if valid,
-        will be set which effectively detaches the reference if it was a purely
-        symbolic one.
+        """Set ourselves to the given `ref`.
+
+        It will stay a symbol if the ref is a :class:`~git.refs.reference.Reference`.
+
+        Otherwise an Object, given as :class:`~git.objects.base.Object` instance or
+        refspec, is assumed and if valid, will be set which effectively detaches the
+        reference if it was a purely symbolic one.
 
         :param ref:
             A :class:`SymbolicReference` instance, an :class:`~git.objects.base.Object`
@@ -399,15 +420,18 @@ class SymbolicReference:
             :class:`SymbolicReference` instance, we will point to it. Everything else is
             dereferenced to obtain the actual object.
 
-        :param logmsg: If set to a string, the message will be used in the reflog.
+        :param logmsg:
+            If set to a string, the message will be used in the reflog.
             Otherwise, a reflog entry is not written for the changed reference.
             The previous commit of the entry will be the commit we point to now.
 
             See also: :meth:`log_append`
 
-        :return: self
+        :return:
+            self
 
-        :note: This symbolic reference will not be dereferenced. For that, see
+        :note:
+            This symbolic reference will not be dereferenced. For that, see
             :meth:`set_object`.
         """
         write_value = None
@@ -467,8 +491,8 @@ class SymbolicReference:
     def is_valid(self) -> bool:
         """
         :return:
-            True if the reference is valid, hence it can be read and points to
-            a valid object or reference.
+            True if the reference is valid, hence it can be read and points to a valid
+            object or reference.
         """
         try:
             self.object
@@ -492,11 +516,13 @@ class SymbolicReference:
 
     def log(self) -> "RefLog":
         """
-        :return: RefLog for this reference. Its last entry reflects the latest change
-            applied to this reference.
+        :return:
+            :class:`~git.refs.log.RefLog` for this reference.
+            Its last entry reflects the latest change applied to this reference.
 
-        .. note:: As the log is parsed every time, its recommended to cache it for use
-            instead of calling this method repeatedly. It should be considered read-only.
+        :note:
+            As the log is parsed every time, its recommended to cache it for use instead
+            of calling this method repeatedly. It should be considered read-only.
         """
         return RefLog.from_file(RefLog.path(self))
 
@@ -508,11 +534,17 @@ class SymbolicReference:
     ) -> "RefLogEntry":
         """Append a logentry to the logfile of this ref.
 
-        :param oldbinsha: Binary sha this ref used to point to.
-        :param message: A message describing the change.
-        :param newbinsha: The sha the ref points to now. If None, our current commit sha
-            will be used.
-        :return: The added :class:`~git.refs.log.RefLogEntry` instance.
+        :param oldbinsha:
+            Binary sha this ref used to point to.
+
+        :param message:
+            A message describing the change.
+
+        :param newbinsha:
+            The sha the ref points to now. If None, our current commit sha will be used.
+
+        :return:
+            The added :class:`~git.refs.log.RefLogEntry` instance.
         """
         # NOTE: We use the committer of the currently active commit - this should be
         # correct to allow overriding the committer on a per-commit level.
@@ -532,20 +564,24 @@ class SymbolicReference:
 
     def log_entry(self, index: int) -> "RefLogEntry":
         """
-        :return: RefLogEntry at the given index
+        :return:
+            RefLogEntry at the given index
 
-        :param index: Python list compatible positive or negative index
+        :param index:
+            Python list compatible positive or negative index.
 
-        .. note:: This method must read part of the reflog during execution, hence
-            it should be used sparingly, or only if you need just one index.
-            In that case, it will be faster than the :meth:`log` method.
+        :note:
+            This method must read part of the reflog during execution, hence it should
+            be used sparingly, or only if you need just one index. In that case, it will
+            be faster than the :meth:`log` method.
         """
         return RefLog.entry_at(RefLog.path(self), index)
 
     @classmethod
     def to_full_path(cls, path: Union[PathLike, "SymbolicReference"]) -> PathLike:
         """
-        :return: string with a full repository-relative path which can be used to initialize
+        :return:
+            String with a full repository-relative path which can be used to initialize
             a Reference instance, for instance by using
             :meth:`Reference.from_path <git.refs.reference.Reference.from_path>`.
         """
@@ -566,8 +602,8 @@ class SymbolicReference:
             Repository to delete the reference from.
 
         :param path:
-            Short or full path pointing to the reference, e.g. ``refs/myreference``
-            or just ``myreference``, hence ``refs/`` is implied.
+            Short or full path pointing to the reference, e.g. ``refs/myreference`` or
+            just ``myreference``, hence ``refs/`` is implied.
             Alternatively the symbolic reference to be deleted.
         """
         full_ref_path = cls.to_full_path(path)
@@ -586,10 +622,10 @@ class SymbolicReference:
                         line = line_bytes.decode(defenc)
                         _, _, line_ref = line.partition(" ")
                         line_ref = line_ref.strip()
-                        # Keep line if it is a comment or if the ref to delete is not
-                        # in the line.
-                        # If we deleted the last line and this one is a tag-reference object,
-                        # we drop it as well.
+                        # Keep line if it is a comment or if the ref to delete is not in
+                        # the line.
+                        # If we deleted the last line and this one is a tag-reference
+                        # object, we drop it as well.
                         if (line.startswith("#") or full_ref_path != line_ref) and (
                             not dropped_last_line or dropped_last_line and not line.startswith("^")
                         ):
@@ -604,8 +640,8 @@ class SymbolicReference:
 
                 # Write the new lines.
                 if made_change:
-                    # Binary writing is required, otherwise Windows will
-                    # open the file in text mode and change LF to CRLF!
+                    # Binary writing is required, otherwise Windows will open the file
+                    # in text mode and change LF to CRLF!
                     with open(pack_file_path, "wb") as fd:
                         fd.writelines(line.encode(defenc) for line in new_lines)
 
@@ -630,10 +666,9 @@ class SymbolicReference:
     ) -> T_References:
         """Internal method used to create a new symbolic reference.
 
-        If `resolve` is False, the reference will be taken as is, creating
-        a proper symbolic reference. Otherwise it will be resolved to the
-        corresponding object and a detached symbolic reference will be created
-        instead.
+        If `resolve` is False, the reference will be taken as is, creating a proper
+        symbolic reference. Otherwise it will be resolved to the corresponding object
+        and a detached symbolic reference will be created instead.
         """
         git_dir = _git_dir(repo, path)
         full_ref_path = cls.to_full_path(path)
@@ -679,28 +714,30 @@ class SymbolicReference:
             Repository to create the reference in.
 
         :param path:
-            Full path at which the new symbolic reference is supposed to be
-            created at, e.g. ``NEW_HEAD`` or ``symrefs/my_new_symref``.
+            Full path at which the new symbolic reference is supposed to be created at,
+            e.g. ``NEW_HEAD`` or ``symrefs/my_new_symref``.
 
         :param reference:
             The reference which the new symbolic reference should point to.
             If it is a commit-ish, the symbolic ref will be detached.
 
         :param force:
-            If True, force creation even if a symbolic reference with that name already exists.
-            Raise :class:`OSError` otherwise.
+            If True, force creation even if a symbolic reference with that name already
+            exists. Raise :class:`OSError` otherwise.
 
         :param logmsg:
-            If not None, the message to append to the reflog. Otherwise no reflog
-            entry is written.
+            If not None, the message to append to the reflog.
+            If None, no reflog entry is written.
 
-        :return: Newly created symbolic Reference
+        :return:
+            Newly created symbolic reference
 
         :raise OSError:
-            If a (Symbolic)Reference with the same name but different contents
-            already exists.
+            If a (Symbolic)Reference with the same name but different contents already
+            exists.
 
-        :note: This does not alter the current HEAD, index or working tree.
+        :note:
+            This does not alter the current HEAD, index or working tree.
         """
         return cls._create(repo, path, cls._resolve_ref_on_create, reference, force, logmsg)
 
@@ -708,17 +745,20 @@ class SymbolicReference:
         """Rename self to a new path.
 
         :param new_path:
-            Either a simple name or a full path, e.g. ``new_name`` or ``features/new_name``.
+            Either a simple name or a full path, e.g. ``new_name`` or
+            ``features/new_name``.
             The prefix ``refs/`` is implied for references and will be set as needed.
             In case this is a symbolic ref, there is no implied prefix.
 
         :param force:
-            If True, the rename will succeed even if a head with the target name
-            already exists. It will be overwritten in that case.
+            If True, the rename will succeed even if a head with the target name already
+            exists. It will be overwritten in that case.
 
-        :return: self
+        :return:
+            self
 
-        :raise OSError: If a file at path but with different contents already exists.
+        :raise OSError:
+            If a file at path but with different contents already exists.
         """
         new_path = self.to_full_path(new_path)
         if self.path == new_path:
@@ -801,7 +841,8 @@ class SymbolicReference:
     ) -> Iterator[T_References]:
         """Find all refs in the repository.
 
-        :param repo: is the Repo
+        :param repo:
+            The :class:`~git.repo.base.Repo`.
 
         :param common_path:
             Optional keyword argument to the path which is to be shared by all returned
@@ -821,13 +862,13 @@ class SymbolicReference:
 
     @classmethod
     def from_path(cls: Type[T_References], repo: "Repo", path: PathLike) -> T_References:
-        """
-        Make a symbolic reference from a path.
+        """Make a symbolic reference from a path.
 
-        :param path: Full ``.git``-directory-relative path name to the Reference to
-            instantiate.
+        :param path:
+            Full ``.git``-directory-relative path name to the Reference to instantiate.
 
-        :note: Use :meth:`to_full_path` if you only have a partial path of a known
+        :note:
+            Use :meth:`to_full_path` if you only have a partial path of a known
             Reference type.
 
         :return:

--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -63,7 +63,7 @@ class SymbolicReference:
     This does not point to a specific commit, but to another
     :class:`~git.refs.head.Head`, which itself specifies a commit.
 
-    A typical example for a symbolic reference is ``HEAD``.
+    A typical example for a symbolic reference is :class:`~git.refs.head.HEAD`.
     """
 
     __slots__ = ("repo", "path")
@@ -115,8 +115,8 @@ class SymbolicReference:
 
     @classmethod
     def _iter_packed_refs(cls, repo: "Repo") -> Iterator[Tuple[str, str]]:
-        """Return an iterator yielding pairs of sha1/path pairs (as strings)
-        for the corresponding refs.
+        """Return an iterator yielding pairs of sha1/path pairs (as strings) for the
+        corresponding refs.
 
         :note:
             The packed refs file will be kept open as long as we iterate.
@@ -226,9 +226,9 @@ class SymbolicReference:
         """
         :return:
             (str(sha), str(target_ref_path)) if available, the sha the file at rela_path
-            points to, or None.
+            points to, or ``None``.
 
-            target_ref_path is the reference we point to, or None.
+            target_ref_path is the reference we point to, or ``None``.
         """
         if ref_path:
             cls._check_ref_name_valid(ref_path)
@@ -273,7 +273,7 @@ class SymbolicReference:
         :return: (str(sha), str(target_ref_path)) if available, the sha the file at
             rela_path points to, or None.
 
-            target_ref_path is the reference we point to, or None.
+            target_ref_path is the reference we point to, or ``None``.
         """
         return cls._get_ref_info_helper(repo, ref_path)
 
@@ -313,7 +313,7 @@ class SymbolicReference:
         :class:`~git.objects.commit.Commit`.
 
         :raise ValueError:
-            If `commit` is not a :class:`~git.objects.commit.Commit` object or doesn't
+            If `commit` is not a :class:`~git.objects.commit.Commit` object, nor does it
             point to a commit.
 
         :return:
@@ -357,7 +357,7 @@ class SymbolicReference:
             to.
 
         :param logmsg:
-            If not None, the message will be used in the reflog entry to be written.
+            If not ``None``, the message will be used in the reflog entry to be written.
             Otherwise the reflog is not altered.
 
         :note:
@@ -491,8 +491,8 @@ class SymbolicReference:
     def is_valid(self) -> bool:
         """
         :return:
-            True if the reference is valid, hence it can be read and points to a valid
-            object or reference.
+            ``True`` if the reference is valid, hence it can be read and points to a
+            valid object or reference.
         """
         try:
             self.object
@@ -505,7 +505,7 @@ class SymbolicReference:
     def is_detached(self) -> bool:
         """
         :return:
-            True if we are a detached reference, hence we point to a specific commit
+            ``True`` if we are a detached reference, hence we point to a specific commit
             instead to another reference.
         """
         try:
@@ -565,7 +565,7 @@ class SymbolicReference:
     def log_entry(self, index: int) -> "RefLogEntry":
         """
         :return:
-            RefLogEntry at the given index
+            :class:`~git.refs.log.RefLogEntry` at the given index
 
         :param index:
             Python list compatible positive or negative index.
@@ -582,7 +582,7 @@ class SymbolicReference:
         """
         :return:
             String with a full repository-relative path which can be used to initialize
-            a Reference instance, for instance by using
+            a :class:`~git.refs.reference.Reference` instance, for instance by using
             :meth:`Reference.from_path <git.refs.reference.Reference.from_path>`.
         """
         if isinstance(path, SymbolicReference):
@@ -666,7 +666,7 @@ class SymbolicReference:
     ) -> T_References:
         """Internal method used to create a new symbolic reference.
 
-        If `resolve` is False, the reference will be taken as is, creating a proper
+        If `resolve` is ``False``, the reference will be taken as is, creating a proper
         symbolic reference. Otherwise it will be resolved to the corresponding object
         and a detached symbolic reference will be created instead.
         """
@@ -722,12 +722,12 @@ class SymbolicReference:
             If it is a commit-ish, the symbolic ref will be detached.
 
         :param force:
-            If True, force creation even if a symbolic reference with that name already
-            exists. Raise :class:`OSError` otherwise.
+            If ``True``, force creation even if a symbolic reference with that name
+            already exists. Raise :class:`OSError` otherwise.
 
         :param logmsg:
-            If not None, the message to append to the reflog.
-            If None, no reflog entry is written.
+            If not ``None``, the message to append to the reflog.
+            If ``None``, no reflog entry is written.
 
         :return:
             Newly created symbolic reference
@@ -751,8 +751,8 @@ class SymbolicReference:
             In case this is a symbolic ref, there is no implied prefix.
 
         :param force:
-            If True, the rename will succeed even if a head with the target name already
-            exists. It will be overwritten in that case.
+            If ``True``, the rename will succeed even if a head with the target name
+            already exists. It will be overwritten in that case.
 
         :return:
             self
@@ -847,8 +847,8 @@ class SymbolicReference:
         :param common_path:
             Optional keyword argument to the path which is to be shared by all returned
             Ref objects.
-            Defaults to class specific portion if None, ensuring that only refs suitable
-            for the actual class are returned.
+            Defaults to class specific portion if ``None``, ensuring that only refs
+            suitable for the actual class are returned.
 
         :return:
             A list of :class:`SymbolicReference`, each guaranteed to be a symbolic ref

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -1,6 +1,13 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
+"""Provides a :class:`~git.refs.reference.Reference`-based type for lightweight tags.
+
+This defines the :class:`TagReference` class (and its alias :class:`Tag`), which
+represents lightweight tags. For annotated tags (which are git objects), see the
+:mod:`git.objects.tag` module.
+"""
+
 from .reference import Reference
 
 __all__ = ["TagReference", "Tag"]

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -109,7 +109,7 @@ class TagReference(Reference):
             The referenced object can be a commit, tree, or blob.
 
         :param logmsg:
-            If not None, the message will be used in your tag object. This will also
+            If not ``None``, the message will be used in your tag object. This will also
             create an additional tag object that allows to obtain that information,
             e.g.::
 
@@ -120,7 +120,7 @@ class TagReference(Reference):
             `logmsg` takes precedence if both are passed.
 
         :param force:
-            If True, force creation of a tag even though that tag already exists.
+            If ``True``, force creation of a tag even though that tag already exists.
 
         :param kwargs:
             Additional keyword arguments to be passed to ``git tag``.

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -43,7 +43,8 @@ class TagReference(Reference):
     def commit(self) -> "Commit":  # type: ignore[override]  # LazyMixin has unrelated commit method
         """:return: Commit object the tag ref points to
 
-        :raise ValueError: If the tag points to a tree or blob
+        :raise ValueError:
+            If the tag points to a tree or blob.
         """
         obj = self.object
         while obj.type != "commit":
@@ -63,8 +64,9 @@ class TagReference(Reference):
     @property
     def tag(self) -> Union["TagObject", None]:
         """
-        :return: Tag object this tag ref points to or None in case
-            we are a lightweight tag"""
+        :return:
+            Tag object this tag ref points to or None in case we are a lightweight tag
+        """
         obj = self.object
         if obj.type == "tag":
             return obj
@@ -97,21 +99,23 @@ class TagReference(Reference):
 
         :param logmsg:
             If not None, the message will be used in your tag object. This will also
-            create an additional tag object that allows to obtain that information, e.g.::
+            create an additional tag object that allows to obtain that information,
+            e.g.::
 
                 tagref.tag.message
 
         :param message:
-            Synonym for the `logmsg` parameter.
-            Included for backwards compatibility. `logmsg` takes precedence if both are passed.
+            Synonym for the `logmsg` parameter. Included for backwards compatibility.
+            `logmsg` takes precedence if both are passed.
 
         :param force:
             If True, force creation of a tag even though that tag already exists.
 
         :param kwargs:
-            Additional keyword arguments to be passed to git-tag.
+            Additional keyword arguments to be passed to ``git tag``.
 
-        :return: A new TagReference.
+        :return:
+            A new :class:`TagReference`.
         """
         if "ref" in kwargs and kwargs["ref"]:
             reference = kwargs["ref"]

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -106,8 +106,7 @@ class TagReference(Reference):
 
         :param reference:
             A reference to the :class:`~git.objects.base.Object` you want to tag.
-            The referenced object can be a :class:`~git.objects.commit.Commit`,
-            :class:`~git.objects.tree.Tree`, or :class:`~git.objects.blob.Blob`.
+            The referenced object can be a commit, tree, or blob.
 
         :param logmsg:
             If not None, the message will be used in your tag object. This will also

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -72,7 +72,8 @@ class TagReference(Reference):
     def tag(self) -> Union["TagObject", None]:
         """
         :return:
-            Tag object this tag ref points to or None in case we are a lightweight tag
+            Tag object this tag ref points to, or ``None`` in case we are a lightweight
+            tag
         """
         obj = self.object
         if obj.type == "tag":
@@ -96,13 +97,17 @@ class TagReference(Reference):
     ) -> "TagReference":
         """Create a new tag reference.
 
+        :param repo:
+            The :class:`~git.repo.base.Repo` to create the tag in.
+
         :param path:
             The name of the tag, e.g. ``1.0`` or ``releases/1.0``.
             The prefix ``refs/tags`` is implied.
 
-        :param ref:
+        :param reference:
             A reference to the :class:`~git.objects.base.Object` you want to tag.
-            The Object can be a commit, tree or blob.
+            The referenced object can be a :class:`~git.objects.commit.Commit`,
+            :class:`~git.objects.tree.Tree`, or :class:`~git.objects.blob.Blob`.
 
         :param logmsg:
             If not None, the message will be used in your tag object. This will also

--- a/git/remote.py
+++ b/git/remote.py
@@ -125,7 +125,8 @@ def to_progress_instance(
 
 
 class PushInfo(IterableObj):
-    """Carries information about the result of a push operation of a single head::
+    """
+    Carries information about the result of a push operation of a single head::
 
         info = remote.push()[0]
         info.flags          # bitflags providing more information about the result
@@ -294,7 +295,8 @@ class PushInfoList(IterableList[PushInfo]):
 
 
 class FetchInfo(IterableObj):
-    """Carries information about the results of a fetch operation of a single head::
+    """
+    Carries information about the results of a fetch operation of a single head::
 
      info = remote.fetch()[0]
      info.ref           # Symbolic Reference or RemoteReference to the changed

--- a/git/remote.py
+++ b/git/remote.py
@@ -1075,13 +1075,14 @@ class Remote(LazyMixin, IterableObj):
         :param progress:
             Can take one of many value types:
 
-            * None to discard progress information.
+            * None, to discard progress information.
             * A function (callable) that is called with the progress information.
               Signature: ``progress(op_code, cur_count, max_count=None, message='')``.
-              `Click here <http://goo.gl/NPa7st>`__ for a description of all arguments
-              given to the function.
-            * An instance of a class derived from :class:`git.RemoteProgress` that
-              overrides the :meth:`~git.RemoteProgress.update` method.
+              See :meth:`RemoteProgress.update <git.util.RemoteProgress.update>` for a
+              description of all arguments given to the function.
+            * An instance of a class derived from :class:`~git.util.RemoteProgress` that
+              overrides the
+              :meth:`RemoteProgress.update <git.util.RemoteProgress.update>` method.
 
         :note: No further progress information is returned after push returns.
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -575,7 +575,10 @@ class Remote(LazyMixin, IterableObj):
         if attr == "_config_reader":
             # NOTE: This is cached as __getattr__ is overridden to return remote config
             # values implicitly, such as in print(r.pushurl).
-            self._config_reader = SectionConstraint(self.repo.config_reader("repository"), self._config_section_name())
+            self._config_reader = SectionConstraint(
+                self.repo.config_reader("repository"),
+                self._config_section_name(),
+            )
         else:
             super()._set_cache_(attr)
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -125,8 +125,7 @@ def to_progress_instance(
 
 
 class PushInfo(IterableObj):
-    """
-    Carries information about the result of a push operation of a single head::
+    """Carries information about the result of a push operation of a single head::
 
         info = remote.push()[0]
         info.flags          # bitflags providing more information about the result
@@ -222,8 +221,8 @@ class PushInfo(IterableObj):
 
     @classmethod
     def _from_line(cls, remote: "Remote", line: str) -> "PushInfo":
-        """Create a new PushInfo instance as parsed from line which is expected to be like
-        refs/heads/master:refs/heads/master 05d2687..1d0568e as bytes."""
+        """Create a new :class:`PushInfo` instance as parsed from line which is expected
+        to be like refs/heads/master:refs/heads/master 05d2687..1d0568e as bytes."""
         control_character, from_to, summary = line.split("\t", 3)
         flags = 0
 
@@ -279,7 +278,7 @@ class PushInfo(IterableObj):
 
 
 class PushInfoList(IterableList[PushInfo]):
-    """IterableList of :class:`PushInfo` objects."""
+    """:class:`~git.util.IterableList` of :class:`PushInfo` objects."""
 
     def __new__(cls) -> "PushInfoList":
         return cast(PushInfoList, IterableList.__new__(cls, "push_infos"))
@@ -295,8 +294,7 @@ class PushInfoList(IterableList[PushInfo]):
 
 
 class FetchInfo(IterableObj):
-    """
-    Carries information about the results of a fetch operation of a single head::
+    """Carries information about the results of a fetch operation of a single head::
 
      info = remote.fetch()[0]
      info.ref           # Symbolic Reference or RemoteReference to the changed
@@ -559,7 +557,7 @@ class Remote(LazyMixin, IterableObj):
             The repository we are a remote of.
 
         :param name:
-            The name of the remote, e.g. 'origin'.
+            The name of the remote, e.g. ``origin``.
         """
         self.repo = repo
         self.name = name
@@ -611,7 +609,7 @@ class Remote(LazyMixin, IterableObj):
     def exists(self) -> bool:
         """
         :return:
-            True if this is a valid, existing remote.
+            ``True`` if this is a valid, existing remote.
             Valid remotes have an entry in the repository's configuration.
         """
         try:
@@ -683,7 +681,7 @@ class Remote(LazyMixin, IterableObj):
         return self.set_url(url, add=True, allow_unsafe_protocols=allow_unsafe_protocols)
 
     def delete_url(self, url: str, **kwargs: Any) -> "Remote":
-        """Deletes a new url on current remote (special case of ``git remote set-url``)
+        """Deletes a new url on current remote (special case of ``git remote set-url``).
 
         This command deletes new URLs to a given remote, making it possible to have
         multiple URLs for a single remote.
@@ -733,7 +731,7 @@ class Remote(LazyMixin, IterableObj):
     def refs(self) -> IterableList[RemoteReference]:
         """
         :return:
-            :class:`~git.util.IterableList` of :class:`git.refs.remote.RemoteReference`
+            :class:`~git.util.IterableList` of :class:`~git.refs.remote.RemoteReference`
             objects.
 
             It is prefixed, allowing you to omit the remote path portion, e.g.::
@@ -748,7 +746,7 @@ class Remote(LazyMixin, IterableObj):
     def stale_refs(self) -> IterableList[Reference]:
         """
         :return:
-            :class:`~git.util.IterableList` of :class:`git.refs.remote.RemoteReference`
+            :class:`~git.util.IterableList` of :class:`~git.refs.remote.RemoteReference`
             objects that do not have a corresponding head in the remote reference
             anymore as they have been deleted on the remote side, but are still
             available locally.
@@ -1019,13 +1017,15 @@ class Remote(LazyMixin, IterableObj):
             supplying a list rather than a string for 'refspec' will make use of this
             facility.
 
-        :param progress: See :meth:`push` method.
+        :param progress:
+            See :meth:`push` method.
 
-        :param verbose: Boolean for verbose output.
+        :param verbose:
+            Boolean for verbose output.
 
         :param kill_after_timeout:
             To specify a timeout in seconds for the git command, after which the process
-            should be killed. It is set to None by default.
+            should be killed. It is set to ``None`` by default.
 
         :param allow_unsafe_protocols:
             Allow unsafe protocols to be used, like ``ext``.
@@ -1101,7 +1101,7 @@ class Remote(LazyMixin, IterableObj):
             Additional arguments to be passed to ``git pull``.
 
         :return:
-            Please see :meth:`fetch` method
+            Please see :meth:`fetch` method.
         """
         if refspec is None:
             # No argument refspec, then ensure the repo's config has a fetch refspec.
@@ -1141,7 +1141,7 @@ class Remote(LazyMixin, IterableObj):
         :param progress:
             Can take one of many value types:
 
-            * None, to discard progress information.
+            * ``None``, to discard progress information.
             * A function (callable) that is called with the progress information.
               Signature: ``progress(op_code, cur_count, max_count=None, message='')``.
               See :meth:`RemoteProgress.update <git.util.RemoteProgress.update>` for a
@@ -1163,7 +1163,8 @@ class Remote(LazyMixin, IterableObj):
         :param allow_unsafe_options:
             Allow unsafe options to be used, like ``--receive-pack``.
 
-        :param kwargs: Additional arguments to be passed to ``git push``.
+        :param kwargs:
+            Additional arguments to be passed to ``git push``.
 
         :return:
             A :class:`PushInfoList` object, where each list member represents an

--- a/git/remote.py
+++ b/git/remote.py
@@ -338,7 +338,7 @@ class FetchInfo(IterableObj):
 
     @classmethod
     def refresh(cls) -> Literal[True]:
-        """This gets called by the refresh function (see the top level __init__)."""
+        """This gets called by the refresh function (see the top level ``__init__``)."""
         # Clear the old values in _flag_map.
         with contextlib.suppress(KeyError):
             del cls._flag_map["t"]
@@ -386,19 +386,22 @@ class FetchInfo(IterableObj):
         """Parse information from the given line as returned by ``git-fetch -v`` and
         return a new :class:`FetchInfo` object representing this information.
 
-        We can handle a line as follows:
-        "%c %-\\*s %-\\*s -> %s%s"
+        We can handle a line as follows::
 
-        Where c is either ' ', !, +, -, \\*, or =
-        ! means error
-        + means success forcing update
-        - means a tag was updated
-        * means birth of new branch or tag
-        = means the head was up to date (and not moved)
-        ' ' means a fast-forward
+            %c %-*s %-*s -> %s%s
 
-        fetch line is the corresponding line from FETCH_HEAD, like
-        acb0fa8b94ef421ad60c8507b634759a472cd56c    not-for-merge   branch '0.1.7RC' of /tmp/tmpya0vairemote_repo
+        Where ``c`` is either a space, ``!``, ``+``, ``-``, ``*``, or ``=``:
+
+        - '!' means error
+        - '+' means success forcing update
+        - '-' means a tag was updated
+        - '*' means birth of new branch or tag
+        - '=' means the head was up to date (and not moved)
+        - ' ' means a fast-forward
+
+        `fetch_line` is the corresponding line from FETCH_HEAD, like::
+
+            acb0fa8b94ef421ad60c8507b634759a472cd56c    not-for-merge   branch '0.1.7RC' of /tmp/tmpya0vairemote_repo
         """
         match = cls._re_fetch_result.match(line)
         if match is None:
@@ -625,7 +628,7 @@ class Remote(LazyMixin, IterableObj):
 
     @classmethod
     def iter_items(cls, repo: "Repo", *args: Any, **kwargs: Any) -> Iterator["Remote"]:
-        """:return: Iterator yielding Remote objects of the given repository"""
+        """:return: Iterator yielding :class:`Remote` objects of the given repository"""
         for section in repo.config_reader("repository").sections():
             if not section.startswith("remote "):
                 continue
@@ -639,7 +642,7 @@ class Remote(LazyMixin, IterableObj):
     def set_url(
         self, new_url: str, old_url: Optional[str] = None, allow_unsafe_protocols: bool = False, **kwargs: Any
     ) -> "Remote":
-        """Configure URLs on current remote (cf command ``git remote set-url``).
+        """Configure URLs on current remote (cf. command ``git remote set-url``).
 
         This command manages URLs on the remote.
 
@@ -1020,7 +1023,7 @@ class Remote(LazyMixin, IterableObj):
             facility.
 
         :param progress:
-            See :meth:`push` method.
+            See the :meth:`push` method.
 
         :param verbose:
             Boolean for verbose output.
@@ -1081,8 +1084,8 @@ class Remote(LazyMixin, IterableObj):
         allow_unsafe_options: bool = False,
         **kwargs: Any,
     ) -> IterableList[FetchInfo]:
-        """Pull changes from the given branch, being the same as a fetch followed
-        by a merge of branch with your local branch.
+        """Pull changes from the given branch, being the same as a fetch followed by a
+        merge of branch with your local branch.
 
         :param refspec:
             See :meth:`fetch` method.
@@ -1157,7 +1160,7 @@ class Remote(LazyMixin, IterableObj):
 
         :param kill_after_timeout:
             To specify a timeout in seconds for the git command, after which the process
-            should be killed. It is set to None by default.
+            should be killed. It is set to ``None`` by default.
 
         :param allow_unsafe_protocols:
             Allow unsafe protocols to be used, like ``ext``.

--- a/git/remote.py
+++ b/git/remote.py
@@ -801,7 +801,7 @@ class Remote(LazyMixin, IterableObj):
         :return:
             New :class:`Remote` instance
 
-        :raise GitCommandError:
+        :raise git.exc.GitCommandError:
             In case an origin with that name already exists.
         """
         scmd = "add"

--- a/git/remote.py
+++ b/git/remote.py
@@ -70,13 +70,15 @@ def add_progress(
     git: Git,
     progress: Union[RemoteProgress, "UpdateProgress", Callable[..., RemoteProgress], None],
 ) -> Any:
-    """Add the --progress flag to the given kwargs dict if supported by the
-    git command.
+    """Add the ``--progress`` flag to the given `kwargs` dict if supported by the git
+    command.
 
-    :note: If the actual progress in the given progress instance is not
-        given, we do not request any progress.
+    :note:
+        If the actual progress in the given progress instance is not given, we do not
+        request any progress.
 
-    :return: possibly altered kwargs
+    :return:
+        Possibly altered `kwargs`
     """
     if progress is not None:
         v = git.version_info[:2]
@@ -108,7 +110,8 @@ def to_progress_instance(progress: RemoteProgress) -> RemoteProgress:
 def to_progress_instance(
     progress: Union[Callable[..., Any], RemoteProgress, None]
 ) -> Union[RemoteProgress, CallableRemoteProgress]:
-    """Given the 'progress' return a suitable object derived from RemoteProgress."""
+    """Given the `progress` return a suitable object derived from
+    :class:`~git.util.RemoteProgress`."""
     # New API only needs progress as a function.
     if callable(progress):
         return CallableRemoteProgress(progress)
@@ -276,7 +279,7 @@ class PushInfo(IterableObj):
 
 
 class PushInfoList(IterableList[PushInfo]):
-    """IterableList of PushInfo objects."""
+    """IterableList of :class:`PushInfo` objects."""
 
     def __new__(cls) -> "PushInfoList":
         return cast(PushInfoList, IterableList.__new__(cls, "push_infos"))
@@ -380,8 +383,8 @@ class FetchInfo(IterableObj):
 
     @classmethod
     def _from_line(cls, repo: "Repo", line: str, fetch_line: str) -> "FetchInfo":
-        """Parse information from the given line as returned by git-fetch -v
-        and return a new FetchInfo object representing this information.
+        """Parse information from the given line as returned by ``git-fetch -v`` and
+        return a new :class:`FetchInfo` object representing this information.
 
         We can handle a line as follows:
         "%c %-\\*s %-\\*s -> %s%s"
@@ -391,7 +394,7 @@ class FetchInfo(IterableObj):
         + means success forcing update
         - means a tag was updated
         * means birth of new branch or tag
-        = means the head was up to date ( and not moved )
+        = means the head was up to date (and not moved)
         ' ' means a fast-forward
 
         fetch line is the corresponding line from FETCH_HEAD, like
@@ -455,15 +458,17 @@ class FetchInfo(IterableObj):
         if remote_local_ref_str == "FETCH_HEAD":
             ref_type = SymbolicReference
         elif ref_type_name == "tag" or is_tag_operation:
-            # The ref_type_name can be branch, whereas we are still seeing a tag operation.
-            # It happens during testing, which is based on actual git operations.
+            # The ref_type_name can be branch, whereas we are still seeing a tag
+            # operation. It happens during testing, which is based on actual git
+            # operations.
             ref_type = TagReference
         elif ref_type_name in ("remote-tracking", "branch"):
-            # Note: remote-tracking is just the first part of the 'remote-tracking branch' token.
-            # We don't parse it correctly, but its enough to know what to do, and it's new in git 1.7something.
+            # Note: remote-tracking is just the first part of the
+            # 'remote-tracking branch' token. We don't parse it correctly, but it's
+            # enough to know what to do, and it's new in git 1.7something.
             ref_type = RemoteReference
         elif "/" in ref_type_name:
-            # If the fetch spec look something like this '+refs/pull/*:refs/heads/pull/*',
+            # If the fetch spec look something like '+refs/pull/*:refs/heads/pull/*',
             # and is thus pretty much anything the user wants, we will have trouble
             # determining what's going on. For now, we assume the local ref is a Head.
             ref_type = Head
@@ -475,17 +480,19 @@ class FetchInfo(IterableObj):
         if ref_type is SymbolicReference:
             remote_local_ref = ref_type(repo, "FETCH_HEAD")
         else:
-            # Determine prefix. Tags are usually pulled into refs/tags, they may have subdirectories.
-            # It is not clear sometimes where exactly the item is, unless we have an absolute path as
-            # indicated by the 'ref/' prefix. Otherwise even a tag could be in refs/remotes, which is
-            # when it will have the 'tags/' subdirectory in its path.
-            # We don't want to test for actual existence, but try to figure everything out analytically.
+            # Determine prefix. Tags are usually pulled into refs/tags; they may have
+            # subdirectories. It is not clear sometimes where exactly the item is,
+            # unless we have an absolute path as indicated by the 'ref/' prefix.
+            # Otherwise even a tag could be in refs/remotes, which is when it will have
+            # the 'tags/' subdirectory in its path. We don't want to test for actual
+            # existence, but try to figure everything out analytically.
             ref_path: Optional[PathLike] = None
             remote_local_ref_str = remote_local_ref_str.strip()
 
             if remote_local_ref_str.startswith(Reference._common_path_default + "/"):
-                # Always use actual type if we get absolute paths.
-                # Will always be the case if something is fetched outside of refs/remotes (if its not a tag).
+                # Always use actual type if we get absolute paths. This will always be
+                # the case if something is fetched outside of refs/remotes (if its not a
+                # tag).
                 ref_path = remote_local_ref_str
                 if ref_type is not TagReference and not remote_local_ref_str.startswith(
                     RemoteReference._common_path_default + "/"
@@ -499,8 +506,8 @@ class FetchInfo(IterableObj):
                 ref_path = join_path(ref_type._common_path_default, remote_local_ref_str)
             # END obtain refpath
 
-            # Even though the path could be within the git conventions, we make
-            # sure we respect whatever the user wanted, and disabled path checking.
+            # Even though the path could be within the git conventions, we make sure we
+            # respect whatever the user wanted, and disabled path checking.
             remote_local_ref = ref_type(repo, ref_path, check_path=False)
         # END create ref instance
 
@@ -517,10 +524,11 @@ class Remote(LazyMixin, IterableObj):
     """Provides easy read and write access to a git remote.
 
     Everything not part of this interface is considered an option for the current
-    remote, allowing constructs like remote.pushurl to query the pushurl.
+    remote, allowing constructs like ``remote.pushurl`` to query the pushurl.
 
-    :note: When querying configuration, the configuration accessor will be cached
-        to speed up subsequent accesses.
+    :note:
+        When querying configuration, the configuration accessor will be cached to speed
+        up subsequent accesses.
     """
 
     __slots__ = ("repo", "name", "_config_reader")
@@ -547,21 +555,24 @@ class Remote(LazyMixin, IterableObj):
     def __init__(self, repo: "Repo", name: str) -> None:
         """Initialize a remote instance.
 
-        :param repo: The repository we are a remote of
-        :param name: The name of the remote, e.g. 'origin'
+        :param repo:
+            The repository we are a remote of.
+
+        :param name:
+            The name of the remote, e.g. 'origin'.
         """
         self.repo = repo
         self.name = name
         self.url: str
 
     def __getattr__(self, attr: str) -> Any:
-        """Allows to call this instance like
-        remote.special( \\*args, \\*\\*kwargs) to call git-remote special self.name."""
+        """Allows to call this instance like ``remote.special(*args, **kwargs)`` to
+        call ``git remote special self.name``."""
         if attr == "_config_reader":
             return super().__getattr__(attr)
 
-        # Sometimes, probably due to a bug in Python itself, we are being called
-        # even though a slot of the same name exists.
+        # Sometimes, probably due to a bug in Python itself, we are being called even
+        # though a slot of the same name exists.
         try:
             return self._config_reader.get(attr)
         except cp.NoOptionError:
@@ -599,7 +610,8 @@ class Remote(LazyMixin, IterableObj):
 
     def exists(self) -> bool:
         """
-        :return: True if this is a valid, existing remote.
+        :return:
+            True if this is a valid, existing remote.
             Valid remotes have an entry in the repository's configuration.
         """
         try:
@@ -627,14 +639,21 @@ class Remote(LazyMixin, IterableObj):
     def set_url(
         self, new_url: str, old_url: Optional[str] = None, allow_unsafe_protocols: bool = False, **kwargs: Any
     ) -> "Remote":
-        """Configure URLs on current remote (cf command git remote set_url).
+        """Configure URLs on current remote (cf command ``git remote set-url``).
 
         This command manages URLs on the remote.
 
-        :param new_url: String being the URL to add as an extra remote URL
-        :param old_url: When set, replaces this URL with new_url for the remote
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :return: self
+        :param new_url:
+            String being the URL to add as an extra remote URL.
+
+        :param old_url:
+            When set, replaces this URL with `new_url` for the remote.
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :return:
+            self
         """
         if not allow_unsafe_protocols:
             Git.check_unsafe_protocols(new_url)
@@ -647,25 +666,33 @@ class Remote(LazyMixin, IterableObj):
         return self
 
     def add_url(self, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
-        """Adds a new url on current remote (special case of git remote set_url).
+        """Adds a new url on current remote (special case of ``git remote set-url``).
 
         This command adds new URLs to a given remote, making it possible to have
         multiple URLs for a single remote.
 
-        :param url: String being the URL to add as an extra remote URL
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :return: self
+        :param url:
+            String being the URL to add as an extra remote URL.
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :return:
+            self
         """
         return self.set_url(url, add=True, allow_unsafe_protocols=allow_unsafe_protocols)
 
     def delete_url(self, url: str, **kwargs: Any) -> "Remote":
-        """Deletes a new url on current remote (special case of git remote set_url)
+        """Deletes a new url on current remote (special case of ``git remote set-url``)
 
         This command deletes new URLs to a given remote, making it possible to have
         multiple URLs for a single remote.
 
-        :param url: String being the URL to delete from the remote
-        :return: self
+        :param url:
+            String being the URL to delete from the remote.
+
+        :return:
+            self
         """
         return self.set_url(url, delete=True)
 
@@ -706,9 +733,12 @@ class Remote(LazyMixin, IterableObj):
     def refs(self) -> IterableList[RemoteReference]:
         """
         :return:
-            IterableList of RemoteReference objects. It is prefixed, allowing
-            you to omit the remote path portion, e.g.::
-            remote.refs.master # yields RemoteReference('/refs/remotes/origin/master')
+            :class:`~git.util.IterableList` of :class:`git.refs.remote.RemoteReference`
+            objects.
+
+            It is prefixed, allowing you to omit the remote path portion, e.g.::
+
+                remote.refs.master  # yields RemoteReference('/refs/remotes/origin/master')
         """
         out_refs: IterableList[RemoteReference] = IterableList(RemoteReference._id_attribute_, "%s/" % self.name)
         out_refs.extend(RemoteReference.list_items(self.repo, remote=self.name))
@@ -718,12 +748,13 @@ class Remote(LazyMixin, IterableObj):
     def stale_refs(self) -> IterableList[Reference]:
         """
         :return:
-            IterableList RemoteReference objects that do not have a corresponding
-            head in the remote reference anymore as they have been deleted on the
-            remote side, but are still available locally.
+            :class:`~git.util.IterableList` of :class:`git.refs.remote.RemoteReference`
+            objects that do not have a corresponding head in the remote reference
+            anymore as they have been deleted on the remote side, but are still
+            available locally.
 
-            The IterableList is prefixed, hence the 'origin' must be omitted. See
-            'refs' property for an example.
+            The :class:`~git.util.IterableList` is prefixed, hence the 'origin' must be
+            omitted. See :attr:`refs` property for an example.
 
             To make things more complicated, it can be possible for the list to include
             other kinds of references, for example, tag references, if these are stale
@@ -752,13 +783,26 @@ class Remote(LazyMixin, IterableObj):
     def create(cls, repo: "Repo", name: str, url: str, allow_unsafe_protocols: bool = False, **kwargs: Any) -> "Remote":
         """Create a new remote to the given repository.
 
-        :param repo: Repository instance that is to receive the new remote
-        :param name: Desired name of the remote
-        :param url: URL which corresponds to the remote's name
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param kwargs: Additional arguments to be passed to the git-remote add command
-        :return: New Remote instance
-        :raise GitCommandError: in case an origin with that name already exists
+        :param repo:
+            Repository instance that is to receive the new remote.
+
+        :param name:
+            Desired name of the remote.
+
+        :param url:
+            URL which corresponds to the remote's name.
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :param kwargs:
+            Additional arguments to be passed to the ``git remote add`` command.
+
+        :return:
+            New :class:`Remote` instance
+
+        :raise GitCommandError:
+            In case an origin with that name already exists.
         """
         scmd = "add"
         kwargs["insert_kwargs_after"] = scmd
@@ -777,7 +821,8 @@ class Remote(LazyMixin, IterableObj):
     def remove(cls, repo: "Repo", name: str) -> str:
         """Remove the remote with the given name.
 
-        :return: The passed remote name to remove
+        :return:
+            The passed remote name to remove
         """
         repo.git.remote("rm", name)
         if isinstance(name, cls):
@@ -788,9 +833,10 @@ class Remote(LazyMixin, IterableObj):
     rm = remove
 
     def rename(self, new_name: str) -> "Remote":
-        """Rename self to the given new_name.
+        """Rename self to the given `new_name`.
 
-        :return: self
+        :return:
+            self
         """
         if self.name == new_name:
             return self
@@ -802,12 +848,15 @@ class Remote(LazyMixin, IterableObj):
         return self
 
     def update(self, **kwargs: Any) -> "Remote":
-        """Fetch all changes for this remote, including new branches which will
-        be forced in (in case your local remote branch is not part the new remote
-        branch's ancestry anymore).
+        """Fetch all changes for this remote, including new branches which will be
+        forced in (in case your local remote branch is not part the new remote branch's
+        ancestry anymore).
 
-        :param kwargs: Additional arguments passed to git-remote update
-        :return: self
+        :param kwargs:
+            Additional arguments passed to ``git remote update``.
+
+        :return:
+            self
         """
         scmd = "update"
         kwargs["insert_kwargs_after"] = scmd
@@ -966,9 +1015,9 @@ class Remote(LazyMixin, IterableObj):
 
             Taken from the git manual, gitglossary(7).
 
-            Fetch supports multiple refspecs (as the
-            underlying git-fetch does) - supplying a list rather than a string
-            for 'refspec' will make use of this facility.
+            Fetch supports multiple refspecs (as the underlying git-fetch does) -
+            supplying a list rather than a string for 'refspec' will make use of this
+            facility.
 
         :param progress: See :meth:`push` method.
 
@@ -978,15 +1027,18 @@ class Remote(LazyMixin, IterableObj):
             To specify a timeout in seconds for the git command, after which the process
             should be killed. It is set to None by default.
 
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
 
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
 
-        :param kwargs: Additional arguments to be passed to git-fetch.
+        :param kwargs:
+            Additional arguments to be passed to ``git fetch``.
 
         :return:
-            IterableList(FetchInfo, ...) list of FetchInfo instances providing detailed
-            information about the fetch results
+            IterableList(FetchInfo, ...) list of :class:`FetchInfo` instances providing
+            detailed information about the fetch results
 
         :note:
             As fetch does not provide progress information to non-ttys, we cannot make
@@ -1030,13 +1082,26 @@ class Remote(LazyMixin, IterableObj):
         """Pull changes from the given branch, being the same as a fetch followed
         by a merge of branch with your local branch.
 
-        :param refspec: See :meth:`fetch` method
-        :param progress: See :meth:`push` method
-        :param kill_after_timeout: See :meth:`fetch` method
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack
-        :param kwargs: Additional arguments to be passed to git-pull
-        :return: Please see :meth:`fetch` method
+        :param refspec:
+            See :meth:`fetch` method.
+
+        :param progress:
+            See :meth:`push` method.
+
+        :param kill_after_timeout:
+            See :meth:`fetch` method.
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
+
+        :param kwargs:
+            Additional arguments to be passed to ``git pull``.
+
+        :return:
+            Please see :meth:`fetch` method
         """
         if refspec is None:
             # No argument refspec, then ensure the repo's config has a fetch refspec.
@@ -1070,7 +1135,8 @@ class Remote(LazyMixin, IterableObj):
     ) -> PushInfoList:
         """Push changes from source branch in refspec to target branch in refspec.
 
-        :param refspec: See :meth:`fetch` method.
+        :param refspec:
+            See :meth:`fetch` method.
 
         :param progress:
             Can take one of many value types:
@@ -1084,26 +1150,31 @@ class Remote(LazyMixin, IterableObj):
               overrides the
               :meth:`RemoteProgress.update <git.util.RemoteProgress.update>` method.
 
-        :note: No further progress information is returned after push returns.
+        :note:
+            No further progress information is returned after push returns.
 
         :param kill_after_timeout:
             To specify a timeout in seconds for the git command, after which the process
             should be killed. It is set to None by default.
 
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
 
         :param allow_unsafe_options:
-            Allow unsafe options to be used, like --receive-pack.
+            Allow unsafe options to be used, like ``--receive-pack``.
 
-        :param kwargs: Additional arguments to be passed to git-push.
+        :param kwargs: Additional arguments to be passed to ``git push``.
 
         :return:
             A :class:`PushInfoList` object, where each list member represents an
             individual head which had been updated on the remote side.
+
             If the push contains rejected heads, these will have the
             :attr:`PushInfo.ERROR` bit set in their flags.
-            If the operation fails completely, the length of the returned PushInfoList
-            will be 0.
+
+            If the operation fails completely, the length of the returned
+            :class:`PushInfoList` will be 0.
+
             Call :meth:`~PushInfoList.raise_if_error` on the returned object to raise on
             any failure.
         """
@@ -1133,8 +1204,9 @@ class Remote(LazyMixin, IterableObj):
     def config_reader(self) -> SectionConstraint[GitConfigParser]:
         """
         :return:
-            GitConfigParser compatible object able to read options for only our remote.
-            Hence you may simple type config.get("pushurl") to obtain the information.
+            :class:`~git.config.GitConfigParser` compatible object able to read options
+            for only our remote. Hence you may simply type ``config.get("pushurl")`` to
+            obtain the information.
         """
         return self._config_reader
 
@@ -1148,7 +1220,9 @@ class Remote(LazyMixin, IterableObj):
     @property
     def config_writer(self) -> SectionConstraint:
         """
-        :return: GitConfigParser compatible object able to write options for this remote.
+        :return:
+            :class:`~git.config.GitConfigParser`-compatible object able to write options
+            for this remote.
 
         :note:
             You can only own one writer at a time - delete it to release the

--- a/git/repo/__init__.py
+++ b/git/repo/__init__.py
@@ -1,6 +1,6 @@
 # This module is part of GitPython and is released under the
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
-"""Initialize the Repo package."""
+"""Initialize the repo package."""
 
 from .base import Repo as Repo  # noqa: F401

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -202,12 +202,12 @@ class Repo:
             Please note that this was the default behaviour in older versions of
             GitPython, which is considered a bug though.
 
-        :raise InvalidGitRepositoryError:
+        :raise git.exc.InvalidGitRepositoryError:
 
-        :raise NoSuchPathError:
+        :raise git.exc.NoSuchPathError:
 
         :return:
-            git.Repo
+            :class:`Repo`
         """
 
         epath = path or os.getenv("GIT_DIR")
@@ -893,7 +893,7 @@ class Repo:
             The array of string paths representing the alternates at which git should
             look for objects, i.e. ``/home/user/repo/.git/objects``.
 
-        :raise NoSuchPathError:
+        :raise git.exc.NoSuchPathError:
 
         :note:
             The method does not check for the existence of the paths in `alts`, as the
@@ -1553,7 +1553,7 @@ class Repo:
               repository-relative path to a directory or file to place into the archive,
               or a list or tuple of multiple paths.
 
-        :raise GitCommandError:
+        :raise git.exc.GitCommandError:
             If something went wrong.
 
         :return:

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -784,7 +784,7 @@ class Repo:
             :class:`~git.objects.commit.Commit`, or is empty if no common merge base
             exists.
 
-        :raises ValueError:
+        :raise ValueError:
             If fewer than two revisions are provided.
         """
         if len(rev) < 2:

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -168,7 +168,7 @@ class Repo:
         search_parent_directories: bool = False,
         expand_vars: bool = True,
     ) -> None:
-        """Create a new Repo instance.
+        R"""Create a new Repo instance.
 
         :param path:
             The path to either the root git directory or the bare git repo::
@@ -177,7 +177,7 @@ class Repo:
                 repo = Repo("/Users/mtrier/Development/git-python.git")
                 repo = Repo("~/Development/git-python.git")
                 repo = Repo("$REPOSITORIES/Development/git-python.git")
-                repo = Repo("C:\\Users\\mtrier\\Development\\git-python\\.git")
+                repo = Repo(R"C:\Users\mtrier\Development\git-python\.git")
 
             - In *Cygwin*, path may be a ``cygdrive/...`` prefixed path.
             - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -102,9 +102,9 @@ class BlameEntry(NamedTuple):
 
 
 class Repo:
-    """Represents a git repository and allows you to query references,
-    gather commit information, generate diffs, create and clone repositories, and query
-    the log.
+    """Represents a git repository and allows you to query references, father
+    commit information, generate diffs, create and clone repositories, and query the
+    log.
 
     The following attributes are worth using:
 
@@ -188,16 +188,18 @@ class Repo:
                 repo = Repo(R"C:\Users\mtrier\Development\git-python\.git")
 
             - In *Cygwin*, `path` may be a ``cygdrive/...`` prefixed path.
-            - If `path` is None or an empty string, :envvar:`GIT_DIR` is used. If that
-              environment variable is absent or empty, the current directory is used.
+            - If `path` is ``None`` or an empty string, :envvar:`GIT_DIR` is used. If
+              that environment variable is absent or empty, the current directory is
+              used.
 
         :param odbt:
             Object DataBase type - a type which is constructed by providing the
             directory containing the database objects, i.e. ``.git/objects``. It will be
-            used to access all object data
+            used to access all object data.
 
         :param search_parent_directories:
-            If True, all parent directories will be searched for a valid repo as well.
+            If ``True``, all parent directories will be searched for a valid repo as
+            well.
 
             Please note that this was the default behaviour in older versions of
             GitPython, which is considered a bug though.
@@ -372,7 +374,7 @@ class Repo:
         """
         :return:
             The working tree directory of our git repository.
-            If this is a bare repository, None is returned.
+            If this is a bare repository, ``None`` is returned.
         """
         return self._working_tree_dir
 
@@ -387,7 +389,7 @@ class Repo:
 
     @property
     def bare(self) -> bool:
-        """:return: True if the repository is bare"""
+        """:return: ``True`` if the repository is bare"""
         return self._bare
 
     @property
@@ -450,7 +452,7 @@ class Repo:
     def remote(self, name: str = "origin") -> "Remote":
         """:return: The remote with the specified name
 
-        :raise ValueError
+        :raise ValueError:
             If no remote with such a name exists.
         """
         r = Remote(self, name)
@@ -494,10 +496,13 @@ class Repo:
         return Submodule.add(self, *args, **kwargs)
 
     def iter_submodules(self, *args: Any, **kwargs: Any) -> Iterator[Submodule]:
-        """An iterator yielding Submodule instances, see Traversable interface
-        for a description of args and kwargs.
+        """An iterator yielding Submodule instances.
 
-        :return: Iterator
+        See the `~git.objects.util.Traversable` interface for a description of `args`
+        and `kwargs`.
+
+        :return:
+            Iterator
         """
         return RootModule(self).traverse(*args, **kwargs)
 
@@ -554,7 +559,8 @@ class Repo:
     ) -> "Head":
         """Create a new head within the repository.
 
-        :note: For more documentation, please see the
+        :note:
+            For more documentation, please see the
             :meth:`Head.create <git.refs.head.Head.create>` method.
 
         :return:
@@ -648,7 +654,7 @@ class Repo:
             configuration files.
 
         :param config_level:
-            For possible values, see the :meth:`config_writer` method. If None, all
+            For possible values, see the :meth:`config_writer` method. If ``None``, all
             applicable levels will be used. Specify a level in case you know which file
             you wish to read to prevent reading multiple files.
 
@@ -744,7 +750,7 @@ class Repo:
 
         :param rev:
             Revision specifier, see ``git rev-parse`` for viable options.
-            If None, the active branch will be used.
+            If ``None``, the active branch will be used.
 
         :param paths:
             An optional path or a list of paths. If set, only commits that include the
@@ -759,7 +765,7 @@ class Repo:
             ``"revA...revB"`` revision specifier.
 
         :return:
-            Iterator of  :class:`~git.objects.commit.Commit` objects
+            Iterator of :class:`~git.objects.commit.Commit` objects
         """
         if rev is None:
             rev = self.head.commit
@@ -819,7 +825,7 @@ class Repo:
             Rev to test against `ancestor_rev`.
 
         :return:
-            True if `ancestor_rev` is an ancestor to `rev`.
+            ``True`` if `ancestor_rev` is an ancestor to `rev`.
         """
         try:
             self.git.merge_base(ancestor_rev, rev, is_ancestor=True)
@@ -923,9 +929,9 @@ class Repo:
     ) -> bool:
         """
         :return:
-            True if the repository is considered dirty. By default it will react like a
-            git-status without untracked files, hence it is dirty if the index or the
-            working copy have changes.
+            ``True`` if the repository is considered dirty. By default it will react
+            like a git-status without untracked files, hence it is dirty if the index or
+            the working copy have changes.
         """
         if self._bare:
             # Bare repositories with no associated working directory are
@@ -1036,9 +1042,9 @@ class Repo:
         stream of :class:`BlameEntry` tuples.
 
         :param rev:
-            Revision specifier. If None, the blame will include all the latest
-            uncommitted changes. Otherwise, anything successfully parsed by ``git
-            rev-parse`` is a valid option.
+            Revision specifier. If ``None``, the blame will include all the latest
+            uncommitted changes. Otherwise, anything successfully parsed by
+            ``git rev-parse`` is a valid option.
 
         :return:
             Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates the
@@ -1132,9 +1138,9 @@ class Repo:
         """The blame information for the given file at the given revision.
 
         :param rev:
-            Revision specifier. If None, the blame will include all the latest
+            Revision specifier. If ``None``, the blame will include all the latest
             uncommitted changes. Otherwise, anything successfully parsed by
-            git-rev-parse is a valid option.
+            ``git rev-parse`` is a valid option.
 
         :return:
             list: [git.Commit, list: [<line>]]
@@ -1286,9 +1292,9 @@ class Repo:
         """Initialize a git repository at the given path if specified.
 
         :param path:
-            The full path to the repo (traditionally ends with ``/<name>.git``).
-            Or None, in which case the repository will be created in the current working
-            directory.
+            The full path to the repo (traditionally ends with ``/<name>.git``). Or
+            ``None``, in which case the repository will be created in the current
+            working directory.
 
         :param mkdir:
             If specified, will create the repository directory if it doesn't already
@@ -1445,7 +1451,7 @@ class Repo:
             Allow unsafe options to be used, like ``--upload-pack``.
 
         :param kwargs:
-            * odbt = ObjectDatabase Type, allowing to determine the object database
+            * ``odbt`` = ObjectDatabase Type, allowing to determine the object database
               implementation used by the returned Repo instance.
             * All remaining keyword arguments are given to the ``git clone`` command.
 
@@ -1547,9 +1553,9 @@ class Repo:
         :param kwargs:
             Additional arguments passed to ``git archive``:
 
-            * Use the 'format' argument to define the kind of format. Use specialized
+            * Use the ``format`` argument to define the kind of format. Use specialized
               ostreams to write any format supported by Python.
-            * You may specify the special **path** keyword, which may either be a
+            * You may specify the special ``path`` keyword, which may either be a
               repository-relative path to a directory or file to place into the archive,
               or a list or tuple of multiple paths.
 
@@ -1581,7 +1587,7 @@ class Repo:
             to.
 
         :note:
-            Bare repositories will always return False here.
+            Bare repositories will always return ``False`` here.
         """
         if self.bare:
             return False
@@ -1601,7 +1607,7 @@ class Repo:
         :return:
             The commit which is currently being replayed while rebasing.
 
-            None if we are not currently rebasing.
+            ``None`` if we are not currently rebasing.
         """
         if self.git_dir:
             rebase_head_file = osp.join(self.git_dir, "REBASE_HEAD")

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1020,7 +1020,7 @@ class Repo:
     def active_branch(self) -> Head:
         """The name of the currently active branch.
 
-        :raises	TypeError:
+        :raise TypeError:
             If HEAD is detached.
 
         :return:

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -103,26 +103,34 @@ class BlameEntry(NamedTuple):
 
 class Repo:
     """Represents a git repository and allows you to query references,
-    gather commit information, generate diffs, create and clone repositories query
+    gather commit information, generate diffs, create and clone repositories, and query
     the log.
 
     The following attributes are worth using:
 
-    'working_dir' is the working directory of the git command, which is the working tree
-    directory if available or the .git directory in case of bare repositories
+    * :attr:`working_dir` is the working directory of the git command, which is the
+      working tree directory if available or the ``.git`` directory in case of bare
+      repositories.
 
-    'working_tree_dir' is the working tree directory, but will return None
-    if we are a bare repository.
+    * :attr:`working_tree_dir` is the working tree directory, but will return None if we
+      are a bare repository.
 
-    'git_dir' is the .git repository directory, which is always set.
+    * :attr:`git_dir` is the ``.git`` repository directory, which is always set.
     """
 
     DAEMON_EXPORT_FILE = "git-daemon-export-ok"
 
-    git = cast("Git", None)  # Must exist, or  __del__  will fail in case we raise on `__init__()`.
+    # Must exist, or  __del__  will fail in case we raise on `__init__()`.
+    git = cast("Git", None)
+
     working_dir: PathLike
+    """The working directory of the git command."""
+
     _working_tree_dir: Optional[PathLike] = None
+
     git_dir: PathLike
+    """The ``.git`` repository directory."""
+
     _common_dir: PathLike = ""
 
     # Precompiled regex
@@ -168,7 +176,7 @@ class Repo:
         search_parent_directories: bool = False,
         expand_vars: bool = True,
     ) -> None:
-        R"""Create a new Repo instance.
+        R"""Create a new :class:`Repo` instance.
 
         :param path:
             The path to either the root git directory or the bare git repo::
@@ -179,14 +187,14 @@ class Repo:
                 repo = Repo("$REPOSITORIES/Development/git-python.git")
                 repo = Repo(R"C:\Users\mtrier\Development\git-python\.git")
 
-            - In *Cygwin*, path may be a ``cygdrive/...`` prefixed path.
-            - If it evaluates to false, :envvar:`GIT_DIR` is used, and if this also
-              evals to false, the current-directory is used.
+            - In *Cygwin*, `path` may be a ``cygdrive/...`` prefixed path.
+            - If `path` is None or an empty string, :envvar:`GIT_DIR` is used. If that
+              environment variable is absent or empty, the current directory is used.
 
         :param odbt:
-            Object DataBase type - a type which is constructed by providing
-            the directory containing the database objects, i.e. .git/objects. It will
-            be used to access all object data
+            Object DataBase type - a type which is constructed by providing the
+            directory containing the database objects, i.e. ``.git/objects``. It will be
+            used to access all object data
 
         :param search_parent_directories:
             If True, all parent directories will be searched for a valid repo as well.
@@ -195,18 +203,20 @@ class Repo:
             GitPython, which is considered a bug though.
 
         :raise InvalidGitRepositoryError:
+
         :raise NoSuchPathError:
 
-        :return: git.Repo
+        :return:
+            git.Repo
         """
 
         epath = path or os.getenv("GIT_DIR")
         if not epath:
             epath = os.getcwd()
         if Git.is_cygwin():
-            # Given how the tests are written, this seems more likely to catch
-            # Cygwin git used from Windows than Windows git used from Cygwin.
-            # Therefore changing to Cygwin-style paths is the relevant operation.
+            # Given how the tests are written, this seems more likely to catch Cygwin
+            # git used from Windows than Windows git used from Cygwin. Therefore
+            # changing to Cygwin-style paths is the relevant operation.
             epath = cygpath(epath)
 
         epath = epath or path or os.getcwd()
@@ -223,25 +233,26 @@ class Repo:
             if not os.path.exists(epath):
                 raise NoSuchPathError(epath)
 
-        ## Walk up the path to find the `.git` dir.
-        #
+        # Walk up the path to find the `.git` dir.
         curpath = epath
         git_dir = None
         while curpath:
             # ABOUT osp.NORMPATH
-            # It's important to normalize the paths, as submodules will otherwise initialize their
-            # repo instances with paths that depend on path-portions that will not exist after being
-            # removed. It's just cleaner.
+            # It's important to normalize the paths, as submodules will otherwise
+            # initialize their repo instances with paths that depend on path-portions
+            # that will not exist after being removed. It's just cleaner.
             if is_git_dir(curpath):
                 git_dir = curpath
                 # from man git-config : core.worktree
-                # Set the path to the root of the working tree. If GIT_COMMON_DIR environment
-                # variable is set, core.worktree is ignored and not used for determining the
-                # root of working tree. This can be overridden by the GIT_WORK_TREE environment
-                # variable. The value can be an absolute path or relative to the path to the .git
-                # directory, which is either specified by GIT_DIR, or automatically discovered.
-                # If GIT_DIR is specified but none of GIT_WORK_TREE and core.worktree is specified,
-                # the current working directory is regarded as the top level of your working tree.
+                # Set the path to the root of the working tree. If GIT_COMMON_DIR
+                # environment variable is set, core.worktree is ignored and not used for
+                # determining the root of working tree. This can be overridden by the
+                # GIT_WORK_TREE environment variable. The value can be an absolute path
+                # or relative to the path to the .git directory, which is either
+                # specified by GIT_DIR, or automatically discovered. If GIT_DIR is
+                # specified but none of GIT_WORK_TREE and core.worktree is specified,
+                # the current working directory is regarded as the top level of your
+                # working tree.
                 self._working_tree_dir = os.path.dirname(git_dir)
                 if os.environ.get("GIT_COMMON_DIR") is None:
                     gitconf = self._config_reader("repository", git_dir)
@@ -359,7 +370,8 @@ class Repo:
     @property
     def working_tree_dir(self) -> Optional[PathLike]:
         """
-        :return: The working tree directory of our git repository.
+        :return:
+            The working tree directory of our git repository.
             If this is a bare repository, None is returned.
         """
         return self._working_tree_dir
@@ -367,8 +379,9 @@ class Repo:
     @property
     def common_dir(self) -> PathLike:
         """
-        :return: The git dir that holds everything except possibly HEAD,
-            FETCH_HEAD, ORIG_HEAD, COMMIT_EDITMSG, index, and logs/.
+        :return:
+            The git dir that holds everything except possibly HEAD, FETCH_HEAD,
+            ORIG_HEAD, COMMIT_EDITMSG, index, and logs/.
         """
         return self._common_dir or self.git_dir
 
@@ -379,17 +392,21 @@ class Repo:
 
     @property
     def heads(self) -> "IterableList[Head]":
-        """A list of ``Head`` objects representing the branch heads in this repo.
+        """A list of :class:`~git.refs.head.Head` objects representing the branch heads
+        in this repo.
 
-        :return: ``git.IterableList(Head, ...)``
+        :return:
+            ``git.IterableList(Head, ...)``
         """
         return Head.list_items(self)
 
     @property
     def references(self) -> "IterableList[Reference]":
-        """A list of Reference objects representing tags, heads and remote references.
+        """A list of :class:`~git.refs.reference.Reference` objects representing tags,
+        heads and remote references.
 
-        :return: ``git.IterableList(Reference, ...)``
+        :return:
+            ``git.IterableList(Reference, ...)``
         """
         return Reference.list_items(self)
 
@@ -402,10 +419,11 @@ class Repo:
     @property
     def index(self) -> "IndexFile":
         """
-        :return: A :class:`~git.index.base.IndexFile` representing this repository's
-            index.
+        :return:
+            A :class:`~git.index.base.IndexFile` representing this repository's index.
 
-        :note: This property can be expensive, as the returned
+        :note:
+            This property can be expensive, as the returned
             :class:`~git.index.base.IndexFile` will be reinitialized.
             It is recommended to reuse the object.
         """
@@ -413,21 +431,27 @@ class Repo:
 
     @property
     def head(self) -> "HEAD":
-        """:return: HEAD Object pointing to the current head reference"""
+        """
+        :return:
+            :class:`~git.refs.head.HEAD` object pointing to the current head reference
+        """
         return HEAD(self, "HEAD")
 
     @property
     def remotes(self) -> "IterableList[Remote]":
-        """A list of Remote objects allowing to access and manipulate remotes.
+        """A list of :class:`~git.remote.Remote` objects allowing to access and
+        manipulate remotes.
 
-        :return: ``git.IterableList(Remote, ...)``
+        :return:
+            ``git.IterableList(Remote, ...)``
         """
         return Remote.list_items(self)
 
     def remote(self, name: str = "origin") -> "Remote":
-        """:return: Remote with the specified name
+        """:return: The remote with the specified name
 
-        :raise ValueError: If no remote with such a name exists
+        :raise ValueError
+            If no remote with such a name exists.
         """
         r = Remote(self, name)
         if not r.exists():
@@ -439,15 +463,17 @@ class Repo:
     @property
     def submodules(self) -> "IterableList[Submodule]":
         """
-        :return: git.IterableList(Submodule, ...) of direct submodules
-            available from the current head
+        :return:
+            git.IterableList(Submodule, ...) of direct submodules available from the
+            current head
         """
         return Submodule.list_items(self)
 
     def submodule(self, name: str) -> "Submodule":
-        """:return: Submodule with the given name
+        """:return: The submodule with the given name
 
-        :raise ValueError: If no such submodule exists
+        :raise ValueError:
+            If no such submodule exists.
         """
         try:
             return self.submodules[name]
@@ -458,10 +484,12 @@ class Repo:
     def create_submodule(self, *args: Any, **kwargs: Any) -> Submodule:
         """Create a new submodule.
 
-        :note: See the documentation of Submodule.add for a description of the
-            applicable parameters.
+        :note:
+            For a description of the applicable parameters, see the documentation of
+            :meth:`Submodule.add <git.objects.submodule.base.Submodule.add>`.
 
-        :return: The created submodules.
+        :return:
+            The created submodule.
         """
         return Submodule.add(self, *args, **kwargs)
 
@@ -477,7 +505,8 @@ class Repo:
         """Update the submodules, keeping the repository consistent as it will
         take the previous state into consideration.
 
-        :note: For more information, please see the documentation of
+        :note:
+            For more information, please see the documentation of
             :meth:`RootModule.update <git.objects.submodule.root.RootModule.update>`.
         """
         return RootModule(self).update(*args, **kwargs)
@@ -486,16 +515,22 @@ class Repo:
 
     @property
     def tags(self) -> "IterableList[TagReference]":
-        """A list of ``Tag`` objects that are available in this repo.
+        """A list of :class:`~git.refs.tag.TagReference` objects that are available in
+        this repo.
 
-        :return: ``git.IterableList(TagReference, ...)``
+        :return:
+            ``git.IterableList(TagReference, ...)``
         """
         return TagReference.list_items(self)
 
     def tag(self, path: PathLike) -> TagReference:
-        """:return: TagReference Object, reference pointing to a Commit or Tag
+        """
+        :return:
+            :class:`~git.refs.tag.TagReference` object, reference pointing to a
+            :class:`~git.objects.commit.Commit` or tag
 
-        :param path: path to the tag reference, i.e. 0.1.5 or tags/0.1.5
+        :param path:
+            Path to the tag reference, e.g. ``0.1.5`` or ``tags/0.1.5``.
         """
         full_path = self._to_full_tag_path(path)
         return TagReference(self, full_path)
@@ -522,14 +557,16 @@ class Repo:
         :note: For more documentation, please see the
             :meth:`Head.create <git.refs.head.Head.create>` method.
 
-        :return: Newly created :class:`~git.refs.head.Head` Reference
+        :return:
+            Newly created :class:`~git.refs.head.Head` Reference.
         """
         return Head.create(self, path, commit, logmsg, force)
 
     def delete_head(self, *heads: "Union[str, Head]", **kwargs: Any) -> None:
         """Delete the given heads.
 
-        :param kwargs: Additional keyword arguments to be passed to git-branch
+        :param kwargs:
+            Additional keyword arguments to be passed to ``git branch``.
         """
         return Head.delete(self, *heads, **kwargs)
 
@@ -543,10 +580,12 @@ class Repo:
     ) -> TagReference:
         """Create a new tag reference.
 
-        :note: For more documentation, please see the
+        :note:
+            For more documentation, please see the
             :meth:`TagReference.create <git.refs.tag.TagReference.create>` method.
 
-        :return: :class:`~git.refs.tag.TagReference` object
+        :return:
+            :class:`~git.refs.tag.TagReference` object
         """
         return TagReference.create(self, path, ref, message, force, **kwargs)
 
@@ -560,7 +599,8 @@ class Repo:
         For more information, please see the documentation of the
         :meth:`Remote.create <git.remote.Remote.create>` method.
 
-        :return: :class:`~git.remote.Remote` reference
+        :return:
+            :class:`~git.remote.Remote` reference
         """
         return Remote.create(self, name, url, **kwargs)
 
@@ -612,7 +652,8 @@ class Repo:
             applicable levels will be used. Specify a level in case you know which file
             you wish to read to prevent reading multiple files.
 
-        :note: On Windows, system configuration cannot currently be read as the path is
+        :note:
+            On Windows, system configuration cannot currently be read as the path is
             unknown, instead the global path will be used.
         """
         return self._config_reader(config_level=config_level)
@@ -650,37 +691,43 @@ class Repo:
         return GitConfigParser(self._get_config_path(config_level), read_only=False, repo=self, merge_includes=False)
 
     def commit(self, rev: Union[str, Commit_ish, None] = None) -> Commit:
-        """The Commit object for the specified revision.
+        """The :class:`~git.objects.commit.Commit` object for the specified revision.
 
-        :param rev: revision specifier, see git-rev-parse for viable options.
-        :return: :class:`git.Commit <git.objects.commit.Commit>`
+        :param rev:
+            Revision specifier, see ``git rev-parse`` for viable options.
+
+        :return:
+            :class:`~git.objects.commit.Commit`
         """
         if rev is None:
             return self.head.commit
         return self.rev_parse(str(rev) + "^0")
 
     def iter_trees(self, *args: Any, **kwargs: Any) -> Iterator["Tree"]:
-        """:return: Iterator yielding Tree objects
+        """:return: Iterator yielding :class:`~git.objects.tree.Tree` objects
 
-        :note: Accepts all arguments known to the :meth:`iter_commits` method.
+        :note:
+            Accepts all arguments known to the :meth:`iter_commits` method.
         """
         return (c.tree for c in self.iter_commits(*args, **kwargs))
 
     def tree(self, rev: Union[Tree_ish, str, None] = None) -> "Tree":
-        """The Tree object for the given tree-ish revision.
+        """The :class:`~git.objects.tree.Tree` object for the given tree-ish revision.
 
         Examples::
 
               repo.tree(repo.heads[0])
 
-        :param rev: is a revision pointing to a Treeish (being a commit or tree)
+        :param rev:
+            A revision pointing to a Treeish (being a commit or tree).
 
-        :return: ``git.Tree``
+        :return:
+            :class:`~git.objects.tree.Tree`
 
         :note:
-            If you need a non-root level tree, find it by iterating the root tree. Otherwise
-            it cannot know about its path relative to the repository root and subsequent
-            operations might have unexpected results.
+            If you need a non-root level tree, find it by iterating the root tree.
+            Otherwise it cannot know about its path relative to the repository root and
+            subsequent operations might have unexpected results.
         """
         if rev is None:
             return self.head.commit.tree
@@ -692,23 +739,27 @@ class Repo:
         paths: Union[PathLike, Sequence[PathLike]] = "",
         **kwargs: Any,
     ) -> Iterator[Commit]:
-        """An iterator of Commit objects representing the history of a given ref/commit.
+        """An iterator of :class:`~git.objects.commit.Commit` objects representing the
+        history of a given ref/commit.
 
         :param rev:
-            Revision specifier, see git-rev-parse for viable options.
+            Revision specifier, see ``git rev-parse`` for viable options.
             If None, the active branch will be used.
 
         :param paths:
-            An optional path or a list of paths; if set only commits that include the
-            path or paths will be returned
+            An optional path or a list of paths. If set, only commits that include the
+            path or paths will be returned.
 
         :param kwargs:
-            Arguments to be passed to git-rev-list - common ones are max_count and skip.
+            Arguments to be passed to ``git rev-list``.
+            Common ones are ``max_count`` and ``skip``.
 
-        :note: To receive only commits between two named revisions, use the
+        :note:
+            To receive only commits between two named revisions, use the
             ``"revA...revB"`` revision specifier.
 
-        :return: Iterator of ``git.Commit``
+        :return:
+            Iterator of  :class:`~git.objects.commit.Commit` objects
         """
         if rev is None:
             rev = self.head.commit
@@ -716,16 +767,25 @@ class Repo:
         return Commit.iter_items(self, rev, paths, **kwargs)
 
     def merge_base(self, *rev: TBD, **kwargs: Any) -> List[Union[Commit_ish, None]]:
-        """Find the closest common ancestor for the given revision (Commits, Tags, References, etc.).
+        R"""Find the closest common ancestor for the given revision
+        (:class:`~git.objects.commit.Commit`\s, :class:`~git.refs.tag.Tag`\s,
+        :class:`git.refs.reference.Reference`\s, etc.).
 
-        :param rev: At least two revs to find the common ancestor for.
-        :param kwargs: Additional arguments to be passed to the
-            ``repo.git.merge_base()`` command which does all the work.
-        :return: A list of :class:`~git.objects.commit.Commit` objects. If ``--all`` was
+        :param rev:
+            At least two revs to find the common ancestor for.
+
+        :param kwargs:
+            Additional arguments to be passed to the ``repo.git.merge_base()`` command
+            which does all the work.
+
+        :return:
+            A list of :class:`~git.objects.commit.Commit` objects. If ``--all`` was
             not passed as a keyword argument, the list will have at max one
             :class:`~git.objects.commit.Commit`, or is empty if no common merge base
             exists.
-        :raises ValueError: If not at least two revs are provided.
+
+        :raises ValueError:
+            If fewer than two revisions are provided.
         """
         if len(rev) < 2:
             raise ValueError("Please specify at least two revs, got only %i" % len(rev))
@@ -752,9 +812,14 @@ class Repo:
     def is_ancestor(self, ancestor_rev: "Commit", rev: "Commit") -> bool:
         """Check if a commit is an ancestor of another.
 
-        :param ancestor_rev: Rev which should be an ancestor
-        :param rev: Rev to test against ancestor_rev
-        :return: ``True``, ancestor_rev is an ancestor to rev.
+        :param ancestor_rev:
+            Rev which should be an ancestor.
+
+        :param rev:
+            Rev to test against `ancestor_rev`.
+
+        :return:
+            True if `ancestor_rev` is an ancestor to `rev`.
         """
         try:
             self.git.merge_base(ancestor_rev, rev, is_ancestor=True)
@@ -809,7 +874,8 @@ class Repo:
     def _get_alternates(self) -> List[str]:
         """The list of alternates for this repo from which objects can be retrieved.
 
-        :return: List of strings being pathnames of alternates
+        :return:
+            List of strings being pathnames of alternates
         """
         if self.git_dir:
             alternates_path = osp.join(self.git_dir, "objects", "info", "alternates")
@@ -821,17 +887,17 @@ class Repo:
         return []
 
     def _set_alternates(self, alts: List[str]) -> None:
-        """Sets the alternates.
+        """Set the alternates.
 
         :param alts:
-            is the array of string paths representing the alternates at which
-            git should look for objects, i.e. /home/user/repo/.git/objects
+            The array of string paths representing the alternates at which git should
+            look for objects, i.e. ``/home/user/repo/.git/objects``.
 
         :raise NoSuchPathError:
 
         :note:
-            The method does not check for the existence of the paths in alts
-            as the caller is responsible.
+            The method does not check for the existence of the paths in `alts`, as the
+            caller is responsible.
         """
         alternates_path = osp.join(self.common_dir, "objects", "info", "alternates")
         if not alts:
@@ -857,9 +923,9 @@ class Repo:
     ) -> bool:
         """
         :return:
-            ``True`` if the repository is considered dirty. By default it will react
-            like a git-status without untracked files, hence it is dirty if the
-            index or the working copy have changes.
+            True if the repository is considered dirty. By default it will react like a
+            git-status without untracked files, hence it is dirty if the index or the
+            working copy have changes.
         """
         if self._bare:
             # Bare repositories with no associated working directory are
@@ -894,11 +960,12 @@ class Repo:
         :return:
             list(str,...)
 
-            Files currently untracked as they have not been staged yet. Paths
-            are relative to the current working directory of the git command.
+            Files currently untracked as they have not been staged yet. Paths are
+            relative to the current working directory of the git command.
 
         :note:
             Ignored files will not appear here, i.e. files mentioned in ``.gitignore``.
+
         :note:
             This property is expensive, as no cache is involved. To process the result,
             please consider caching it yourself.
@@ -926,23 +993,25 @@ class Repo:
         return untracked_files
 
     def ignored(self, *paths: PathLike) -> List[str]:
-        """Checks if paths are ignored via .gitignore.
+        """Checks if paths are ignored via ``.gitignore``.
 
         This does so using the ``git check-ignore`` method.
 
-        :param paths: List of paths to check whether they are ignored or not
+        :param paths:
+            List of paths to check whether they are ignored or not.
 
-        :return: Subset of those paths which are ignored
+        :return:
+            Subset of those paths which are ignored
         """
         try:
             proc: str = self.git.check_ignore(*paths)
         except GitCommandError as err:
-            # If return code is 1, this means none of the items in *paths
-            # are ignored by Git, so return an empty list.  Raise the
-            # exception on all other return codes.
             if err.status == 1:
+                # If return code is 1, this means none of the items in *paths are
+                # ignored by Git, so return an empty list.
                 return []
             else:
+                # Raise the exception on all other return codes.
                 raise
 
         return proc.replace("\\\\", "\\").replace('"', "").split("\n")
@@ -951,8 +1020,11 @@ class Repo:
     def active_branch(self) -> Head:
         """The name of the currently active branch.
 
-        :raises	TypeError: If HEAD is detached
-        :return: Head to the active branch
+        :raises	TypeError:
+            If HEAD is detached.
+
+        :return:
+            Head to the active branch
         """
         # reveal_type(self.head.reference)  # => Reference
         return self.head.reference
@@ -963,13 +1035,15 @@ class Repo:
         Unlike :meth:`blame`, this does not return the actual file's contents, only a
         stream of :class:`BlameEntry` tuples.
 
-        :param rev: Revision specifier. If `None`, the blame will include all the latest
-            uncommitted changes. Otherwise, anything succesfully parsed by git-rev-parse
-            is a valid option.
+        :param rev:
+            Revision specifier. If None, the blame will include all the latest
+            uncommitted changes. Otherwise, anything successfully parsed by ``git
+            rev-parse`` is a valid option.
 
-        :return: Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates
-            the commit to blame for the line, and range indicates a span of line numbers
-            in the resulting file.
+        :return:
+            Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates the
+            commit to blame for the line, and range indicates a span of line numbers in
+            the resulting file.
 
         If you combine all line number ranges outputted by this command, you should get
         a continuous range spanning all line numbers in the file.
@@ -981,7 +1055,8 @@ class Repo:
         stream = (line for line in data.split(b"\n") if line)
         while True:
             try:
-                line = next(stream)  # When exhausted, causes a StopIteration, terminating this function.
+                # When exhausted, causes a StopIteration, terminating this function.
+                line = next(stream)
             except StopIteration:
                 return
             split_line = line.split()
@@ -990,8 +1065,8 @@ class Repo:
             num_lines = int(num_lines_b)
             orig_lineno = int(orig_lineno_b)
             if hexsha not in commits:
-                # Now read the next few lines and build up a dict of properties
-                # for this commit.
+                # Now read the next few lines and build up a dict of properties for this
+                # commit.
                 props: Dict[bytes, bytes] = {}
                 while True:
                     try:
@@ -999,8 +1074,8 @@ class Repo:
                     except StopIteration:
                         return
                     if line == b"boundary":
-                        # "boundary" indicates a root commit and occurs
-                        # instead of the "previous" tag.
+                        # "boundary" indicates a root commit and occurs instead of the
+                        # "previous" tag.
                         continue
 
                     tag, value = line.split(b" ", 1)
@@ -1026,11 +1101,12 @@ class Repo:
                 )
                 commits[hexsha] = c
             else:
-                # Discard all lines until we find "filename" which is
-                # guaranteed to be the last line.
+                # Discard all lines until we find "filename" which is guaranteed to be
+                # the last line.
                 while True:
                     try:
-                        line = next(stream)  # Will fail if we reach the EOF unexpectedly.
+                        # Will fail if we reach the EOF unexpectedly.
+                        line = next(stream)
                     except StopIteration:
                         return
                     tag, value = line.split(b" ", 1)
@@ -1055,16 +1131,18 @@ class Repo:
     ) -> List[List[Commit | List[str | bytes] | None]] | Iterator[BlameEntry] | None:
         """The blame information for the given file at the given revision.
 
-        :param rev: Revision specifier. If `None`, the blame will include all the latest
-            uncommitted changes. Otherwise, anything succesfully parsed by git-rev-parse
-            is a valid option.
+        :param rev:
+            Revision specifier. If None, the blame will include all the latest
+            uncommitted changes. Otherwise, anything successfully parsed by
+            git-rev-parse is a valid option.
 
         :return:
             list: [git.Commit, list: [<line>]]
 
-            A list of lists associating a Commit object with a list of lines that
-            changed within the given commit. The Commit objects will be given in order
-            of appearance.
+            A list of lists associating a :class:`~git.objects.commit.Commit` object
+            with a list of lines that changed within the given commit. The
+            :class:`~git.objects.commit.Commit` objects will be given in order of
+            appearance.
         """
         if incremental:
             return self.blame_incremental(rev, file, **kwargs)
@@ -1096,10 +1174,11 @@ class Repo:
                 parts = []
                 is_binary = True
             else:
-                # As we don't have an idea when the binary data ends, as it could contain multiple newlines
-                # in the process. So we rely on being able to decode to tell us what it is.
-                # This can absolutely fail even on text files, but even if it does, we should be fine treating it
-                # as binary instead.
+                # As we don't have an idea when the binary data ends, as it could
+                # contain multiple newlines in the process. So we rely on being able to
+                # decode to tell us what it is. This can absolutely fail even on text
+                # files, but even if it does, we should be fine treating it as binary
+                # instead.
                 parts = self.re_whitespace.split(line_str, 1)
                 firstpart = parts[0]
                 is_binary = False
@@ -1180,10 +1259,12 @@ class Repo:
                                     line = line_str
                                 else:
                                     line = line_bytes
-                                    # NOTE: We are actually parsing lines out of binary data, which can lead to the
-                                    # binary being split up along the newline separator. We will append this to the
-                                    # blame we are currently looking at, even though it should be concatenated with
-                                    # the last line we have seen.
+                                    # NOTE: We are actually parsing lines out of binary
+                                    # data, which can lead to the binary being split up
+                                    # along the newline separator. We will append this
+                                    # to the blame we are currently looking at, even
+                                    # though it should be concatenated with the last
+                                    # line we have seen.
                                 blames[-1][1].append(line)
 
                             info = {"id": sha}
@@ -1205,28 +1286,30 @@ class Repo:
         """Initialize a git repository at the given path if specified.
 
         :param path:
-            The full path to the repo (traditionally ends with /<name>.git) or None in
-            which case the repository will be created in the current working directory
+            The full path to the repo (traditionally ends with ``/<name>.git``).
+            Or None, in which case the repository will be created in the current working
+            directory.
 
         :param mkdir:
-            If specified, will create the repository directory if it doesn't
-            already exist. Creates the directory with a mode=0755.
+            If specified, will create the repository directory if it doesn't already
+            exist. Creates the directory with a mode=0755.
             Only effective if a path is explicitly given.
 
         :param odbt:
-            Object DataBase type - a type which is constructed by providing
-            the directory containing the database objects, i.e. .git/objects.
-            It will be used to access all object data.
+            Object DataBase type - a type which is constructed by providing the
+            directory containing the database objects, i.e. ``.git/objects``. It will be
+            used to access all object data.
 
         :param expand_vars:
-            If specified, environment variables will not be escaped. This
-            can lead to information disclosure, allowing attackers to
-            access the contents of environment variables.
+            If specified, environment variables will not be escaped. This can lead to
+            information disclosure, allowing attackers to access the contents of
+            environment variables.
 
         :param kwargs:
-            Keyword arguments serving as additional options to the git-init command.
+            Keyword arguments serving as additional options to the ``git init`` command.
 
-        :return: ``git.Repo`` (the newly created repo)
+        :return:
+            :class:`Repo` (the newly created repo)
         """
         if path:
             path = expand_path(path, expand_vars)
@@ -1253,7 +1336,7 @@ class Repo:
     ) -> "Repo":
         odbt = kwargs.pop("odbt", odb_default_type)
 
-        # When pathlib.Path or other classbased path is passed
+        # When pathlib.Path or other class-based path is passed
         if not isinstance(path, str):
             path = str(path)
 
@@ -1315,11 +1398,10 @@ class Repo:
         # Retain env values that were passed to _clone().
         repo.git.update_environment(**git.environment())
 
-        # Adjust remotes - there may be operating systems which use backslashes,
-        # These might be given as initial paths, but when handling the config file
-        # that contains the remote from which we were clones, git stops liking it
-        # as it will escape the backslashes. Hence we undo the escaping just to be
-        # sure.
+        # Adjust remotes - there may be operating systems which use backslashes, These
+        # might be given as initial paths, but when handling the config file that
+        # contains the remote from which we were clones, git stops liking it as it will
+        # escape the backslashes. Hence we undo the escaping just to be sure.
         if repo.remotes:
             with repo.remotes[0].config_writer as writer:
                 writer.set_value("url", Git.polish_url(repo.remotes[0].url))
@@ -1337,21 +1419,38 @@ class Repo:
     ) -> "Repo":
         """Create a clone from this repository.
 
-        :param path: The full path of the new repo (traditionally ends with
-            ``./<name>.git``).
-        :param progress: See :meth:`git.remote.Remote.push`.
-        :param multi_options: A list of Clone options that can be provided multiple times.
+        :param path:
+            The full path of the new repo (traditionally ends with ``./<name>.git``).
+
+        :param progress:
+            See :meth:`Remote.push <git.remote.Remote.push>`.
+
+        :param multi_options:
+            A list of ``git clone`` options that can be provided multiple times.
+
             One option per list item which is passed exactly as specified to clone.
-            For example: ['--config core.filemode=false', '--config core.ignorecase',
-            '--recurse-submodule=repo1_path', '--recurse-submodule=repo2_path']
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
+            For example::
+
+                [
+                    "--config core.filemode=false",
+                    "--config core.ignorecase",
+                    "--recurse-submodule=repo1_path",
+                    "--recurse-submodule=repo2_path",
+                ]
+
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
+
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
+
         :param kwargs:
             * odbt = ObjectDatabase Type, allowing to determine the object database
               implementation used by the returned Repo instance.
-            * All remaining keyword arguments are given to the git-clone command.
+            * All remaining keyword arguments are given to the ``git clone`` command.
 
-        :return: :class:`Repo` (the newly cloned repo)
+        :return:
+            :class:`Repo` (the newly cloned repo)
         """
         return self._clone(
             self.git,
@@ -1379,29 +1478,38 @@ class Repo:
     ) -> "Repo":
         """Create a clone from the given URL.
 
-        :param url: Valid git url, see http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
+        :param url:
+            Valid git url, see:
+            http://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
 
-        :param to_path: Path to which the repository should be cloned to.
+        :param to_path:
+            Path to which the repository should be cloned to.
 
-        :param progress: See :meth:`git.remote.Remote.push`.
+        :param progress:
+            See :meth:`Remote.push <git.remote.Remote.push>`.
 
-        :param env: Optional dictionary containing the desired environment variables.
+        :param env:
+            Optional dictionary containing the desired environment variables.
 
-            Note: Provided variables will be used to update the execution
-            environment for `git`. If some variable is not specified in `env`
-            and is defined in `os.environ`, value from `os.environ` will be used.
-            If you want to unset some variable, consider providing empty string
-            as its value.
+            Note: Provided variables will be used to update the execution environment
+            for ``git``. If some variable is not specified in `env` and is defined in
+            :attr:`os.environ`, value from :attr:`os.environ` will be used. If you want
+            to unset some variable, consider providing empty string as its value.
 
-        :param multi_options: See :meth:`clone` method.
+        :param multi_options:
+            See the :meth:`clone` method.
 
-        :param allow_unsafe_protocols: Allow unsafe protocols to be used, like ext.
+        :param allow_unsafe_protocols:
+            Allow unsafe protocols to be used, like ``ext``.
 
-        :param allow_unsafe_options: Allow unsafe options to be used, like --upload-pack.
+        :param allow_unsafe_options:
+            Allow unsafe options to be used, like ``--upload-pack``.
 
-        :param kwargs: See the :meth:`clone` method.
+        :param kwargs:
+            See the :meth:`clone` method.
 
-        :return: :class:`Repo` instance pointing to the cloned directory.
+        :return:
+            :class:`Repo` instance pointing to the cloned directory.
         """
         git = cls.GitCommandWrapperType(os.getcwd())
         if env is not None:
@@ -1459,10 +1567,14 @@ class Repo:
 
     def has_separate_working_tree(self) -> bool:
         """
-        :return: True if our git_dir is not at the root of our working_tree_dir, but a .git file with a
-            platform agnositic symbolic link. Our git_dir will be wherever the .git file points to.
+        :return:
+            True if our :attr:`git_dir` is not at the root of our
+            :attr:`working_tree_dir`, but a ``.git`` file with a platform-agnostic
+            symbolic link. Our :attr:`git_dir` will be wherever the ``.git`` file points
+            to.
 
-        :note: bare repositories will always return False here
+        :note:
+            Bare repositories will always return False here.
         """
         if self.bare:
             return False
@@ -1479,7 +1591,8 @@ class Repo:
 
     def currently_rebasing_on(self) -> Commit | None:
         """
-        :return: The commit which is currently being replayed while rebasing.
+        :return:
+            The commit which is currently being replayed while rebasing.
 
             None if we are not currently rebasing.
         """

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -692,7 +692,7 @@ class Repo:
         paths: Union[PathLike, Sequence[PathLike]] = "",
         **kwargs: Any,
     ) -> Iterator[Commit]:
-        """A list of Commit objects representing the history of a given ref/commit.
+        """An iterator of Commit objects representing the history of a given ref/commit.
 
         :param rev:
             Revision specifier, see git-rev-parse for viable options.
@@ -708,7 +708,7 @@ class Repo:
         :note: To receive only commits between two named revisions, use the
             ``"revA...revB"`` revision specifier.
 
-        :return: ``git.Commit[]``
+        :return: Iterator of ``git.Commit``
         """
         if rev is None:
             rev = self.head.commit

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -1535,22 +1535,29 @@ class Repo:
     ) -> Repo:
         """Archive the tree at the given revision.
 
-        :param ostream: file compatible stream object to which the archive will be written as bytes.
+        :param ostream:
+            File-compatible stream object to which the archive will be written as bytes.
 
-        :param treeish: is the treeish name/id, defaults to active branch.
+        :param treeish:
+            The treeish name/id, defaults to active branch.
 
-        :param prefix: is the optional prefix to prepend to each filename in the archive.
+        :param prefix:
+            The optional prefix to prepend to each filename in the archive.
 
-        :param kwargs: Additional arguments passed to git-archive:
+        :param kwargs:
+            Additional arguments passed to ``git archive``:
 
-            * Use the 'format' argument to define the kind of format. Use
-              specialized ostreams to write any format supported by python.
-            * You may specify the special **path** keyword, which may either be a repository-relative
-              path to a directory or file to place into the archive, or a list or tuple of multiple paths.
+            * Use the 'format' argument to define the kind of format. Use specialized
+              ostreams to write any format supported by Python.
+            * You may specify the special **path** keyword, which may either be a
+              repository-relative path to a directory or file to place into the archive,
+              or a list or tuple of multiple paths.
 
-        :raise GitCommandError: If something went wrong.
+        :raise GitCommandError:
+            If something went wrong.
 
-        :return: self
+        :return:
+            self
         """
         if treeish is None:
             treeish = self.head.commit

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -798,8 +798,8 @@ class Repo:
             if err.status == 128:
                 raise
             # END handle invalid rev
-            # Status code 1 is returned if there is no merge-base
-            # (see https://github.com/git/git/blob/master/builtin/merge-base.c#L16)
+            # Status code 1 is returned if there is no merge-base.
+            # (See: https://github.com/git/git/blob/v2.44.0/builtin/merge-base.c#L19)
             return res
         # END exception handling
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -102,9 +102,8 @@ class BlameEntry(NamedTuple):
 
 
 class Repo:
-    """Represents a git repository and allows you to query references, father
-    commit information, generate diffs, create and clone repositories, and query the
-    log.
+    """Represents a git repository and allows you to query references, create commit
+    information, generate diffs, create and clone repositories, and query the log.
 
     The following attributes are worth using:
 
@@ -112,8 +111,8 @@ class Repo:
       working tree directory if available or the ``.git`` directory in case of bare
       repositories.
 
-    * :attr:`working_tree_dir` is the working tree directory, but will return None if we
-      are a bare repository.
+    * :attr:`working_tree_dir` is the working tree directory, but will return ``None``
+      if we are a bare repository.
 
     * :attr:`git_dir` is the ``.git`` repository directory, which is always set.
     """
@@ -596,7 +595,7 @@ class Repo:
         return TagReference.create(self, path, ref, message, force, **kwargs)
 
     def delete_tag(self, *tags: TagReference) -> None:
-        """Delete the given tag references"""
+        """Delete the given tag references."""
         return TagReference.delete(self, *tags)
 
     def create_remote(self, name: str, url: str, **kwargs: Any) -> Remote:
@@ -775,7 +774,7 @@ class Repo:
     def merge_base(self, *rev: TBD, **kwargs: Any) -> List[Union[Commit_ish, None]]:
         R"""Find the closest common ancestor for the given revision
         (:class:`~git.objects.commit.Commit`\s, :class:`~git.refs.tag.Tag`\s,
-        :class:`git.refs.reference.Reference`\s, etc.).
+        :class:`~git.refs.reference.Reference`\s, etc.).
 
         :param rev:
             At least two revs to find the common ancestor for.
@@ -1030,7 +1029,7 @@ class Repo:
             If HEAD is detached.
 
         :return:
-            Head to the active branch
+            :class:`~git.refs.head.Head` to the active branch
         """
         # reveal_type(self.head.reference)  # => Reference
         return self.head.reference

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -59,7 +59,7 @@ def touch(filename: str) -> str:
 def is_git_dir(d: "PathLike") -> bool:
     """This is taken from the git setup.c:is_git_directory function.
 
-    :raise WorkTreeRepositoryUnsupported:
+    :raise git.exc.WorkTreeRepositoryUnsupported:
         If it sees a worktree directory. It's quite hacky to do that here, but at least
         clearly indicates that we don't support it. There is the unlikely danger to
         throw if we see directories which just look like a worktree dir, but are none.
@@ -234,7 +234,7 @@ def rev_parse(repo: "Repo", rev: str) -> Union["Commit", "Tag", "Tree", "Blob"]:
         ``git rev-parse``-compatible revision specification as string. Please see
         http://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html for details.
 
-    :raise BadObject:
+    :raise gitdb.exc.BadObject:
         If the given revision could not be found.
 
     :raise ValueError:

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -246,7 +246,7 @@ def rev_parse(repo: "Repo", rev: str) -> Union["Commit", "Tag", "Tree", "Blob"]:
     # Are we in colon search mode?
     if rev.startswith(":/"):
         # Colon search mode
-        raise NotImplementedError("commit by message search ( regex )")
+        raise NotImplementedError("commit by message search (regex)")
     # END handle search
 
     obj: Union[Commit_ish, "Reference", None] = None

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -151,7 +151,7 @@ def name_to_object(
 
     :param return_ref:
         If ``True``, and name specifies a reference, we will return the reference
-        instead of the object. Otherwise it will raise `~gitdb.exc.BadObject` o
+        instead of the object. Otherwise it will raise `~gitdb.exc.BadObject` or
         `~gitdb.exc.BadName`.
     """
     hexsha: Union[None, str, bytes] = None

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -128,7 +128,7 @@ def find_submodule_git_dir(d: "PathLike") -> Optional["PathLike"]:
 def short_to_long(odb: "GitCmdObjectDB", hexsha: str) -> Optional[bytes]:
     """
     :return:
-        Long hexadecimal sha1 from the given less than 40 byte hexsha or None if no
+        Long hexadecimal sha1 from the given less than 40 byte hexsha, or ``None`` if no
         candidate could be found.
 
     :param hexsha:
@@ -150,7 +150,7 @@ def name_to_object(
         references are supported.
 
     :param return_ref:
-        If True, and name specifies a reference, we will return the reference
+        If ``True``, and name specifies a reference, we will return the reference
         instead of the object. Otherwise it will raise `~gitdb.exc.BadObject` o
         `~gitdb.exc.BadName`.
     """
@@ -202,7 +202,7 @@ def name_to_object(
 
 
 def deref_tag(tag: "Tag") -> "TagObject":
-    """Recursively dereference a tag and return the resulting object"""
+    """Recursively dereference a tag and return the resulting object."""
     while True:
         try:
             tag = tag.object
@@ -213,7 +213,7 @@ def deref_tag(tag: "Tag") -> "TagObject":
 
 
 def to_commit(obj: Object) -> Union["Commit", "TagObject"]:
-    """Convert the given object to a commit if possible and return it"""
+    """Convert the given object to a commit if possible and return it."""
     if obj.type == "tag":
         obj = deref_tag(obj)
 

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -59,7 +59,7 @@ def touch(filename: str) -> str:
 def is_git_dir(d: "PathLike") -> bool:
     """This is taken from the git setup.c:is_git_directory function.
 
-    :raises WorkTreeRepositoryUnsupported:
+    :raise WorkTreeRepositoryUnsupported:
         If it sees a worktree directory. It's quite hacky to do that here, but at least
         clearly indicates that we don't support it. There is the unlikely danger to
         throw if we see directories which just look like a worktree dir, but are none.

--- a/git/util.py
+++ b/git/util.py
@@ -260,7 +260,7 @@ def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 *
 
 def join_path(a: PathLike, *p: PathLike) -> PathLike:
     R"""Join path tokens together similar to osp.join, but always use
-    '/' instead of possibly '\' on Windows."""
+    ``/`` instead of possibly ``\`` on Windows."""
     path = str(a)
     for b in p:
         b = str(b)
@@ -300,7 +300,7 @@ def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
     R"""Like join_path, but makes sure an OS native path is returned.
 
     This is only needed to play it safe on Windows and to ensure nice paths that only
-    use '\'.
+    use ``\``.
     """
     return to_native_path(join_path(a, *p))
 

--- a/git/util.py
+++ b/git/util.py
@@ -201,9 +201,9 @@ def patch_env(name: str, value: str) -> Generator[None, None, None]:
 def rmtree(path: PathLike) -> None:
     """Remove the given directory tree recursively.
 
-    :note: We use :func:`shutil.rmtree` but adjust its behaviour to see whether files
-        that couldn't be deleted are read-only. Windows will not remove them in that
-        case.
+    :note:
+        We use :func:`shutil.rmtree` but adjust its behaviour to see whether files that
+        couldn't be deleted are read-only. Windows will not remove them in that case.
     """
 
     def handler(function: Callable, path: PathLike, _excinfo: Any) -> None:
@@ -241,8 +241,8 @@ def rmfile(path: PathLike) -> None:
 
 
 def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 * 1024) -> int:
-    """Copy all data from the source stream into the destination stream in chunks
-    of size chunk_size.
+    """Copy all data from the `source` stream into the `destination` stream in chunks
+    of size `chunk_size`.
 
     :return:
         Number of bytes written
@@ -259,8 +259,8 @@ def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 *
 
 
 def join_path(a: PathLike, *p: PathLike) -> PathLike:
-    R"""Join path tokens together similar to osp.join, but always use
-    ``/`` instead of possibly ``\`` on Windows."""
+    R"""Join path tokens together similar to osp.join, but always use ``/`` instead of
+    possibly ``\`` on Windows."""
     path = str(a)
     for b in p:
         b = str(b)
@@ -297,7 +297,7 @@ else:
 
 
 def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
-    R"""Like join_path, but makes sure an OS native path is returned.
+    R"""Like :func:`join_path`, but makes sure an OS native path is returned.
 
     This is only needed to play it safe on Windows and to ensure nice paths that only
     use ``\``.
@@ -308,10 +308,12 @@ def join_path_native(a: PathLike, *p: PathLike) -> PathLike:
 def assure_directory_exists(path: PathLike, is_file: bool = False) -> bool:
     """Make sure that the directory pointed to by path exists.
 
-    :param is_file: If True, ``path`` is assumed to be a file and handled correctly.
+    :param is_file:
+        If True, `path` is assumed to be a file and handled correctly.
         Otherwise it must be a directory.
 
-    :return: True if the directory was created, False if it already existed.
+    :return:
+        True if the directory was created, False if it already existed.
     """
     if is_file:
         path = osp.dirname(path)
@@ -339,7 +341,8 @@ def py_where(program: str, path: Optional[PathLike] = None) -> List[str]:
     :func:`is_cygwin_git`. When a search following all shell rules is needed,
     :func:`shutil.which` can be used instead.
 
-    :note: Neither this function nor :func:`shutil.which` will predict the effect of an
+    :note:
+        Neither this function nor :func:`shutil.which` will predict the effect of an
         executable search on a native Windows system due to a :class:`subprocess.Popen`
         call without ``shell=True``, because shell and non-shell executable search on
         Windows differ considerably.
@@ -550,8 +553,7 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
 class RemoteProgress:
     """Handler providing an interface to parse progress information emitted by
     ``git push`` and ``git fetch`` and to dispatch callbacks allowing subclasses to
-    react to the progress.
-    """
+    react to the progress."""
 
     _num_op_codes: int = 9
     (
@@ -761,8 +763,8 @@ class CallableRemoteProgress(RemoteProgress):
 
 class Actor:
     """Actors hold information about a person acting on the repository. They
-    can be committers and authors or anything with a name and an email as
-    mentioned in the git log entries."""
+    can be committers and authors or anything with a name and an email as mentioned in
+    the git log entries."""
 
     # PRECOMPILED REGEX
     name_only_regex = re.compile(r"<(.*)>")
@@ -802,7 +804,7 @@ class Actor:
 
     @classmethod
     def _from_string(cls, string: str) -> "Actor":
-        """Create an Actor from a string.
+        """Create an :class:`Actor` from a string.
 
         :param string:
             The string, which is expected to be in regular git format::
@@ -868,10 +870,11 @@ class Actor:
     @classmethod
     def committer(cls, config_reader: Union[None, "GitConfigParser", "SectionConstraint"] = None) -> "Actor":
         """
-        :return: Actor instance corresponding to the configured committer. It behaves
-            similar to the git implementation, such that the environment will override
-            configuration values of `config_reader`. If no value is set at all, it will
-            be generated.
+        :return:
+            :class:`Actor` instance corresponding to the configured committer. It
+            behaves similar to the git implementation, such that the environment will
+            override configuration values of `config_reader`. If no value is set at all,
+            it will be generated.
 
         :param config_reader:
             ConfigReader to use to retrieve the values from in case they are not set in
@@ -887,8 +890,7 @@ class Actor:
 
 
 class Stats:
-    """
-    Represents stat information as presented by git at the end of a merge. It is
+    """Represents stat information as presented by git at the end of a merge. It is
     created from the output of a diff operation.
 
     Example::
@@ -949,9 +951,9 @@ class Stats:
 
 
 class IndexFileSHA1Writer:
-    """Wrapper around a file-like object that remembers the SHA1 of
-    the data written to it. It will write a sha when the stream is closed
-    or if asked for explicitly using :meth:`write_sha`.
+    """Wrapper around a file-like object that remembers the SHA1 of the data written to
+    it. It will write a sha when the stream is closed or if asked for explicitly using
+    :meth:`write_sha`.
 
     Only useful to the index file.
 

--- a/git/util.py
+++ b/git/util.py
@@ -762,9 +762,9 @@ class CallableRemoteProgress(RemoteProgress):
 
 
 class Actor:
-    """Actors hold information about a person acting on the repository. They
-    can be committers and authors or anything with a name and an email as mentioned in
-    the git log entries."""
+    """Actors hold information about a person acting on the repository. They can be
+    committers and authors or anything with a name and an email as mentioned in the git
+    log entries."""
 
     # PRECOMPILED REGEX
     name_only_regex = re.compile(r"<(.*)>")

--- a/git/util.py
+++ b/git/util.py
@@ -1257,7 +1257,7 @@ class IterableObj(Protocol):
         keyword arguments, subclasses are obliged to to yield all items.
 
         :return:
-            :class:`~collections.abc.Iterator` yielding Items
+            Iterator yielding Items
         """
         raise NotImplementedError("To be implemented by Subclass")
 

--- a/git/util.py
+++ b/git/util.py
@@ -500,7 +500,7 @@ def expand_path(p: None, expand_vars: bool = ...) -> None:
 
 @overload
 def expand_path(p: PathLike, expand_vars: bool = ...) -> str:
-    # improve these overloads when 3.5 dropped
+    # TODO: Support for Python 3.5 has been dropped, so these overloads can be improved.
     ...
 
 

--- a/git/util.py
+++ b/git/util.py
@@ -111,10 +111,11 @@ def _read_win_env_flag(name: str, default: bool) -> bool:
     """Read a boolean flag from an environment variable on Windows.
 
     :return:
-        On Windows, the flag, or the ``default`` value if absent or ambiguous.
-        On all other operating systems, ``False``.
+        On Windows, the flag, or the `default` value if absent or ambiguous.
+        On all other operating systems, False.
 
-    :note: This only accesses the environment on Windows.
+    :note:
+        This only accesses the environment on Windows.
     """
     if os.name != "nt":
         return False
@@ -151,8 +152,8 @@ T = TypeVar("T")
 
 
 def unbare_repo(func: Callable[..., T]) -> Callable[..., T]:
-    """Methods with this decorator raise :class:`.exc.InvalidGitRepositoryError` if they
-    encounter a bare repository."""
+    """Methods with this decorator raise
+    :class:`~git.exc.InvalidGitRepositoryError` if they encounter a bare repository."""
 
     from .exc import InvalidGitRepositoryError
 
@@ -206,7 +207,10 @@ def rmtree(path: PathLike) -> None:
     """
 
     def handler(function: Callable, path: PathLike, _excinfo: Any) -> None:
-        """Callback for :func:`shutil.rmtree`. Works either as ``onexc`` or ``onerror``."""
+        """Callback for :func:`shutil.rmtree`.
+
+        This works as either a ``onexc`` or ``onerror`` style callback.
+        """
         # Is the error an access error?
         os.chmod(path, stat.S_IWUSR)
 
@@ -228,7 +232,8 @@ def rmtree(path: PathLike) -> None:
 
 
 def rmfile(path: PathLike) -> None:
-    """Ensure file deleted also on *Windows* where read-only files need special treatment."""
+    """Ensure file deleted also on *Windows* where read-only files need special
+    treatment."""
     if osp.isfile(path):
         if os.name == "nt":
             os.chmod(path, 0o777)
@@ -239,7 +244,8 @@ def stream_copy(source: BinaryIO, destination: BinaryIO, chunk_size: int = 512 *
     """Copy all data from the source stream into the destination stream in chunks
     of size chunk_size.
 
-    :return: Number of bytes written
+    :return:
+        Number of bytes written
     """
     br = 0
     while True:
@@ -473,12 +479,13 @@ def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
 
 
 def get_user_id() -> str:
-    """:return: string identifying the currently active system user as name@node"""
+    """:return: String identifying the currently active system user as ``name@node``"""
     return "%s@%s" % (getpass.getuser(), platform.node())
 
 
 def finalize_process(proc: Union[subprocess.Popen, "Git.AutoInterrupt"], **kwargs: Any) -> None:
-    """Wait for the process (clone, fetch, pull or push) and handle its errors accordingly"""
+    """Wait for the process (clone, fetch, pull or push) and handle its errors
+    accordingly."""
     # TODO: No close proc-streams??
     proc.wait(**kwargs)
 
@@ -541,9 +548,9 @@ def remove_password_if_present(cmdline: Sequence[str]) -> List[str]:
 
 
 class RemoteProgress:
-    """
-    Handler providing an interface to parse progress information emitted by git-push
-    and git-fetch and to dispatch callbacks allowing subclasses to react to the progress.
+    """Handler providing an interface to parse progress information emitted by
+    ``git push`` and ``git fetch`` and to dispatch callbacks allowing subclasses to
+    react to the progress.
     """
 
     _num_op_codes: int = 9
@@ -580,8 +587,8 @@ class RemoteProgress:
         self.other_lines: List[str] = []
 
     def _parse_progress_line(self, line: AnyStr) -> None:
-        """Parse progress information from the given line as retrieved by git-push
-        or git-fetch.
+        """Parse progress information from the given line as retrieved by ``git push``
+        or ``git fetch``.
 
         - Lines that do not contain progress info are stored in :attr:`other_lines`.
         - Lines that seem to contain an error (i.e. start with ``error:`` or ``fatal:``)
@@ -685,8 +692,8 @@ class RemoteProgress:
     def new_message_handler(self) -> Callable[[str], None]:
         """
         :return:
-            A progress handler suitable for handle_process_output(), passing lines on to
-            this Progress handler in a suitable format
+            A progress handler suitable for :func:`~git.cmd.handle_process_output`,
+            passing lines on to this progress handler in a suitable format.
         """
 
         def handler(line: AnyStr) -> None:
@@ -712,25 +719,29 @@ class RemoteProgress:
         :param op_code:
             Integer allowing to be compared against Operation IDs and stage IDs.
 
-            Stage IDs are BEGIN and END. BEGIN will only be set once for each Operation
-            ID as well as END. It may be that BEGIN and END are set at once in case only
-            one progress message was emitted due to the speed of the operation.
-            Between BEGIN and END, none of these flags will be set.
+            Stage IDs are :attr:`BEGIN` and :attr:`END`. :attr:`BEGIN` will only be set
+            once for each Operation ID as well as :attr:`END`. It may be that
+            :attr:`BEGIN` and :attr:`END` are set at once in case only one progress
+            message was emitted due to the speed of the operation. Between :attr:`BEGIN`
+            and :attr:`END`, none of these flags will be set.
 
-            Operation IDs are all held within the OP_MASK. Only one Operation ID will
-            be active per call.
+            Operation IDs are all held within the :attr:`OP_MASK`. Only one Operation ID
+            will be active per call.
 
-        :param cur_count: Current absolute count of items.
+        :param cur_count:
+            Current absolute count of items.
 
         :param max_count:
-            The maximum count of items we expect. It may be None in case there is
-            no maximum number of items or if it is (yet) unknown.
+            The maximum count of items we expect. It may be None in case there is no
+            maximum number of items or if it is (yet) unknown.
 
         :param message:
-            In case of the 'WRITING' operation, it contains the amount of bytes
+            In case of the :attr:`WRITING` operation, it contains the amount of bytes
             transferred. It may possibly be used for other purposes as well.
 
-        You may read the contents of the current line in ``self._cur_line``.
+        :note:
+            You may read the contents of the current line in
+            :attr:`self._cur_line <_cur_line>`.
         """
         pass
 
@@ -793,11 +804,13 @@ class Actor:
     def _from_string(cls, string: str) -> "Actor":
         """Create an Actor from a string.
 
-        :param string: The string, which is expected to be in regular git format::
+        :param string:
+            The string, which is expected to be in regular git format::
 
-            John Doe <jdoe@example.com>
+                John Doe <jdoe@example.com>
 
-        :return: Actor
+        :return:
+            :class:`Actor`
         """
         m = cls.name_email_regex.search(string)
         if m:
@@ -857,18 +870,19 @@ class Actor:
         """
         :return: Actor instance corresponding to the configured committer. It behaves
             similar to the git implementation, such that the environment will override
-            configuration values of config_reader. If no value is set at all, it will be
-            generated.
+            configuration values of `config_reader`. If no value is set at all, it will
+            be generated.
 
-        :param config_reader: ConfigReader to use to retrieve the values from in case
-            they are not set in the environment.
+        :param config_reader:
+            ConfigReader to use to retrieve the values from in case they are not set in
+            the environment.
         """
         return cls._main_actor(cls.env_committer_name, cls.env_committer_email, config_reader)
 
     @classmethod
     def author(cls, config_reader: Union[None, "GitConfigParser", "SectionConstraint"] = None) -> "Actor":
-        """Same as committer(), but defines the main author. It may be specified in the
-        environment, but defaults to the committer."""
+        """Same as :meth:`committer`, but defines the main author. It may be specified
+        in the environment, but defaults to the committer."""
         return cls._main_actor(cls.env_author_name, cls.env_author_email, config_reader)
 
 
@@ -877,7 +891,7 @@ class Stats:
     Represents stat information as presented by git at the end of a merge. It is
     created from the output of a diff operation.
 
-    ``Example``::
+    Example::
 
      c = Commit( sha1 )
      s = c.stats
@@ -907,9 +921,10 @@ class Stats:
 
     @classmethod
     def _list_from_string(cls, repo: "Repo", text: str) -> "Stats":
-        """Create a Stat object from output retrieved by git-diff.
+        """Create a :class:`Stats` object from output retrieved by ``git diff``.
 
-        :return: git.Stat
+        :return:
+            :class:`git.Stats`
         """
 
         hsh: HSH_TD = {
@@ -936,11 +951,12 @@ class Stats:
 class IndexFileSHA1Writer:
     """Wrapper around a file-like object that remembers the SHA1 of
     the data written to it. It will write a sha when the stream is closed
-    or if the asked for explicitly using write_sha.
+    or if asked for explicitly using :meth:`write_sha`.
 
     Only useful to the index file.
 
-    :note: Based on the dulwich project.
+    :note:
+        Based on the dulwich project.
     """
 
     __slots__ = ("f", "sha1")
@@ -991,16 +1007,20 @@ class LockFile:
 
     def _has_lock(self) -> bool:
         """
-        :return: True if we have a lock and if the lockfile still exists
+        :return:
+            True if we have a lock and if the lockfile still exists
 
-        :raise AssertionError: If our lock-file does not exist
+        :raise AssertionError:
+            If our lock-file does not exist.
         """
         return self._owns_lock
 
     def _obtain_lock_or_raise(self) -> None:
-        """Create a lock file as flag for other instances, mark our instance as lock-holder.
+        """Create a lock file as flag for other instances, mark our instance as
+        lock-holder.
 
-        :raise IOError: If a lock was already present or a lock file could not be written
+        :raise IOError:
+            If a lock was already present or a lock file could not be written.
         """
         if self._has_lock():
             return
@@ -1021,7 +1041,9 @@ class LockFile:
 
     def _obtain_lock(self) -> None:
         """The default implementation will raise if a lock cannot be obtained.
-        Subclasses may override this method to provide a different implementation."""
+
+        Subclasses may override this method to provide a different implementation.
+        """
         return self._obtain_lock_or_raise()
 
     def _release_lock(self) -> None:
@@ -1029,8 +1051,8 @@ class LockFile:
         if not self._has_lock():
             return
 
-        # If someone removed our file beforehand, lets just flag this issue
-        # instead of failing, to make it more usable.
+        # If someone removed our file beforehand, lets just flag this issue instead of
+        # failing, to make it more usable.
         lfp = self._lock_file_path()
         try:
             rmfile(lfp)
@@ -1040,12 +1062,12 @@ class LockFile:
 
 
 class BlockingLockFile(LockFile):
-    """The lock file will block until a lock could be obtained, or fail after
-    a specified timeout.
+    """The lock file will block until a lock could be obtained, or fail after a
+    specified timeout.
 
-    :note: If the directory containing the lock was removed, an exception will
-        be raised during the blocking period, preventing hangs as the lock
-        can never be obtained.
+    :note:
+        If the directory containing the lock was removed, an exception will be raised
+        during the blocking period, preventing hangs as the lock can never be obtained.
     """
 
     __slots__ = ("_check_interval", "_max_block_time")
@@ -1062,14 +1084,15 @@ class BlockingLockFile(LockFile):
             Period of time to sleep until the lock is checked the next time.
             By default, it waits a nearly unlimited time.
 
-        :param max_block_time_s: Maximum amount of seconds we may lock.
+        :param max_block_time_s:
+            Maximum amount of seconds we may lock.
         """
         super().__init__(file_path)
         self._check_interval = check_interval_s
         self._max_block_time = max_block_time_s
 
     def _obtain_lock(self) -> None:
-        """This method blocks until it obtained the lock, or raises IOError if
+        """This method blocks until it obtained the lock, or raises :class:`IOError` if
         it ran out of time or if the parent directory was not available anymore.
 
         If this method returns, you are guaranteed to own the lock.
@@ -1105,23 +1128,32 @@ class BlockingLockFile(LockFile):
 
 
 class IterableList(List[T_IterableObj]):
-    """
-    List of iterable objects allowing to query an object by id or by named index::
+    """List of iterable objects allowing to query an object by id or by named index::
 
      heads = repo.heads
      heads.master
      heads['master']
      heads[0]
 
-    Iterable parent objects = [Commit, SubModule, Reference, FetchInfo, PushInfo]
-    Iterable via inheritance = [Head, TagReference, RemoteReference]
+    Iterable parent objects:
 
-    It requires an id_attribute name to be set which will be queried from its
+    * :class:`Commit <git.objects.Commit>`
+    * :class:`Submodule <git.objects.submodule.base.Submodule>`
+    * :class:`Reference <git.refs.reference.Reference>`
+    * :class:`FetchInfo <git.remote.FetchInfo>`
+    * :class:`PushInfo <git.remote.PushInfo>`
+
+    Iterable via inheritance:
+
+    * :class:`Head <git.refs.head.Head>`
+    * :class:`TagReference <git.refs.tag.TagReference>`
+    * :class:`RemoteReference <git.refs.remote.RemoteReference>`
+
+    This requires an ``id_attribute`` name to be set which will be queried from its
     contained items to have a means for comparison.
 
-    A prefix can be specified which is to be used in case the id returned by the
-    items always contains a prefix that does not matter to the user, so it
-    can be left out.
+    A prefix can be specified which is to be used in case the id returned by the items
+    always contains a prefix that does not matter to the user, so it can be left out.
     """
 
     __slots__ = ("_id_attr", "_prefix")
@@ -1198,7 +1230,14 @@ class IterableObj(Protocol):
     """Defines an interface for iterable items, so there is a uniform way to retrieve
     and iterate items within the git repository.
 
-    Subclasses = [Submodule, Commit, Reference, PushInfo, FetchInfo, Remote]
+    Subclasses:
+
+    * :class:`Submodule <git.objects.submodule.base.Submodule>`
+    * :class:`Commit <git.objects.Commit>`
+    * :class:`Reference <git.refs.reference.Reference>`
+    * :class:`PushInfo <git.remote.PushInfo>`
+    * :class:`FetchInfo <git.remote.FetchInfo>`
+    * :class:`Remote <git.remote.Remote>`
     """
 
     __slots__ = ()
@@ -1211,11 +1250,12 @@ class IterableObj(Protocol):
         # Return-typed to be compatible with subtypes e.g. Remote.
         """Find (all) items of this type.
 
-        Subclasses can specify ``args`` and ``kwargs`` differently, and may use them for
+        Subclasses can specify `args` and `kwargs` differently, and may use them for
         filtering. However, when the method is called with no additional positional or
         keyword arguments, subclasses are obliged to to yield all items.
 
-        :return: Iterator yielding Items
+        :return:
+            :class:`~collections.abc.Iterator` yielding Items
         """
         raise NotImplementedError("To be implemented by Subclass")
 
@@ -1225,11 +1265,13 @@ class IterableObj(Protocol):
 
         For more information about the arguments, see :meth:`iter_items`.
 
-        :note: Favor the :meth:`iter_items` method as it will avoid eagerly collecting
-            all items. When there are many items, that can slow performance and increase
+        :note:
+            Favor the :meth:`iter_items` method as it will avoid eagerly collecting all
+            items. When there are many items, that can slow performance and increase
             memory usage.
 
-        :return: list(Item,...) list of item instances
+        :return:
+            list(Item,...) list of item instances
         """
         out_list: IterableList = IterableList(cls._id_attribute_)
         out_list.extend(cls.iter_items(repo, *args, **kwargs))
@@ -1272,7 +1314,8 @@ class Iterable(metaclass=IterableClassWatcher):
 
         See :meth:`IterableObj.iter_items` for details on usage.
 
-        :return: Iterator yielding Items
+        :return:
+            Iterator yielding Items
         """
         raise NotImplementedError("To be implemented by Subclass")
 
@@ -1284,7 +1327,8 @@ class Iterable(metaclass=IterableClassWatcher):
 
         See :meth:`IterableObj.list_items` for details on usage.
 
-        :return: list(Item,...) list of item instances
+        :return:
+            list(Item,...) list of item instances
         """
         out_list: Any = IterableList(cls._id_attribute_)
         out_list.extend(cls.iter_items(repo, *args, **kwargs))

--- a/git/util.py
+++ b/git/util.py
@@ -112,7 +112,7 @@ def _read_win_env_flag(name: str, default: bool) -> bool:
 
     :return:
         On Windows, the flag, or the `default` value if absent or ambiguous.
-        On all other operating systems, False.
+        On all other operating systems, ``False``.
 
     :note:
         This only accesses the environment on Windows.
@@ -309,11 +309,11 @@ def assure_directory_exists(path: PathLike, is_file: bool = False) -> bool:
     """Make sure that the directory pointed to by path exists.
 
     :param is_file:
-        If True, `path` is assumed to be a file and handled correctly.
+        If ``True``, `path` is assumed to be a file and handled correctly.
         Otherwise it must be a directory.
 
     :return:
-        True if the directory was created, False if it already existed.
+        ``True`` if the directory was created, ``False`` if it already existed.
     """
     if is_file:
         path = osp.dirname(path)
@@ -734,7 +734,7 @@ class RemoteProgress:
             Current absolute count of items.
 
         :param max_count:
-            The maximum count of items we expect. It may be None in case there is no
+            The maximum count of items we expect. It may be ``None`` in case there is no
             maximum number of items or if it is (yet) unknown.
 
         :param message:

--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -346,17 +346,20 @@ class TestBase(TestCase):
     """Base class providing default functionality to all tests such as:
 
     - Utility functions provided by the TestCase base of the unittest method such as::
+
         self.fail("todo")
         self.assertRaises(...)
 
     - Class level repository which is considered read-only as it is shared among
       all test cases in your type.
+
       Access it using::
-      self.rorepo  # 'ro' stands for read-only
+
+        self.rorepo  # 'ro' stands for read-only
 
       The rorepo is in fact your current project's git repo. If you refer to specific
-      shas for your objects, be sure you choose some that are part of the immutable portion
-      of the project history (so that tests don't fail for others).
+      shas for your objects, be sure you choose some that are part of the immutable
+      portion of the project history (so that tests don't fail for others).
     """
 
     def _small_repo_url(self):
@@ -383,8 +386,8 @@ class TestBase(TestCase):
 
     def _make_file(self, rela_path, data, repo=None):
         """
-        Create a file at the given path relative to our repository, filled
-        with the given data.
+        Create a file at the given path relative to our repository, filled with the
+        given data.
 
         :return: An absolute path to the created file.
         """

--- a/test/performance/test_streams.py
+++ b/test/performance/test_streams.py
@@ -25,8 +25,8 @@ class TestObjDBPerformance(TestBigRepoR):
 
     @with_rw_repo("HEAD", bare=True)
     def test_large_data_streaming(self, rwrepo):
-        # TODO: This part overlaps with the same file in gitdb.test.performance.test_stream.
-        # It should be shared if possible.
+        # TODO: This part overlaps with the same file in
+        # gitdb.test.performance.test_stream. It should be shared if possible.
         ldb = LooseObjectDB(osp.join(rwrepo.git_dir, "objects"))
 
         for randomize in range(2):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -135,8 +135,8 @@ class TestBase(_TestBase):
             # https://github.com/gitpython-developers/GitPython/issues/147#issuecomment-68881897
             # Therefore, it must be added using the Python implementation.
             rw_repo.index.add([file_path])
-            # However, when the test winds down, rmtree fails to delete this file, which is recognized
-            # as ??? only.
+            # However, when the test winds down, rmtree fails to delete this file, which
+            # is recognized as ??? only.
         else:
             # On POSIX, we can just add Unicode files without problems.
             rw_repo.git.add(rw_repo.working_dir)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -72,7 +72,10 @@ class TestBase(_TestBase):
                 self.assertEqual(item, item.stream_data(tmpfile))
                 tmpfile.seek(0)
                 self.assertEqual(tmpfile.read(), data)
-            os.remove(tmpfile.name)  # Do it this way so we can inspect the file on failure.
+
+            # Remove the file this way, instead of with a context manager or "finally",
+            # so it is only removed on success, and we can inspect the file on failure.
+            os.remove(tmpfile.name)
         # END for each object type to create
 
         # Each has a unique sha.

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -19,8 +19,8 @@ class TestClone(TestBase):
         garbage_file = non_empty_dir / "not-empty"
         garbage_file.write_text("Garbage!")
 
-        # Verify that cloning into the non-empty dir fails while complaining about
-        # the target directory not being empty/non-existent.
+        # Verify that cloning into the non-empty dir fails while complaining about the
+        # target directory not being empty/non-existent.
         try:
             self.rorepo.clone(non_empty_dir)
         except git.GitCommandError as exc:

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -27,8 +27,8 @@ import os.path as osp
 
 class TestCommitSerialization(TestBase):
     def assert_commit_serialization(self, rwrepo, commit_id, print_performance_info=False):
-        """Traverse all commits in the history of commit identified by commit_id and check
-        if the serialization works.
+        """Traverse all commits in the history of commit identified by commit_id and
+        check if the serialization works.
 
         :param print_performance_info: If True, we will show how fast we are.
         """
@@ -317,8 +317,9 @@ class TestCommit(TestCommitSerialization):
         self.assertEqual(self.rorepo.tag("refs/tags/0.1.5").commit.count(), 143)
 
     def test_list(self):
-        # This doesn't work anymore, as we will either attempt getattr with bytes, or compare 20 byte string
-        # with actual 20 byte bytes. This usage makes no sense anyway.
+        # This doesn't work anymore, as we will either attempt getattr with bytes, or
+        # compare 20 byte string with actual 20 byte bytes. This usage makes no sense
+        # anyway.
         assert isinstance(
             Commit.list_items(self.rorepo, "0.1.5", max_count=5)["5117c9c8a4d3af19a9958677e45cda9269de1541"],
             Commit,
@@ -383,8 +384,8 @@ class TestCommit(TestCommitSerialization):
 
         self.assertEqual(cmt.author.name, ncmt.author.name)
         self.assertEqual(cmt.message, ncmt.message)
-        # Actually, it can't be printed in a shell as repr wants to have ascii only
-        # it appears.
+        # Actually, it can't be printed in a shell as repr wants to have ascii only it
+        # appears.
         cmt.author.__repr__()
 
     def test_invalid_commit(self):
@@ -498,7 +499,8 @@ JzJMZDRLQLFvnzqZuCjE
         KEY_2 = "Key"
         VALUE_2 = "Value with inner spaces"
 
-        # Check that the following trailer example is extracted from multiple msg variations.
+        # Check that the following trailer example is extracted from multiple msg
+        # variations.
         TRAILER = f"{KEY_1}: {VALUE_1_1}\n{KEY_2}: {VALUE_2}\n{KEY_1}: {VALUE_1_2}"
         msgs = [
             f"Subject\n\n{TRAILER}\n",

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,7 +41,7 @@ class TestBase(TestCase):
         return sio
 
     def test_read_write(self):
-        # writer must create the exact same file as the one read before
+        # The writer must create the exact same file as the one read before.
         for filename in ("git_config", "git_config_global"):
             file_obj = self._to_memcache(fixture_path(filename))
             with GitConfigParser(file_obj, read_only=False) as w_config:
@@ -56,7 +56,8 @@ class TestBase(TestCase):
                     self._to_memcache(fixture_path(filename)).getvalue(),
                 )
 
-                # Creating an additional config writer must fail due to exclusive access.
+                # Creating an additional config writer must fail due to exclusive
+                # access.
                 with self.assertRaises(IOError):
                     GitConfigParser(file_obj, read_only=False)
 
@@ -91,8 +92,8 @@ class TestBase(TestCase):
             r_config.read()  # Enforce reading.
             # Simple inclusions, again checking them taking precedence.
             assert r_config.get_value("sec", "var0") == "value0_included"
-            # This one should take the git_config_global value since included
-            # values must be considered as soon as they get them.
+            # This one should take the git_config_global value since included values
+            # must be considered as soon as they get them.
             assert r_config.get_value("diff", "tool") == "meld"
             try:
                 # FIXME: Split this assertion out somehow and mark it xfail (or fix it).
@@ -109,7 +110,8 @@ class TestBase(TestCase):
         # Entering again locks the file again...
         with gcp as cw:
             cw.set_value("include", "some_other_value", "b")
-            # ...so creating an additional config writer must fail due to exclusive access.
+            # ...so creating an additional config writer must fail due to exclusive
+            # access.
             with self.assertRaises(IOError):
                 GitConfigParser(fpl, read_only=False)
         # but work when the lock is removed

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -271,18 +271,18 @@ class TestDiff(TestBase):
         self.assertEqual(res[10].b_rawpath, b"path/\x80-invalid-unicode-path.txt")
 
         # The "Moves"
-        # NOTE: The path prefixes a/ and b/ here are legit!  We're actually
-        # verifying that it's not "a/a/" that shows up, see the fixture data.
-        self.assertEqual(res[11].a_path, "a/with spaces")  # NOTE: path a/ here legit!
-        self.assertEqual(res[11].b_path, "b/with some spaces")  # NOTE: path b/ here legit!
+        # NOTE: The path prefixes "a/" and "b/" here are legit! We're actually verifying
+        # that it's not "a/a/" that shows up; see the fixture data.
+        self.assertEqual(res[11].a_path, "a/with spaces")  # NOTE: path "a/"" legit!
+        self.assertEqual(res[11].b_path, "b/with some spaces")  # NOTE: path "b/"" legit!
         self.assertEqual(res[12].a_path, "a/ending in a space ")
         self.assertEqual(res[12].b_path, "b/ending with space ")
         self.assertEqual(res[13].a_path, 'a/"with-quotes"')
         self.assertEqual(res[13].b_path, 'b/"with even more quotes"')
 
     def test_diff_patch_format(self):
-        # Test all of the 'old' format diffs for completeness - it should at least
-        # be able to deal with it.
+        # Test all of the 'old' format diffs for completeness - it should at least be
+        # able to deal with it.
         fixtures = (
             "diff_2",
             "diff_2f",
@@ -345,8 +345,9 @@ class TestDiff(TestBase):
         repo.create_tag("2")
 
         diff = repo.commit("1").diff(repo.commit("2"))[0]
-        # If diff is unable to find the commit hashes (looks in wrong repo) the *_blob.size
-        # property will be a string containing exception text, an int indicates success.
+        # If diff is unable to find the commit hashes (looks in wrong repo) the
+        # *_blob.size property will be a string containing exception text, an int
+        # indicates success.
         self.assertIsInstance(diff.a_blob.size, int)
         self.assertIsInstance(diff.b_blob.size, int)
 
@@ -392,9 +393,9 @@ class TestDiff(TestBase):
             # END for each other side
         # END for each commit
 
-        # Assert that we could always find at least one instance of the members we
-        # can iterate in the diff index - if not this indicates its not working correctly
-        # or our test does not span the whole range of possibilities.
+        # Assert that we could always find at least one instance of the members we can
+        # iterate in the diff index - if not this indicates its not working correctly or
+        # our test does not span the whole range of possibilities.
         for key, value in assertion_map.items():
             self.assertIsNotNone(value, "Did not find diff for %s" % key)
         # END for each iteration type

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -19,8 +19,9 @@ class Tutorials(TestBase):
     def tearDown(self):
         gc.collect()
 
-    # ACTUALLY skipped by git.util.rmtree (in local onerror function), from the last call to it via
-    # git.objects.submodule.base.Submodule.remove (at "handle separate bare repository"), line 1062.
+    # ACTUALLY skipped by git.util.rmtree (in local onerror function), from the last
+    # call to it via git.objects.submodule.base.Submodule.remove
+    # (at "handle separate bare repository"), line 1062.
     #
     # @skipIf(HIDE_WINDOWS_KNOWN_ERRORS,
     #         "FIXME: helper.wrapper fails with: PermissionError: [WinError 5] Access is denied: "
@@ -31,8 +32,8 @@ class Tutorials(TestBase):
         from git import Repo
 
         # rorepo is a Repo instance pointing to the git-python repository.
-        # For all you know, the first argument to Repo is a path to the repository
-        # you want to work with.
+        # For all you know, the first argument to Repo is a path to the repository you
+        # want to work with.
         repo = Repo(self.rorepo.working_tree_dir)
         assert not repo.bare
         # ![1-test_init_repo_object]
@@ -149,8 +150,8 @@ class Tutorials(TestBase):
         assert origin.exists()
         for fetch_info in origin.fetch(progress=MyProgressPrinter()):
             print("Updated %s to %s" % (fetch_info.ref, fetch_info.commit))
-        # Create a local branch at the latest fetched master. We specify the name statically, but you have all
-        # information to do it programmatically as well.
+        # Create a local branch at the latest fetched master. We specify the name
+        # statically, but you have all information to do it programmatically as well.
         bare_master = bare_repo.create_head("master", origin.refs.master)
         bare_repo.head.set_reference(bare_master)
         assert not bare_repo.delete_remote(origin).exists()
@@ -188,9 +189,9 @@ class Tutorials(TestBase):
         # submodules
 
         # [14-test_init_repo_object]
-        # Create a new submodule and check it out on the spot, setup to track master branch of `bare_repo`.
-        # As our GitPython repository has submodules already that point to GitHub, make sure we don't
-        # interact with them.
+        # Create a new submodule and check it out on the spot, setup to track master
+        # branch of `bare_repo`. As our GitPython repository has submodules already that
+        # point to GitHub, make sure we don't interact with them.
         for sm in cloned_repo.submodules:
             assert not sm.remove().exists()  # after removal, the sm doesn't exist anymore
         sm = cloned_repo.create_submodule("mysubrepo", "path/to/subrepo", url=bare_repo.git_dir, branch="master")
@@ -424,8 +425,8 @@ class Tutorials(TestBase):
         with origin.config_writer as cw:
             cw.set("pushurl", "other_url")
 
-        # Please note that in Python 2, writing origin.config_writer.set(...) is totally safe.
-        # In py3 __del__ calls can be delayed, thus not writing changes in time.
+        # Please note that in Python 2, writing origin.config_writer.set(...) is totally
+        # safe. In py3 __del__ calls can be delayed, thus not writing changes in time.
         # ![26-test_references_and_objects]
 
         # [27-test_references_and_objects]
@@ -462,7 +463,8 @@ class Tutorials(TestBase):
         # ![29-test_references_and_objects]
 
         # [30-test_references_and_objects]
-        # Check out the branch using git-checkout. It will fail as the working tree appears dirty.
+        # Check out the branch using git-checkout.
+        # It will fail as the working tree appears dirty.
         self.assertRaises(git.GitCommandError, repo.heads.master.checkout)
         repo.heads.past_branch.checkout()
         # ![30-test_references_and_objects]

--- a/test/test_fun.py
+++ b/test/test_fun.py
@@ -35,7 +35,8 @@ class TestFun(TestBase):
         # END assert entry matches fully
 
     def test_aggressive_tree_merge(self):
-        # Head tree with additions, removals and modification compared to its predecessor.
+        # Head tree with additions, removals and modification compared to its
+        # predecessor.
         odb = self.rorepo.odb
         HC = self.rorepo.commit("6c1faef799095f3990e9970bc2cb10aa0221cf9c")
         H = HC.tree

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -253,21 +253,27 @@ class TestGit(TestBase):
         if old_name == old_name.upper():
             raise RuntimeError("test bug or strange locale: old_name invariant under upcasing")
 
-        # Step 1: Set the environment variable in this parent process. Because os.putenv is a thin
-        #         wrapper around a system API, os.environ never sees the variable in this parent
-        #         process, so the name is not upcased even on Windows.
+        # Step 1
+        #
+        # Set the environment variable in this parent process. Because os.putenv is a
+        # thin wrapper around a system API, os.environ never sees the variable in this
+        # parent process, so the name is not upcased even on Windows.
         os.putenv(old_name, "1")
 
-        # Step 2: Create the child process that inherits the environment variable. The child uses
-        #         GitPython, and we are testing that it passes the variable with the exact original
-        #         name to its own child process (the grandchild).
+        # Step 2
+        #
+        # Create the child process that inherits the environment variable. The child
+        # uses GitPython, and we are testing that it passes the variable with the exact
+        # original name to its own child process (the grandchild).
         cmdline = [
             sys.executable,
             fixture_path("env_case.py"),  # Contains steps 3 and 4.
             self.rorepo.working_dir,
             old_name,
         ]
-        pair_text = subprocess.check_output(cmdline, shell=False, text=True)  # Run steps 3 and 4.
+
+        # Run steps 3 and 4.
+        pair_text = subprocess.check_output(cmdline, shell=False, text=True)
 
         new_name = pair_text.split("=")[0]
         self.assertEqual(new_name, old_name)
@@ -668,7 +674,7 @@ class TestGit(TestBase):
                 # as unintended shell expansions can occur, and is deprecated. Instead,
                 # use a custom command, by setting the GIT_PYTHON_GIT_EXECUTABLE
                 # environment variable to git.cmd or by passing git.cmd's full path to
-                # git.refresh. Or wrap the script with a .exe shim.
+                # git.refresh. Or wrap the script with a .exe shim.)
                 stack.enter_context(mock.patch.object(Git, "USE_SHELL", True))
 
             new_git = Git()

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -219,8 +219,7 @@ class TestIndex(TestBase):
         self._fprogress_map[path] = curval + 1
 
     def _fprogress_add(self, path, done, item):
-        """Called as progress func - we keep track of the proper
-        call order"""
+        """Called as progress func - we keep track of the proper call order."""
         assert item is not None
         self._fprogress(path, done, item)
 
@@ -385,17 +384,17 @@ class TestIndex(TestBase):
 
         # FAKE MERGE
         #############
-        # Add a change with a NULL sha that should conflict with next_commit. We
-        # pretend there was a change, but we do not even bother adding a proper
-        # sha for it (which makes things faster of course).
+        # Add a change with a NULL sha that should conflict with next_commit. We pretend
+        # there was a change, but we do not even bother adding a proper sha for it
+        # (which makes things faster of course).
         manifest_fake_entry = BaseIndexEntry((manifest_entry[0], b"\0" * 20, 0, manifest_entry[3]))
         # Try write flag.
         self._assert_entries(rw_repo.index.add([manifest_fake_entry], write=False))
-        # Add actually resolves the null-hex-sha for us as a feature, but we can
-        # edit the index manually.
+        # Add actually resolves the null-hex-sha for us as a feature, but we can edit
+        # the index manually.
         assert rw_repo.index.entries[manifest_key].binsha != Object.NULL_BIN_SHA
-        # We must operate on the same index for this! It's a bit problematic as
-        # it might confuse people.
+        # We must operate on the same index for this! It's a bit problematic as it might
+        # confuse people.
         index = rw_repo.index
         index.entries[manifest_key] = IndexEntry.from_base(manifest_fake_entry)
         index.write()
@@ -404,19 +403,20 @@ class TestIndex(TestBase):
         # Write an unchanged index (just for the fun of it).
         rw_repo.index.write()
 
-        # A three way merge would result in a conflict and fails as the command will
-        # not overwrite any entries in our index and hence leave them unmerged. This is
+        # A three way merge would result in a conflict and fails as the command will not
+        # overwrite any entries in our index and hence leave them unmerged. This is
         # mainly a protection feature as the current index is not yet in a tree.
         self.assertRaises(GitCommandError, index.merge_tree, next_commit, base=parent_commit)
 
-        # The only way to get the merged entries is to safe the current index away into a tree,
-        # which is like a temporary commit for us. This fails as well as the NULL sha does not
-        # have a corresponding object.
+        # The only way to get the merged entries is to safe the current index away into
+        # a tree, which is like a temporary commit for us. This fails as well as the
+        # NULL sha does not have a corresponding object.
         # NOTE: missing_ok is not a kwarg anymore, missing_ok is always true.
         # self.assertRaises(GitCommandError, index.write_tree)
 
-        # If missing objects are okay, this would work though (they are always okay now).
-        # As we can't read back the tree with NULL_SHA, we rather set it to something else.
+        # If missing objects are okay, this would work though (they are always okay
+        # now). As we can't read back the tree with NULL_SHA, we rather set it to
+        # something else.
         index.entries[manifest_key] = IndexEntry(manifest_entry[:1] + (hex_to_bin("f" * 40),) + manifest_entry[2:])
         tree = index.write_tree()
 
@@ -428,7 +428,7 @@ class TestIndex(TestBase):
 
     @with_rw_repo("0.1.6")
     def test_index_file_diffing(self, rw_repo):
-        # Default Index instance points to our index.
+        # Default IndexFile instance points to our index.
         index = IndexFile(rw_repo)
         assert index.path is not None
         assert len(index.entries)
@@ -439,8 +439,8 @@ class TestIndex(TestBase):
         # Could sha it, or check stats.
 
         # Test diff.
-        # Resetting the head will leave the index in a different state, and the
-        # diff will yield a few changes.
+        # Resetting the head will leave the index in a different state, and the diff
+        # will yield a few changes.
         cur_head_commit = rw_repo.head.reference.commit
         rw_repo.head.reset("HEAD~6", index=True, working_tree=False)
 
@@ -956,10 +956,10 @@ class TestIndex(TestBase):
 
     @with_rw_repo("HEAD", bare=True)
     def test_index_bare_add(self, rw_bare_repo):
-        # Something is wrong after cloning to a bare repo, reading the
-        # property rw_bare_repo.working_tree_dir will return '/tmp'
-        # instead of throwing the Exception we are expecting. This is
-        # a quick hack to make this test fail when expected.
+        # Something is wrong after cloning to a bare repo, reading the property
+        # rw_bare_repo.working_tree_dir will return '/tmp' instead of throwing the
+        # Exception we are expecting. This is a quick hack to make this test fail when
+        # expected.
         assert rw_bare_repo.working_tree_dir is None
         assert rw_bare_repo.bare
         contents = b"This is a BytesIO file"
@@ -984,7 +984,8 @@ class TestIndex(TestBase):
 
     @with_rw_directory
     def test_add_utf8P_path(self, rw_dir):
-        # NOTE: fp is not a Unicode object in Python 2 (which is the source of the problem).
+        # NOTE: fp is not a Unicode object in Python 2
+        # (which is the source of the problem).
         fp = osp.join(rw_dir, "ø.txt")
         with open(fp, "wb") as fs:
             fs.write("content of ø".encode("utf-8"))

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -46,9 +46,9 @@ class TestInstallation(TestBase):
             msg=result.stderr or result.stdout or "Dependencies not installed",
         )
 
-        # Even IF gitdb or any other dependency is supplied during development
-        # by inserting its location into PYTHONPATH or otherwise patched into
-        # sys.path, make sure it is not wrongly inserted as the *first* entry.
+        # Even IF gitdb or any other dependency is supplied during development by
+        # inserting its location into PYTHONPATH or otherwise patched into sys.path,
+        # make sure it is not wrongly inserted as the *first* entry.
         result = subprocess.run(
             [venv.python, "-c", "import sys; import git; print(sys.path)"],
             stdout=subprocess.PIPE,

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -245,8 +245,8 @@ class TestRefs(TestBase):
         cur_head.reset(new_head_commit)
         rw_repo.index.checkout(["lib"], force=True)
 
-        # Now that we have a write write repo, change the HEAD reference - it's
-        # like "git-reset --soft".
+        # Now that we have a write write repo, change the HEAD reference - it's like
+        # "git-reset --soft".
         heads = rw_repo.heads
         assert heads
         for head in heads:
@@ -349,8 +349,8 @@ class TestRefs(TestBase):
         for remote in remotes:
             refs = remote.refs
 
-            # If a HEAD exists, it must be deleted first. Otherwise it might
-            # end up pointing to an invalid ref it the ref was deleted before.
+            # If a HEAD exists, it must be deleted first. Otherwise it might end up
+            # pointing to an invalid ref it the ref was deleted before.
             remote_head_name = "HEAD"
             if remote_head_name in refs:
                 RemoteReference.delete(rw_repo, refs[remote_head_name])
@@ -383,7 +383,7 @@ class TestRefs(TestBase):
         # Setting a non-commit as commit fails, but succeeds as object.
         head_tree = head.commit.tree
         self.assertRaises(ValueError, setattr, head, "commit", head_tree)
-        assert head.commit == old_commit  # and the ref did not change
+        assert head.commit == old_commit  # And the ref did not change.
         # We allow heads to point to any object.
         head.object = head_tree
         assert head.object == head_tree
@@ -492,8 +492,8 @@ class TestRefs(TestBase):
         # Would raise if the symref wouldn't have been deleted (probably).
         symref = SymbolicReference.create(rw_repo, symref_path, cur_head.reference)
 
-        # Test symbolic references which are not at default locations like HEAD
-        # or FETCH_HEAD - they may also be at spots in refs of course.
+        # Test symbolic references which are not at default locations like HEAD or
+        # FETCH_HEAD - they may also be at spots in refs of course.
         symbol_ref_path = "refs/symbol_ref"
         symref = SymbolicReference(rw_repo, symbol_ref_path)
         assert symref.path == symbol_ref_path
@@ -525,14 +525,13 @@ class TestRefs(TestBase):
         assert active_branch in heads
         assert rw_repo.tags
 
-        # We should be able to iterate all symbolic refs as well - in that case
-        # we should expect only symbolic references to be returned.
+        # We should be able to iterate all symbolic refs as well - in that case we
+        # should expect only symbolic references to be returned.
         for symref in SymbolicReference.iter_items(rw_repo):
             assert not symref.is_detached
 
-        # When iterating references, we can get references and symrefs
-        # when deleting all refs, I'd expect them to be gone! Even from
-        # the packed ones.
+        # When iterating references, we can get references and symrefs when deleting all
+        # refs, I'd expect them to be gone! Even from the packed ones.
         # For this to work, we must not be on any branch.
         rw_repo.head.reference = rw_repo.head.commit
         deleted_refs = set()
@@ -577,9 +576,9 @@ class TestRefs(TestBase):
             self.assertRaises(ValueError, setattr, ref, "commit", "nonsense")
             assert not ref.is_valid()
 
-            # I am sure I had my reason to make it a class method at first, but
-            # now it doesn't make so much sense anymore, want an instance method as well
-            # See http://byronimo.lighthouseapp.com/projects/51787-gitpython/tickets/27
+            # I am sure I had my reason to make it a class method at first, but now it
+            # doesn't make so much sense anymore, want an instance method as well. See:
+            # http://byronimo.lighthouseapp.com/projects/51787-gitpython/tickets/27
             Reference.delete(ref.repo, ref.path)
             assert not ref.is_valid()
 
@@ -619,8 +618,8 @@ class TestRefs(TestBase):
 
     def test_refs_outside_repo(self):
         # Create a file containing a valid reference outside the repository. Attempting
-        # to access it should raise an exception, due to it containing a parent directory
-        # reference ('..'). This tests for CVE-2023-41040.
+        # to access it should raise an exception, due to it containing a parent
+        # directory reference ('..'). This tests for CVE-2023-41040.
         git_dir = Path(self.rorepo.git_dir)
         repo_parent_dir = git_dir.parent.parent
         with tempfile.NamedTemporaryFile(dir=repo_parent_dir) as ref_file:
@@ -630,37 +629,52 @@ class TestRefs(TestBase):
             self.assertRaises(BadName, self.rorepo.commit, f"../../{ref_file_name}")
 
     def test_validity_ref_names(self):
+        """Ensure ref names are checked for validity.
+
+        This is based on the rules specified in:
+        https://git-scm.com/docs/git-check-ref-format/#_description
+        """
         check_ref = SymbolicReference._check_ref_name_valid
-        # Based on the rules specified in https://git-scm.com/docs/git-check-ref-format/#_description.
+
         # Rule 1
         self.assertRaises(ValueError, check_ref, ".ref/begins/with/dot")
         self.assertRaises(ValueError, check_ref, "ref/component/.begins/with/dot")
         self.assertRaises(ValueError, check_ref, "ref/ends/with/a.lock")
         self.assertRaises(ValueError, check_ref, "ref/component/ends.lock/with/period_lock")
+
         # Rule 2
         check_ref("valid_one_level_refname")
+
         # Rule 3
         self.assertRaises(ValueError, check_ref, "ref/contains/../double/period")
+
         # Rule 4
         for c in " ~^:":
             self.assertRaises(ValueError, check_ref, f"ref/contains/invalid{c}/character")
         for code in range(0, 32):
             self.assertRaises(ValueError, check_ref, f"ref/contains/invalid{chr(code)}/ASCII/control_character")
         self.assertRaises(ValueError, check_ref, f"ref/contains/invalid{chr(127)}/ASCII/control_character")
+
         # Rule 5
         for c in "*?[":
             self.assertRaises(ValueError, check_ref, f"ref/contains/invalid{c}/character")
+
         # Rule 6
         self.assertRaises(ValueError, check_ref, "/ref/begins/with/slash")
         self.assertRaises(ValueError, check_ref, "ref/ends/with/slash/")
         self.assertRaises(ValueError, check_ref, "ref/contains//double/slash/")
+
         # Rule 7
         self.assertRaises(ValueError, check_ref, "ref/ends/with/dot.")
+
         # Rule 8
         self.assertRaises(ValueError, check_ref, "ref/contains@{/at_brace")
+
         # Rule 9
         self.assertRaises(ValueError, check_ref, "@")
+
         # Rule 10
         self.assertRaises(ValueError, check_ref, "ref/contain\\s/backslash")
+
         # Valid reference name should not raise.
         check_ref("valid/ref/name")

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -294,11 +294,11 @@ class TestRemote(TestBase):
 
         # Provoke to receive actual objects to see what kind of output we have to
         # expect. For that we need a remote transport protocol.
-        # Create a new UN-shared repo and fetch into it after we pushed a change
-        # to the shared repo.
+        # Create a new UN-shared repo and fetch into it after we pushed a change to the
+        # shared repo.
         other_repo_dir = tempfile.mktemp("other_repo")
-        # Must clone with a local path for the repo implementation not to freak out
-        # as it wants local paths only (which I can understand).
+        # Must clone with a local path for the repo implementation not to freak out as
+        # it wants local paths only (which I can understand).
         other_repo = remote_repo.clone(other_repo_dir, shared=False)
         remote_repo_url = osp.basename(remote_repo.git_dir)  # git-daemon runs with appropriate `--base-path`.
         remote_repo_url = Git.polish_url("git://localhost:%s/%s" % (GIT_DAEMON_PORT, remote_repo_url))
@@ -317,10 +317,10 @@ class TestRemote(TestBase):
             self._commit_random_file(rw_repo)
             remote.push(rw_repo.head.reference)
 
-            # Here I would expect to see remote-information about packing
-            # objects and so on. Unfortunately, this does not happen
-            # if we are redirecting the output - git explicitly checks for this
-            # and only provides progress information to ttys.
+            # Here I would expect to see remote-information about packing objects and so
+            # on. Unfortunately, this does not happen if we are redirecting the output -
+            # git explicitly checks for this and only provides progress information to
+            # ttys.
             res = fetch_and_test(other_origin)
         finally:
             rmtree(other_repo_dir)
@@ -333,8 +333,8 @@ class TestRemote(TestBase):
         try:
             lhead.reference = rw_repo.heads.master
         except AttributeError:
-            # If the author is on a non-master branch, the clones might not have
-            # a local master yet. We simply create it.
+            # If the author is on a non-master branch, the clones might not have a local
+            # master yet. We simply create it.
             lhead.reference = rw_repo.create_head("master")
         # END master handling
         lhead.reset(remote.refs.master, working_tree=True)
@@ -488,8 +488,8 @@ class TestRemote(TestBase):
             self._assert_push_and_pull(remote, rw_repo, remote_repo)
 
             # FETCH TESTING
-            # Only for remotes - local cases are the same or less complicated
-            # as additional progress information will never be emitted.
+            # Only for remotes - local cases are the same or less complicated as
+            # additional progress information will never be emitted.
             if remote.name == "daemon_origin":
                 self._do_test_fetch(remote, rw_repo, remote_repo, kill_after_timeout=10.0)
                 ran_fetch_test = True
@@ -508,7 +508,8 @@ class TestRemote(TestBase):
         # Verify we can handle prunes when fetching.
         # stderr lines look like this:  x [deleted]         (none)     -> origin/experiment-2012
         # These should just be skipped.
-        # If we don't have a manual checkout, we can't actually assume there are any non-master branches.
+        # If we don't have a manual checkout, we can't actually assume there are any
+        # non-master branches.
         remote_repo.create_head("myone_for_deletion")
         # Get the branch - to be pruned later
         origin.fetch()
@@ -812,8 +813,8 @@ class TestRemote(TestBase):
                 "fd::17/foo",
             ]
             for url in urls:
-                # The URL will be allowed into the command, but the command will
-                # fail since we don't have that protocol enabled in the Git config file.
+                # The URL will be allowed into the command, but the command will fail
+                # since we don't have that protocol enabled in the Git config file.
                 with self.assertRaises(GitCommandError):
                     remote.fetch(url, allow_unsafe_protocols=True)
                 assert not tmp_file.exists()
@@ -880,8 +881,8 @@ class TestRemote(TestBase):
                 "fd::17/foo",
             ]
             for url in urls:
-                # The URL will be allowed into the command, but the command will
-                # fail since we don't have that protocol enabled in the Git config file.
+                # The URL will be allowed into the command, but the command will fail
+                # since we don't have that protocol enabled in the Git config file.
                 with self.assertRaises(GitCommandError):
                     remote.pull(url, allow_unsafe_protocols=True)
                 assert not tmp_file.exists()
@@ -948,8 +949,8 @@ class TestRemote(TestBase):
                 "fd::17/foo",
             ]
             for url in urls:
-                # The URL will be allowed into the command, but the command will
-                # fail since we don't have that protocol enabled in the Git config file.
+                # The URL will be allowed into the command, but the command will fail
+                # since we don't have that protocol enabled in the Git config file.
                 with self.assertRaises(GitCommandError):
                     remote.push(url, allow_unsafe_protocols=True)
                 assert not tmp_file.exists()

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -543,8 +543,8 @@ class TestRepo(TestBase):
                 try:
                     rmtree(clone_path)
                 except OSError:
-                    # When relative paths are used, the clone may actually be inside
-                    # of the parent directory.
+                    # When relative paths are used, the clone may actually be inside of
+                    # the parent directory.
                     pass
                 # END exception handling
 
@@ -556,8 +556,8 @@ class TestRepo(TestBase):
                 try:
                     rmtree(clone_path)
                 except OSError:
-                    # When relative paths are used, the clone may actually be inside
-                    # of the parent directory.
+                    # When relative paths are used, the clone may actually be inside of
+                    # the parent directory.
                     pass
                 # END exception handling
 
@@ -832,8 +832,8 @@ class TestRepo(TestBase):
             assert self.rorepo._get_config_path(config_level)
 
     def test_creation_deletion(self):
-        # Just a very quick test to assure it generally works. There are
-        # specialized cases in the test_refs module.
+        # Just a very quick test to assure it generally works. There are specialized
+        # cases in the test_refs module.
         head = self.rorepo.create_head("new_head", "HEAD~1")
         self.rorepo.delete_head(head)
 
@@ -1027,7 +1027,8 @@ class TestRepo(TestBase):
                     num_resolved += 1
                 except (BadName, BadObject):
                     print("failed on %s" % path_section)
-                    # This is fine if we have something like 112, which belongs to remotes/rname/merge-requests/112.
+                    # This is fine if we have something like 112, which belongs to
+                    # remotes/rname/merge-requests/112.
                 # END exception handling
             # END for each token
             if ref_no == 3 - 1:
@@ -1149,7 +1150,7 @@ class TestRepo(TestBase):
         )
         self.assertIsInstance(sm, Submodule)
 
-        # NOTE: the rest of this functionality is tested in test_submodule.
+        # NOTE: The rest of this functionality is tested in test_submodule.
 
     @with_rw_repo("HEAD")
     def test_git_file(self, rwrepo):
@@ -1178,8 +1179,9 @@ class TestRepo(TestBase):
         # This is based on this comment:
         # https://github.com/gitpython-developers/GitPython/issues/60#issuecomment-23558741
         # And we expect to set max handles to a low value, like 64.
-        # You should set ulimit -n X, see .travis.yml
-        # The loops below would easily create 500 handles if these would leak (4 pipes + multiple mapped files).
+        # You should set ulimit -n X. See .travis.yml.
+        # The loops below would easily create 500 handles if these would leak
+        # (4 pipes + multiple mapped files).
         for _ in range(64):
             for repo_type in (GitCmdObjectDB, GitDB):
                 repo = Repo(self.rorepo.working_tree_dir, odbt=repo_type)
@@ -1200,8 +1202,8 @@ class TestRepo(TestBase):
         self.assertEqual(r.active_branch.name, "master")
         assert not r.active_branch.is_valid(), "Branch is yet to be born"
 
-        # Actually, when trying to create a new branch without a commit, git itself fails.
-        # We should, however, not fail ungracefully.
+        # Actually, when trying to create a new branch without a commit, git itself
+        # fails. We should, however, not fail ungracefully.
         self.assertRaises(BadName, r.create_head, "foo")
         self.assertRaises(BadName, r.create_head, "master")
         # It's expected to not be able to access a tree
@@ -1315,13 +1317,13 @@ class TestRepo(TestBase):
         repo = Repo(worktree_path)
         self.assertIsInstance(repo, Repo)
 
-        # This ensures we're able to actually read the refs in the tree, which
-        # means we can read commondir correctly.
+        # This ensures we're able to actually read the refs in the tree, which means we
+        # can read commondir correctly.
         commit = repo.head.commit
         self.assertIsInstance(commit, Object)
 
-        # This ensures we can read the remotes, which confirms we're reading
-        # the config correctly.
+        # This ensures we can read the remotes, which confirms we're reading the config
+        # correctly.
         origin = repo.remotes.origin
         self.assertIsInstance(origin, Remote)
 

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -94,13 +94,15 @@ class TestSubmodule(TestBase):
         # The module is not checked-out yet.
         self.assertRaises(InvalidGitRepositoryError, sm.module)
 
-        # ...which is why we can't get the branch either - it points into the module() repository.
+        # ...which is why we can't get the branch either - it points into the module()
+        # repository.
         self.assertRaises(InvalidGitRepositoryError, getattr, sm, "branch")
 
         # branch_path works, as it's just a string.
         assert isinstance(sm.branch_path, str)
 
-        # Some commits earlier we still have a submodule, but it's at a different commit.
+        # Some commits earlier we still have a submodule, but it's at a different
+        # commit.
         smold = next(Submodule.iter_items(rwrepo, self.k_subm_changed))
         assert smold.binsha != sm.binsha
         assert smold != sm  # the name changed
@@ -141,11 +143,12 @@ class TestSubmodule(TestBase):
         smold.set_parent_commit(self.k_subm_changed + "~1")
         assert smold.binsha != sm.binsha
 
-        # Raises if the sm didn't exist in new parent - it keeps its
-        # parent_commit unchanged.
+        # Raises if the sm didn't exist in new parent - it keeps its parent_commit
+        # unchanged.
         self.assertRaises(ValueError, smold.set_parent_commit, self.k_no_subm_tag)
 
-        # TEST TODO: If a path is in the .gitmodules file, but not in the index, it raises.
+        # TODO: Test that, if a path is in the .gitmodules file, but not in the index,
+        # then it raises.
 
         # TEST UPDATE
         ##############
@@ -196,8 +199,8 @@ class TestSubmodule(TestBase):
 
             # INTERLEAVE ADD TEST
             #####################
-            # url must match the one in the existing repository (if submodule name suggests a new one)
-            # or we raise.
+            # url must match the one in the existing repository (if submodule name
+            # suggests a new one) or we raise.
             self.assertRaises(
                 ValueError,
                 Submodule.add,
@@ -228,7 +231,8 @@ class TestSubmodule(TestBase):
             assert not csm.module_exists()
             csm_repopath = csm.path
 
-            # Adjust the path of the submodules module to point to the local destination.
+            # Adjust the path of the submodules module to point to the local
+            # destination.
             new_csmclone_path = Git.polish_url(osp.join(self.rorepo.working_tree_dir, sm.path, csm.path))
             with csm.config_writer() as writer:
                 writer.set_value("url", new_csmclone_path)
@@ -249,7 +253,8 @@ class TestSubmodule(TestBase):
             # This flushed in a sub-submodule.
             assert len(list(rwrepo.iter_submodules())) == 2
 
-            # Reset both heads to the previous version, verify that to_latest_revision works.
+            # Reset both heads to the previous version, verify that to_latest_revision
+            # works.
             smods = (sm.module(), csm.module())
             for repo in smods:
                 repo.head.reset("HEAD~2", working_tree=1)
@@ -296,8 +301,8 @@ class TestSubmodule(TestBase):
             # Must delete something.
             self.assertRaises(ValueError, csm.remove, module=False, configuration=False)
 
-            # module() is supposed to point to gitdb, which has a child-submodule whose URL is still pointing
-            # to GitHub. To save time, we will change it to:
+            # module() is supposed to point to gitdb, which has a child-submodule whose
+            # URL is still pointing to GitHub. To save time, we will change it to:
             csm.set_parent_commit(csm.repo.head.commit)
             with csm.config_writer() as cw:
                 cw.set_value("url", self._small_repo_url())
@@ -399,8 +404,8 @@ class TestSubmodule(TestBase):
             rwrepo.index.commit("my submod commit")
             assert len(rwrepo.submodules) == 2
 
-            # Needs update, as the head changed. It thinks it's in the history
-            # of the repo otherwise.
+            # Needs update, as the head changed.
+            # It thinks it's in the history of the repo otherwise.
             nsm.set_parent_commit(rwrepo.head.commit)
             osm.set_parent_commit(rwrepo.head.commit)
 
@@ -434,7 +439,8 @@ class TestSubmodule(TestBase):
 
             # REMOVE 'EM ALL
             ################
-            # If a submodule's repo has no remotes, it can't be added without an explicit url.
+            # If a submodule's repo has no remotes, it can't be added without an
+            # explicit url.
             osmod = osm.module()
 
             osm.remove(module=False)
@@ -510,7 +516,8 @@ class TestSubmodule(TestBase):
 
         # TEST UPDATE
         #############
-        # Set up a commit that removes existing, adds new and modifies existing submodules.
+        # Set up a commit that removes existing, adds new and modifies existing
+        # submodules.
         rm = RootModule(rwrepo)
         assert len(rm.children()) == 1
 
@@ -534,13 +541,15 @@ class TestSubmodule(TestBase):
         sm.update(recursive=False)
         assert sm.module_exists()
         with sm.config_writer() as writer:
-            writer.set_value("path", fp)  # Change path to something with prefix AFTER url change.
+            # Change path to something with prefix AFTER url change.
+            writer.set_value("path", fp)
 
-        # Update doesn't fail, because list_items ignores the wrong path in such situations.
+        # Update doesn't fail, because list_items ignores the wrong path in such
+        # situations.
         rm.update(recursive=False)
 
-        # Move it properly - doesn't work as it its path currently points to an indexentry
-        # which doesn't exist (move it to some path, it doesn't matter here).
+        # Move it properly - doesn't work as it its path currently points to an
+        # indexentry which doesn't exist (move it to some path, it doesn't matter here).
         self.assertRaises(InvalidGitRepositoryError, sm.move, pp)
         # Reset the path(cache) to where it was, now it works.
         sm.path = prep
@@ -588,23 +597,27 @@ class TestSubmodule(TestBase):
         rm.update(recursive=False, dry_run=True, force_remove=True)
         assert osp.isdir(smp)
 
-        # When removing submodules, we may get new commits as nested submodules are auto-committing changes
-        # to allow deletions without force, as the index would be dirty otherwise.
+        # When removing submodules, we may get new commits as nested submodules are
+        # auto-committing changes to allow deletions without force, as the index would
+        # be dirty otherwise.
         # QUESTION: Why does this seem to work in test_git_submodule_compatibility() ?
         self.assertRaises(InvalidGitRepositoryError, rm.update, recursive=False, force_remove=False)
         rm.update(recursive=False, force_remove=True)
         assert not osp.isdir(smp)
 
-        # 'Apply work' to the nested submodule and ensure this is not removed/altered during updates
-        # Need to commit first, otherwise submodule.update wouldn't have a reason to change the head.
+        # 'Apply work' to the nested submodule and ensure this is not removed/altered
+        # during updates. We need to commit first, otherwise submodule.update wouldn't
+        # have a reason to change the head.
         touch(osp.join(nsm.module().working_tree_dir, "new-file"))
-        # We cannot expect is_dirty to even run as we wouldn't reset a head to the same location.
+        # We cannot expect is_dirty to even run as we wouldn't reset a head to the same
+        # location.
         assert nsm.module().head.commit.hexsha == nsm.hexsha
         nsm.module().index.add([nsm])
         nsm.module().index.commit("added new file")
         rm.update(recursive=False, dry_run=True, progress=prog)  # Would not change head, and thus doesn't fail.
-        # Everything we can do from now on will trigger the 'future' check, so no is_dirty() check will even run.
-        # This would only run if our local branch is in the past and we have uncommitted changes.
+        # Everything we can do from now on will trigger the 'future' check, so no
+        # is_dirty() check will even run. This would only run if our local branch is in
+        # the past and we have uncommitted changes.
 
         prev_commit = nsm.module().head.commit
         rm.update(recursive=False, dry_run=False, progress=prog)
@@ -616,8 +629,8 @@ class TestSubmodule(TestBase):
 
         # Change url...
         # =============
-        # ...to the first repository. This way we have a fast checkout, and a completely different
-        # repository at the different url.
+        # ...to the first repository. This way we have a fast checkout, and a completely
+        # different repository at the different url.
         nsm.set_parent_commit(csmremoved)
         nsmurl = Git.polish_url(osp.join(self.rorepo.working_tree_dir, rsmsp[0]))
         with nsm.config_writer() as writer:
@@ -637,16 +650,15 @@ class TestSubmodule(TestBase):
         assert len(rwrepo.submodules) == 1
         assert not rwrepo.submodules[0].children()[0].module_exists(), "nested submodule should not be checked out"
 
-        # Add the submodule's changed commit to the index, which is what the
-        # user would do.
-        # Beforehand, update our instance's binsha with the new one.
+        # Add the submodule's changed commit to the index, which is what the user would
+        # do. Beforehand, update our instance's binsha with the new one.
         nsm.binsha = nsm.module().head.commit.binsha
         rwrepo.index.add([nsm])
 
         # Change branch.
         # ==============
-        # We only have one branch, so we switch to a virtual one, and back
-        # to the current one to trigger the difference.
+        # We only have one branch, so we switch to a virtual one, and back to the
+        # current one to trigger the difference.
         cur_branch = nsm.branch
         nsmm = nsm.module()
         prev_commit = nsmm.head.commit
@@ -808,8 +820,8 @@ class TestSubmodule(TestBase):
         smm.git.add(Git.polish_url(fp))
         smm.git.commit(m="new file added")
 
-        # Submodules are retrieved from the current commit's tree, therefore we can't really get a new submodule
-        # object pointing to the new submodule commit.
+        # Submodules are retrieved from the current commit's tree, therefore we can't
+        # really get a new submodule object pointing to the new submodule commit.
         sm_too = parent.submodules["module_moved"]
         assert parent.head.commit.tree[sm.path].binsha == sm.binsha
         assert sm_too.binsha == sm.binsha, "cached submodule should point to the same commit as updated one"
@@ -848,8 +860,9 @@ class TestSubmodule(TestBase):
 
         # END assert_exists
 
-        # As git is backwards compatible itself, it would still recognize what we do here... unless we really
-        # muss it up. That's the only reason why the test is still here...
+        # As git is backwards compatible itself, it would still recognize what we do
+        # here... unless we really muss it up. That's the only reason why the test is
+        # still here...
         assert len(parent.git.submodule().splitlines()) == 1
 
         module_repo_path = osp.join(sm.module().working_tree_dir, ".git")
@@ -885,7 +898,8 @@ class TestSubmodule(TestBase):
         assert_exists(csm)
 
         # Rename nested submodule.
-        # This name would move itself one level deeper - needs special handling internally.
+        # This name would move itself one level deeper - needs special handling
+        # internally.
         new_name = csm.name + "/mine"
         assert csm.rename(new_name).name == new_name
         assert_exists(csm)
@@ -1011,13 +1025,15 @@ class TestSubmodule(TestBase):
         sm_source_repo.index.add([new_file])
         sm.repo.index.commit("added new file")
 
-        # Change designated submodule checkout branch to the new upstream feature branch.
+        # Change designated submodule checkout branch to the new upstream feature
+        # branch.
         with sm.config_writer() as smcw:
             smcw.set_value("branch", sm_fb.name)
         assert sm.repo.is_dirty(index=True, working_tree=False)
         sm.repo.index.commit("changed submodule branch to '%s'" % sm_fb)
 
-        # Verify submodule update with feature branch that leaves currently checked out branch in it's past.
+        # Verify submodule update with feature branch that leaves currently checked out
+        # branch in it's past.
         sm_mod = sm.module()
         prev_commit = sm_mod.commit()
         assert sm_mod.head.ref.name == "master"
@@ -1029,7 +1045,8 @@ class TestSubmodule(TestBase):
         assert sm_mod.head.ref.name == sm_fb.name
         assert sm_mod.commit() == sm_fb.commit
 
-        # Create new branch which is in our past, and thus seemingly unrelated to the currently checked out one.
+        # Create new branch which is in our past, and thus seemingly unrelated to the
+        # currently checked out one.
         # To make it even 'harder', we shall fork and create a new commit.
         sm_pfb = sm_source_repo.create_head("past-feature", commit="HEAD~20")
         sm_pfb.checkout()
@@ -1043,8 +1060,8 @@ class TestSubmodule(TestBase):
 
         # Test submodule updates - must fail if submodule is dirty.
         touch(osp.join(sm_mod.working_tree_dir, "unstaged file"))
-        # This doesn't fail as our own submodule binsha didn't change, and the reset is only triggered if
-        # to_latest_revision is True.
+        # This doesn't fail as our own submodule binsha didn't change, and the reset is
+        # only triggered if to_latest_revision is True.
         parent_repo.submodule_update(to_latest_revision=False)
         assert sm_mod.head.ref.name == sm_pfb.name, "should have been switched to past head"
         assert sm_mod.commit() == sm_fb.commit, "Head wasn't reset"
@@ -1184,8 +1201,8 @@ class TestSubmodule(TestBase):
                 "fd::/foo",
             ]
             for url in urls:
-                # The URL will be allowed into the command, but the command will
-                # fail since we don't have that protocol enabled in the Git config file.
+                # The URL will be allowed into the command, but the command will fail
+                # since we don't have that protocol enabled in the Git config file.
                 with self.assertRaises(GitCommandError):
                     Submodule.add(rw_repo, "new", "new", url, allow_unsafe_protocols=True)
                 assert not tmp_file.exists()
@@ -1269,8 +1286,8 @@ class TestSubmodule(TestBase):
             ]
             for url in urls:
                 submodule = Submodule(rw_repo, b"\0" * 20, name="new", path="new", url=url)
-                # The URL will be allowed into the command, but the command will
-                # fail since we don't have that protocol enabled in the Git config file.
+                # The URL will be allowed into the command, but the command will fail
+                # since we don't have that protocol enabled in the Git config file.
                 with self.assertRaises(GitCommandError):
                     submodule.update(allow_unsafe_protocols=True)
                 assert not tmp_file.exists()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -153,7 +153,8 @@ class TestRmtree:
         reason="PermissionError is only ever wrapped on Windows",
     )
     def test_wraps_perm_error_if_enabled(self, mocker, permission_error_tmpdir):
-        """rmtree wraps PermissionError on Windows when HIDE_WINDOWS_KNOWN_ERRORS is true."""
+        """rmtree wraps PermissionError on Windows when HIDE_WINDOWS_KNOWN_ERRORS is
+        true."""
         self._patch_for_wrapping_test(mocker, True)
 
         with pytest.raises(SkipTest):
@@ -171,7 +172,8 @@ class TestRmtree:
         ],
     )
     def test_does_not_wrap_perm_error_unless_enabled(self, mocker, permission_error_tmpdir, hide_windows_known_errors):
-        """rmtree does not wrap PermissionError on non-Windows systems or when HIDE_WINDOWS_KNOWN_ERRORS is false."""
+        """rmtree does not wrap PermissionError on non-Windows systems or when
+        HIDE_WINDOWS_KNOWN_ERRORS is false."""
         self._patch_for_wrapping_test(mocker, hide_windows_known_errors)
 
         with pytest.raises(PermissionError):
@@ -182,7 +184,9 @@ class TestRmtree:
 
     @pytest.mark.parametrize("hide_windows_known_errors", [False, True])
     def test_does_not_wrap_other_errors(self, tmp_path, mocker, hide_windows_known_errors):
-        file_not_found_tmpdir = tmp_path / "testdir"  # It is deliberately never created.
+        # The file is deliberately never created.
+        file_not_found_tmpdir = tmp_path / "testdir"
+
         self._patch_for_wrapping_test(mocker, hide_windows_known_errors)
 
         with pytest.raises(FileNotFoundError):
@@ -502,7 +506,8 @@ class TestUtils(TestBase):
         committer = Actor.committer(None)
         author = Actor.author(None)
         # We can't test with `self.rorepo.config_reader()` here, as the UUID laziness
-        # depends on whether the user running the test has their global user.name config set.
+        # depends on whether the user running the test has their global user.name config
+        # set.
         self.assertEqual(committer.name, "user")
         self.assertTrue(committer.email.startswith("user@"))
         self.assertEqual(author.name, "user")


### PR DESCRIPTION
Fixes #1845
Fixes #1847
Fixes #1849

This pull request is a sequel to #1725. Most changes are to docstrings. Notable changes:

- Applies revisions to recently discussed docstrings, including improving on the wording I added in [#1839](https://github.com/gitpython-developers/GitPython/pull/1839) and [#1844](https://github.com/gitpython-developers/GitPython/pull/1844), and making the changes discussed in [#1845](https://github.com/gitpython-developers/GitPython/issues/1845), [#1847](https://github.com/gitpython-developers/GitPython/issues/1847), and [#1849](https://github.com/gitpython-developers/GitPython/issues/1849).

- Revises docstrings throughout the `git` package along the lines of [#1725](https://github.com/gitpython-developers/GitPython/pull/1725), covering areas I outright missed, or where a further improvement or kind of improvement became apparent since then (either over time or due to recent rereading), or arose since then, or where I am better able to check the effect on rendered documentation, or where I am more comfortable making the change due to an improved understanding of the code being documented (or commented).

- Goes beyond that in making some new *kinds* of formatting changes to improve consistency that I had not included there, some that I had intentionally omitted at that time due to less experience with the project, and others that I only realized the benefit of more recently. See 1cd73ba for a list of many of these (that commit only covers a handful of files, but other commits made those kinds of changes to more files).

- Makes bigger formatting changes for readability, when reading the docstrings in the code, than in [#1725](https://github.com/gitpython-developers/GitPython/pull/1725). These also improve consistency, but their value is even more for readability:

  * Putting blank lines between all sections of all docstrings (in the `git` package).
  * Giving role-labeled sections a newline after the leading `:role:`/`:role args...:`.
  * Wrapping nearly all docstrings and most comments to 88 columns.
  * Formatting all occurrences of a class name that is intended to refer to that class with `:class:`, except in rare cases where there are disadvantages of doing so (e.g., the first line of a class docstring must not link to the class itself, or some readers may infer that it is a reference to another same-named class).

  The addition of blank lines and line breaks in docstrings is unneeded in some projects and often not done, but seems very useful to me *in GitPython*, where many docstrings have long sections (rather than, for example, sections like `:param foo: the predecessor of *bar*` that fit on a single line).

  The advantages of linking class names almost everywhere are that it:

  * makes clear *that* the class is what is being referred to (this is not always obvious, especially in GitPython due to subtleties of Git itself and, to a lesser extent, of GitPython's design), and
  * makes it easy to use the reference to get to information on something one is reading about.

- Codes all Sphinx references to classes, methods/functions, and attributes as either:

  * Relative to the current module, top-level function, class, or method.
  * Absolute.

  One effect is that there are far more absolute Sphinx references than before. This does not cause rendered Sphinx documentation to become more longwinded, because the references are written in such a way that the rendered text still omits the qualifiers (except on hover). This is mostly achieved by writing things like `` :class:`~a.b.c.D` ``, which is short for `` :class:`D <a.b.c.D>` ``, though occasionally I used the latter form: when the last two parts should be shown (`` :meth:`D.e <a.b.c.D.e>` ``), and in base classes' bulleted lists of documented subclasses where having the displayed name first lined it up better so as also to be readable unrendered in the code.

  There are important tradeoffs to consider here. **It is not at all obvious that this is the correct choice.** When I began to do it, it was not even with the intention that this would stay that way; I planned to make them all absolute, and thus obviously correct, and then thorough a combination of experimentation and consulting documentation about Sphinx and autodoc, make them relative again where correct, sufficiently reliable, and clear on reading. However, I noticed two things as I made many references absolute:

  * Clarity seems to be greatly improved by distinguishing things in the current module from other things that only *happen* to be in scope due to having been imported into it.
  * The entire module structure and logical organization of GitPython became clear when reading the docstrings in the code.

  Taken together with the advantage of avoiding confusing scoping issues (example: does Sphinx autodoc resolve references that are brought in scope due to `TYPE_CHECKING` imports?), I think it may actually be justified to leave it this way.

  **But it may not be justified, and this is an area that I want to call attention to for review.** The rendered documentation is not more longwinded as a result of doing this, but the *unrendered* documentation, i.e., the docstrings as written in the code, certainly are more longwinded in many cases. This potentially worsens readability.

  Overall readability seems improved to me, but there are two caveats to this:

  * I've been looking at the docstrings in this state for a while as I work on them, so what is readable to me may differ from what is readable in general.
  * I worry I may be giving with one hand and taking away with another: it may be that these absolute references are worsening readability, and by enough to make them unjustified in their current form, but that it is hard to know that this is so, because adding consistent spacing between sections (as described above) improves readability enough that it more than counterbalances it.

- Adds a small number of missing docstrings, and a moderately small number of previously omitted sections in docstrings. But this was not the focus.

- Slightly adjusts the wording of a few messages that GitPython outputs to signify errors. This is in cd8a312 (see [#1844](https://github.com/gitpython-developers/GitPython/pull/1844)), afd943a, and c67b2e2. These are the only behavioral changes. Besides adjusting code formatting slightly in small handful of cases, these are also the only code changes outside docstrings and comments.

There are some kinds of changes that are notably omitted from this pull request. These include:

- As in [#1725](https://github.com/gitpython-developers/GitPython/pull/1725), to limit the scope, I have not undertaken to update outdated documentation in `doc/source/` here, and nor applied any revisions to the project readme.
- Unlike [#1725](https://github.com/gitpython-developers/GitPython/pull/1725), I've kept the scope here a bit narrower: There are no modifications to type annotations, aspects of code style other than formatting (and very few of those), or changes of *any* kind in `doc/source/` (including no changes to its `conf.py`).
- This conspicuously excludes the `git.types` module from being revised. The reason is that, while docstrings should be revised there, it looks like it will make the most sense to do that together with changes to imports, which are beyond the intended scope of this pull request.
- This revises docstrings and (to a lesser extent) comments both in `git/` and `test/`, but the changes in `test/` are much less substantial, since there are fewer docstrings there, and tradeoffs there are different due to no part of the docstrings in the test suite being rendered by Sphinx. (This distinction is expanded on in 5cf5b60.)