### PR TITLE
Expand what is included in the API Reference

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -3,12 +3,15 @@
 API Reference
 =============
 
-Version
--------
+Top-Level
+---------
 
 .. py:data:: git.__version__
 
    Current GitPython version.
+
+.. automodule:: git
+   :members: refresh
 
 Objects.Base
 ------------
@@ -17,7 +20,7 @@ Objects.Base
    :members:
    :undoc-members:
    :special-members:
- 
+
 Objects.Blob
 ------------
 
@@ -25,7 +28,7 @@ Objects.Blob
    :members:
    :undoc-members:
    :special-members:
-   
+
 Objects.Commit
 --------------
 
@@ -33,7 +36,7 @@ Objects.Commit
    :members:
    :undoc-members:
    :special-members:
-   
+
 Objects.Tag
 -----------
 
@@ -73,7 +76,7 @@ Objects.Submodule.root
    :members:
    :undoc-members:
    :special-members:
-   
+
 Objects.Submodule.util
 ----------------------
 
@@ -81,7 +84,7 @@ Objects.Submodule.util
    :members:
    :undoc-members:
    :special-members:
-   
+
 Objects.Util
 -------------
 
@@ -105,7 +108,7 @@ Index.Functions
    :members:
    :undoc-members:
    :special-members:
-   
+
 Index.Types
 -----------
 
@@ -113,7 +116,7 @@ Index.Types
    :members:
    :undoc-members:
    :special-members:
-   
+
 Index.Util
 -------------
 
@@ -121,7 +124,7 @@ Index.Util
    :members:
    :undoc-members:
    :special-members:
-   
+
 GitCmd
 ------
 
@@ -137,7 +140,7 @@ Config
    :members:
    :undoc-members:
    :special-members:
-   
+
 Diff
 ----
 
@@ -154,7 +157,7 @@ Exceptions
    :undoc-members:
    :special-members:
 
- 
+
 Refs.symbolic
 -------------
 
@@ -162,7 +165,7 @@ Refs.symbolic
    :members:
    :undoc-members:
    :special-members:
-   
+
 Refs.reference
 --------------
 
@@ -178,7 +181,7 @@ Refs.head
    :members:
    :undoc-members:
    :special-members:
-   
+
 Refs.tag
 ------------
 
@@ -186,7 +189,7 @@ Refs.tag
    :members:
    :undoc-members:
    :special-members:
-   
+
 Refs.remote
 ------------
 
@@ -194,7 +197,7 @@ Refs.remote
    :members:
    :undoc-members:
    :special-members:
-   
+
 Refs.log
 ------------
 
@@ -202,7 +205,7 @@ Refs.log
    :members:
    :undoc-members:
    :special-members:
-   
+
 Remote
 ------
 
@@ -218,7 +221,7 @@ Repo.Base
    :members:
    :undoc-members:
    :special-members:
-   
+
 Repo.Functions
 --------------
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -230,6 +230,30 @@ Repo.Functions
    :undoc-members:
    :special-members:
 
+Compat
+------
+
+.. automodule:: git.compat
+   :members:
+   :undoc-members:
+   :special-members:
+
+DB
+--
+
+.. automodule:: git.db
+   :members:
+   :undoc-members:
+   :special-members:
+
+Types
+-----
+
+.. automodule:: git.types
+   :members:
+   :undoc-members:
+   :special-members:
+
 Util
 ----
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -389,9 +389,12 @@ class Git:
 
     @classmethod
     def refresh(cls, path: Union[None, PathLike] = None) -> bool:
-        """This gets called by the :func:`git.refresh` function.
+        """Update information about the git executable :class:`Git` objects will use.
 
-        See the top level ``__init__.py``.
+        Called by the :func:`git.refresh` function in the top level ``__init__``.
+
+        This gets called by the :func:`git.refresh` function in the top-level
+        ``__init__``.
 
         :param path:
             Optional path to the git executable. If not absolute, it is resolved

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -389,7 +389,9 @@ class Git:
 
     @classmethod
     def refresh(cls, path: Union[None, PathLike] = None) -> bool:
-        """This gets called by the refresh function (see the top level ``__init__``).
+        """This gets called by the :func:`git.refresh` function.
+
+        See the top level ``__init__.py``.
 
         :param path:
             Optional path to the git executable. If not absolute, it is resolved

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1491,7 +1491,9 @@ class Git:
     def _parse_object_header(self, header_line: str) -> Tuple[str, str, int]:
         """
         :param header_line:
-            <hex_sha> type_string size_as_int
+            A line of the form::
+
+                <hex_sha> type_string size_as_int
 
         :return:
             (hex_sha, type_string, size_as_int)
@@ -1581,7 +1583,7 @@ class Git:
         return (hexsha, typename, size, data)
 
     def stream_object_data(self, ref: str) -> Tuple[str, str, int, "Git.CatFileContentStream"]:
-        """Similar to :meth:`get_object_header`, but returns the data as a stream.
+        """Similar to :meth:`get_object_data`, but returns the data as a stream.
 
         :return:
             (hexsha, type_string, size_as_int, stream)

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -393,9 +393,6 @@ class Git:
 
         Called by the :func:`git.refresh` function in the top level ``__init__``.
 
-        This gets called by the :func:`git.refresh` function in the top-level
-        ``__init__``.
-
         :param path:
             Optional path to the git executable. If not absolute, it is resolved
             immediately, relative to the current directory. (See note below.)

--- a/git/compat.py
+++ b/git/compat.py
@@ -61,7 +61,7 @@ This is deprecated because it clearer to write out :attr:`os.name` or
 
 :note:
     For macOS (Darwin), ``os.name == "posix"`` as in other Unix-like systems, while
-    ``sys.platform == "darwin"`.
+    ``sys.platform == "darwin"``.
 """
 
 defenc = sys.getfilesystemencoding()

--- a/git/db.py
+++ b/git/db.py
@@ -38,11 +38,12 @@ class GitCmdObjectDB(LooseObjectDB):
         self._git = git
 
     def info(self, binsha: bytes) -> OInfo:
+        """Get a git object header (using git itself)."""
         hexsha, typename, size = self._git.get_object_header(bin_to_hex(binsha))
         return OInfo(hex_to_bin(hexsha), typename, size)
 
     def stream(self, binsha: bytes) -> OStream:
-        """For now, all lookup is done by git itself"""
+        """Get git object data as a stream supporting ``read()`` (using git itself)."""
         hexsha, typename, size, stream = self._git.stream_object_data(bin_to_hex(binsha))
         return OStream(hex_to_bin(hexsha), typename, size, stream)
 

--- a/git/remote.py
+++ b/git/remote.py
@@ -338,7 +338,10 @@ class FetchInfo(IterableObj):
 
     @classmethod
     def refresh(cls) -> Literal[True]:
-        """This gets called by the refresh function (see the top level ``__init__``)."""
+        """This gets called by the :func:`git.refresh` function.
+
+        See the top level ``__init__.py``.
+        """
         # Clear the old values in _flag_map.
         with contextlib.suppress(KeyError):
             del cls._flag_map["t"]

--- a/git/remote.py
+++ b/git/remote.py
@@ -338,9 +338,10 @@ class FetchInfo(IterableObj):
 
     @classmethod
     def refresh(cls) -> Literal[True]:
-        """This gets called by the :func:`git.refresh` function.
+        """Update information about which ``git fetch`` flags are supported by the git
+        executable being used.
 
-        See the top level ``__init__.py``.
+        Called by the :func:`git.refresh` function in the top level ``__init__``.
         """
         # Clear the old values in _flag_map.
         with contextlib.suppress(KeyError):


### PR DESCRIPTION
Fixes #1854

This adds some missing modules in the API Reference. It adds the modules covered under "case 1" (top-level `git`, but only `refresh` and, as before, `__version__`) and "case 3" (the three leaf modules whose documentation wasn't previously emitted), as I classified them in #1854. It does not add "case 2".

Even if this is what should be done, there is some question about the specifics:

- I don't know what top-level entries should be grouped under in the existing naming convention. Its relationship to the actual module names is usually predictable but not precise. The general pattern doesn't allow me to predict a useful name for the section at the top that now contains `git.__version__` and `git.refresh`; it was previously called "Version", which is no longer suitable. I picked "Top-Level", but this feels not altogether in keeping with the rest of the style.
- I don't know what order the sections for `git.compat`, `git.db`, and `git.types` should come in, relative to the existing sections and each other. The existing sections are ordered in a largely but not entirely alphabetical fashion, and that seems like it may be intentional. I placed them at the end with the section for `git.util` and I kept those modules at the end sorted alphabetically relative to each other (so they are actually before `git.util`). That seems to make sense, since their documentation may be less often consulted than than of other modules. But I don't know if that's really true.

Each commit is self-contained, addressing one small part of these changes or other small changes that support or relate to them. While doing this, I noticed opportunities to improve some of the especially affected docstrings or those of closely related functions; those improvements are the first four commits.