### PR TITLE
Restore building of documentation downloads

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,9 +23,7 @@ sphinx:
   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub.
-# formats:
-# - pdf
-# - epub
+formats: all
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation.


### PR DESCRIPTION
Although documentation resumed being built in 634151a, and the RTD theme and API Reference section were restored in 64ad585 (#1843), documentation for download did not resume being built, with 3.1.37 (not 3.1.42) being the latest version listed at:

- https://readthedocs.org/projects/gitpython/downloads/

Three kinds of downloadable documentation are supported -- PDF, ePub, and HTML -- and all three were previously being built but all have stopped.

This attempts to resume building all three, listing `all` under the `formats` key in .readthedocs.yml. `all` currently should have the same effect as listing all of `htmlzip`, `pdf`, and `epub`, per:

- https://docs.readthedocs.io/en/stable/downloadable-documentation.html
- https://docs.readthedocs.io/en/stable/config-file/v2.html#formats

---

As I understand it, for purposes of efficiency, pull request preview builds do not build that documentation. The [Limitations](https://docs.readthedocs.io/en/stable/guides/pull-requests.html#limitations) of such builds include:

> Additional formats like PDF and EPUB aren’t built, to reduce build time.

So the effect, even if successful, may not be observable immediately.