### PR TITLE
Split tox lint env into three envs, all safe

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,3 @@ jobs:
         python-version: "3.x"
 
     - uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files --hook-stage manual

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires = tox>=4
-env_list = py{37,38,39,310,311,312}, mypy, html
+env_list = py{37,38,39,310,311,312}, ruff, format, mypy, html, misc
 
 [testenv]
 description = Run unit tests
@@ -9,10 +9,17 @@ extras = test
 pass_env = SSH_*
 commands = pytest --color=yes {posargs}
 
-[testenv:lint]
-description = Lint via pre-commit
+[testenv:ruff]
+description = Lint with Ruff
 base_python = py{39,310,311,312,38,37}
-commands = pre-commit run --all-files
+deps = ruff
+commands = ruff check .
+
+[testenv:format]
+description = Check formatting with Ruff
+base_python = py{39,310,311,312,38,37}
+deps = ruff
+commands = ruff format --check .
 
 [testenv:mypy]
 description = Typecheck with mypy
@@ -28,3 +35,10 @@ allowlist_externals = make
 commands =
     make BUILDDIR={env_tmp_dir}/doc/build -C doc clean
     make BUILDDIR={env_tmp_dir}/doc/build -C doc html
+
+[testenv:misc]
+description = Run other checks via pre-commit
+base_python = py{39,310,311,312,38,37}
+set_env =
+    SKIP = ruff-format,ruff
+commands = pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = pytest --color=yes {posargs}
 [testenv:lint]
 description = Lint via pre-commit
 base_python = py{39,310,311,312,38,37}
-commands = pre-commit run --all-files --hook-stage manual
+commands = pre-commit run --all-files
 
 [testenv:mypy]
 description = Typecheck with mypy

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ commands = ruff format --check .
 [testenv:mypy]
 description = Typecheck with mypy
 base_python = py{39,310,311,312,38,37}
+set_env =
+    MYPY_FORCE_COLOR = 1
 commands = mypy -p git
 ignore_outcome = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,16 @@ commands = pytest --color=yes {posargs}
 description = Lint with Ruff
 base_python = py{39,310,311,312,38,37}
 deps = ruff
+set_env =
+    CLICOLOR_FORCE = 1  # Set NO_COLOR to override this.
 commands = ruff check .
 
 [testenv:format]
 description = Check formatting with Ruff
 base_python = py{39,310,311,312,38,37}
 deps = ruff
+set_env =
+    CLICOLOR_FORCE = 1  # Set NO_COLOR to override this.
 commands = ruff format --check .
 
 [testenv:mypy]


### PR DESCRIPTION
See 4c034db for details on the main changes.

This adds tox environments for both linting and format checking with Ruff, specifying Ruff as a dependency and calling it in such a way that it does not mutate files in the working tree, since one expects tox not to do that. This still has tox use pre-commit to run other hooks (which do not modify files).

Since none of these modify files, they all can and should run automatically when `tox` is run with no arguments, so they are added to the `env_list` (which the old lint env had been removed from in #1868, pending a change like this).

With this approach taken, there is no clear use for the already-unused manual hook stage in the near future anymore, and it's easy to bring back if needed, so I've also removed that, including in the CI linting workflow.

After adding the tox envs for Ruff, I tweaked them so they would show colored output, so then I went ahead and made a similar change for mypy when run with tox. I have included that here as well, even though it is not related to Ruff. But the changes here do not cause mypy to show colored output when run in the `pythonpackage.yml` workflow, because I ended up doing that in #1859 to help with the work there (alongside other mypy configuration improvements).