### PR TITLE
Slightly broaden Ruff, and update and clarify tool configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.0
+  rev: v0.3.2
   hooks:
   - id: ruff-format
     exclude: ^git/ext/
@@ -10,14 +9,14 @@ repos:
     exclude: ^git/ext/
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.9.0.5
+  rev: v0.9.0.6
   hooks:
   - id: shellcheck
     args: [--color]
     exclude: ^test/fixtures/polyglot$|^git/ext/
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-toml
   - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     exclude: ^git/ext/
   - id: ruff
     args: ["--fix"]
-    exclude: ^doc|^git/ext/
+    exclude: ^git/ext/
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.9.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ line-length = 120
 # Exclude a variety of commonly ignored directories.
 exclude = [
     "git/ext/",
-    "doc",
     "build",
     "dist",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,24 +54,28 @@ exclude = [
 # Enable Pyflakes `E` and `F` codes by default.
 lint.select = [
     "E",
-    "W", # see: https://pypi.org/project/pycodestyle
-    "F", # see: https://pypi.org/project/pyflakes
-#    "I", #see: https://pypi.org/project/isort/
-#    "S", # see: https://pypi.org/project/flake8-bandit
-#    "UP", # see: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "W",     # See: https://pypi.org/project/pycodestyle
+    "F",     # See: https://pypi.org/project/pyflakes
+    # "I",   # See: https://pypi.org/project/isort/
+    # "S",   # See: https://pypi.org/project/flake8-bandit
+    # "UP",  # See: https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 lint.extend-select = [
-    #"A",    # see: https://pypi.org/project/flake8-builtins
-    "B",    # see: https://pypi.org/project/flake8-bugbear
-    "C4",   # see: https://pypi.org/project/flake8-comprehensions
-    "TCH004", # see: https://docs.astral.sh/ruff/rules/runtime-import-in-type-checking-block/
+    # "A",     # See: https://pypi.org/project/flake8-builtins
+    "B",       # See: https://pypi.org/project/flake8-bugbear
+    "C4",      # See: https://pypi.org/project/flake8-comprehensions
+    "TCH004",  # See: https://docs.astral.sh/ruff/rules/runtime-import-in-type-checking-block/
 ]
 lint.ignore = [
-    "E203",
-    "E731", # Do not assign a `lambda` expression, use a `def`
+    "E203",  # Whitespace before ':'
+    "E731",  # Do not assign a `lambda` expression, use a `def`
 ]
 lint.ignore-init-module-imports = true
-lint.unfixable = ["F401"]
+lint.unfixable = [
+    "F401",  # Module imported but unused
+]
 
 [tool.ruff.lint.per-file-ignores]
-"test/**" = ["B018"]
+"test/**" = [
+    "B018",  # useless-expression
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 -r test-requirements.txt
 
-# libraries for additional local testing/linting - to be added to test-requirements.txt when all pass
-
+# For additional local testing/linting - to be added elsewhere eventually.
+ruff
+shellcheck
 pytest-icdiff
 # pytest-profiling


### PR DESCRIPTION
Changes:

- Lets Ruff scan `doc/source/conf.py`, and other Python modules in `doc` outside `build` if there were any (00ff7e3).
- Adds comments on all suppressed Ruff rules and puts all of `pyproject.toml` in closer to the same style (4814775).
- Adds Ruff (and ShellCheck, which could've been added before) to the file currently used to list tools not listed as dependencies (a8a73ff).
- Bumps pre-commit hook versions, which brings small benefits for Ruff and ShellCheck (ff1ebf8).