### PR TITLE
Revise type annotations slightly

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -749,7 +749,7 @@ class Git:
         rest to ensure the underlying stream continues to work.
         """
 
-        __slots__: Tuple[str, ...] = ("_stream", "_nbr", "_size")
+        __slots__ = ("_stream", "_nbr", "_size")
 
         def __init__(self, size: int, stream: IO[bytes]) -> None:
             self._stream = stream


### PR DESCRIPTION
This pull request is mostly a small revision to type hints to improve a couple things I had noticed when working on #1850 but omitted from there to avoid bloating its scope:

- 9f226fc: `__slots__` is typically unannotated, but in once place it had an unnecessary annotation.
- 5d7e55b: Although `mypy` treats it the same when there are parameter annotations, `__init__` is best annotated with an explicit return type of `None`, per PEP 484.

In addition, I noticed some slight under-indentation in a few docstrings I had worked on #1850, and fixed that here in e984bfe. (The type annotation tweaks are sufficiently minor that there is an argument to be made that this is really the most significant individual change in this pull request.)

There is some more information in the commit messages.