### PR TITLE
Update readme and tox.ini for recent tooling changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ probably the skills to scratch that itch of mine: implement `git` in a way that 
 If you like the idea and want to learn more, please head over to [gitoxide](https://github.com/Byron/gitoxide), an
 implementation of 'git' in [Rust](https://www.rust-lang.org).
 
-*(Please note that `gitoxide` is not currently available for use in Python, and that Rust is required)*
+*(Please note that `gitoxide` is not currently available for use in Python, and that Rust is required.)*
 
 ## GitPython
 
@@ -39,9 +39,9 @@ The project is open to contributions of all kinds, as well as new maintainers.
 
 ### REQUIREMENTS
 
-GitPython needs the `git` executable to be installed on the system and available in your `PATH` for most operations.
-If it is not in your `PATH`, you can help GitPython find it by setting
-the `GIT_PYTHON_GIT_EXECUTABLE=<path/to/git>` environment variable.
+GitPython needs the `git` executable to be installed on the system and available in your
+`PATH` for most operations. If it is not in your `PATH`, you can help GitPython find it
+by setting the `GIT_PYTHON_GIT_EXECUTABLE=<path/to/git>` environment variable.
 
 - Git (1.7.x or newer)
 - Python >= 3.7
@@ -57,7 +57,7 @@ GitPython and its required package dependencies can be installed in any of the f
 
 To obtain and install a copy [from PyPI](https://pypi.org/project/GitPython/), run:
 
-```bash
+```sh
 pip install GitPython
 ```
 
@@ -67,7 +67,7 @@ pip install GitPython
 
 If you have downloaded the source code, run this from inside the unpacked `GitPython` directory:
 
-```bash
+```sh
 pip install .
 ```
 
@@ -75,7 +75,7 @@ pip install .
 
 To clone the [the GitHub repository](https://github.com/gitpython-developers/GitPython) from source to work on the code, you can do it like so:
 
-```bash
+```sh
 git clone https://github.com/gitpython-developers/GitPython
 cd GitPython
 ./init-tests-after-clone.sh
@@ -85,7 +85,7 @@ On Windows, `./init-tests-after-clone.sh` can be run in a Git Bash shell.
 
 If you are cloning [your own fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks), then replace the above `git clone` command with one that gives the URL of your fork. Or use this [`gh`](https://cli.github.com/) command (assuming you have `gh` and your fork is called `GitPython`):
 
-```bash
+```sh
 gh repo clone GitPython
 ```
 
@@ -93,7 +93,7 @@ Having cloned the repo, create and activate your [virtual environment](https://d
 
 Then make an [editable install](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs):
 
-```bash
+```sh
 pip install -e ".[test]"
 ```
 
@@ -105,7 +105,7 @@ In rare cases, you may want to work on GitPython and one or both of its [gitdb](
 
 If you want to do that *and* you want the versions in GitPython's git submodules to be used, then pass `-e git/ext/gitdb` and/or `-e git/ext/gitdb/gitdb/ext/smmap` to `pip install`. This can be done in any order, and in separate `pip install` commands or the same one, so long as `-e` appears before *each* path. For example, you can install GitPython, gitdb, and smmap editably in the currently active virtual environment this way:
 
-```bash
+```sh
 pip install -e ".[test]" -e git/ext/gitdb -e git/ext/gitdb/gitdb/ext/smmap
 ```
 
@@ -141,13 +141,13 @@ you will encounter test failures.
 
 Ensure testing libraries are installed. This is taken care of already if you installed with:
 
-```bash
+```sh
 pip install -e ".[test]"
 ```
 
 Otherwise, you can run:
 
-```bash
+```sh
 pip install -r test-requirements.txt
 ```
 
@@ -155,19 +155,19 @@ pip install -r test-requirements.txt
 
 To test, run:
 
-```bash
+```sh
 pytest
 ```
 
 To lint, and apply automatic code formatting, run:
 
-```bash
+```sh
 pre-commit run --all-files
 ```
 
 To typecheck, run:
 
-```bash
+```sh
 mypy -p git
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,13 @@ To test, run:
 pytest
 ```
 
-To lint, and apply automatic code formatting, run:
+To lint, and apply some linting fixes as well as automatic code formatting, run:
 
 ```sh
 pre-commit run --all-files
 ```
+
+This includes the linting and autoformatting done by Ruff, as well as some other checks.
 
 To typecheck, run:
 
@@ -170,7 +172,7 @@ mypy -p git
 
 #### CI (and tox)
 
-The same linting, and running tests on all the different supported Python versions, will be performed:
+Style and formatting checks, and running tests on all the different supported Python versions, will be performed:
 
 - Upon submitting a pull request.
 - On each push, *if* you have a fork with GitHub Actions enabled.
@@ -178,10 +180,12 @@ The same linting, and running tests on all the different supported Python versio
 
 #### Configuration files
 
-Specific tools:
+Specific tools are all configured in the `./pyproject.toml` file:
 
-- Configurations for `mypy`, `pytest`, `coverage.py`, and `black` are in `./pyproject.toml`.
-- Configuration for `ruff` is in the `pyproject.toml` file.
+- `pytest` (test runner)
+- `coverage.py` (code coverage)
+- `ruff` (linter and formatter)
+- `mypy` (type checker)
 
 Orchestration tools:
 

--- a/README.md
+++ b/README.md
@@ -145,11 +145,8 @@ Ensure testing libraries are installed. This is taken care of already if you ins
 pip install -e ".[test]"
 ```
 
-Otherwise, you can run:
-
-```sh
-pip install -r test-requirements.txt
-```
+If you had installed with a command like `pip install -e .` instead, you can still run
+the above command to add the testing dependencies.
 
 #### Test commands
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires = tox>=4
-env_list = py{37,38,39,310,311,312}, lint, mypy, html
+env_list = py{37,38,39,310,311,312}, mypy, html
 
 [testenv]
 description = Run unit tests


### PR DESCRIPTION
There are some changes that I should have proposed and/or made in `README.md` and `tox.ini` related to #1862, which are made slightly more needed by #1865. This brings the readme and tox configuration up to date for both #1862, which was merged, and #1865, which I think will be merged soon ~~pending one small change~~. Further related changes should be eventually be made in both, but they will depend on future decisions, and nothing bad will happen if changes end up not being made for an extended time after merging both #1865 and this PR.

The changes here seem significantly more cumbersome to recommend be included in #1865 than to do separately, and because they also apply to the situation brought about since #1862, I don't think they need to be done there or done before that is merged. I suggest #1865 be merged before this; the changes here will not be all correct until #1865 comes in anyway. #1865 could be merged and then this immediately merged, but I think it is also fine to merge #1865 and request changes here; that is, I think #1865 is reasonable to merge even if this is delayed. Merging them in the other order would also be okay, I think.

The core issue is that some actions that were presented as not changing file contents now change them. Currently on the main branch:

1. I believe running `tox` with no arguments is always in practice assumed not to change source code in the working tree. But its `lint` environment changes source code due to running `ruff` with `--fix` through `pre-commit`. With [#1865](https://github.com/gitpython-developers/GitPython/pull/1865), this will happen in more cases, but the issue already exists. As noted below and in commit messages, I believe `--fix` is nonetheless good and should be kept. (When I reviewed [#1862](https://github.com/gitpython-developers/GitPython/pull/1862) I did not mention this, because I agreed with the change, which is what users of `pre-commit` will expect. In hindsight, I could've simplified things by proposing these changes at that time.)
2. The readme documents `make lint` as linting and running a formatting check without modifying any files. This is likewise not fully accurate since [#1862](https://github.com/gitpython-developers/GitPython/pull/1862). The issue is not that `make lint` needs to behave differently, because *(a)* in hindsight I shouldn't have added that target, *(b)* I'm not sure anyone uses it, and *(c)* it was added to address a situation where checking for code style and formatting problems involved multiple commands and tool and plugin packages, instead of just `ruff`. So it's sufficient for the readme to stop recommending it as a way to avoid linting without automatic code changes.

This PR fixes *(1)* by making the tox `lint` environment not run unless explicitly listed on the command line, for now, and fixes *(2)* by changing the readme. This also fixes some related outdated material in the readme, improves how tools are described, and makes some some other small improvements when it seemed like I could do them without significantly complicating this PR or its review.

Most information about these changes is in the two most important commits, [c66257e](https://github.com/gitpython-developers/GitPython/pull/1868/commits/c66257eac7f344814d95bc45243f30659d767350) and [91f967a](https://github.com/gitpython-developers/GitPython/pull/1868/commits/91f967a9bb579050f2450ce59f657e225101b05a). This includes some information about why I believe `--fix` should be kept.

- I've also included information in [91f967a](https://github.com/gitpython-developers/GitPython/pull/1868/commits/91f967a9bb579050f2450ce59f657e225101b05a) about what it does *not* do and why it does not do it, which may be considered excessive in a commit message, and I'd be pleased to amend that and move that information into this PR description on request.
- The reason I've included that information is so that no matter what order things happen in, and even if some are omitted, and regardless of what related changes do or don't happen in the future, and even if I am making a mistake in thinking that it is better to have this additional PR rather than delay and expand the scope of [#1865](https://github.com/gitpython-developers/GitPython/pull/1865), the full context will still be readily available to anyone who looks at that commit while trying to figure something out.