### PR TITLE
Add a "doc" extra for documentation build dependencies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -100,5 +100,5 @@ jobs:
 
     - name: Documentation
       run: |
-        pip install -r doc/requirements.txt
+        pip install ".[doc]"
         make -C doc html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,4 +32,5 @@ python:
   install:
   - method: pip
     path: .
-  - requirements: doc/requirements.txt
+    extra_requirements:
+    - doc

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 from typing import Sequence
 
 from setuptools import setup, find_packages
@@ -9,17 +10,14 @@ from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.sdist import sdist as _sdist
 
 
-with open(os.path.join(os.path.dirname(__file__), "VERSION"), encoding="utf-8") as ver_file:
-    VERSION = ver_file.readline().strip()
+def _read_content(path: str) -> str:
+    return (Path(__file__).parent / path).read_text(encoding="utf-8")
 
-with open("requirements.txt", encoding="utf-8") as reqs_file:
-    requirements = reqs_file.read().splitlines()
 
-with open("test-requirements.txt", encoding="utf-8") as reqs_file:
-    test_requirements = reqs_file.read().splitlines()
-
-with open("README.md", encoding="utf-8") as rm_file:
-    long_description = rm_file.read()
+version = _read_content("VERSION").strip()
+requirements = _read_content("requirements.txt").splitlines()
+test_requirements = _read_content("test-requirements.txt").splitlines()
+long_description = _read_content("README.md")
 
 
 class build_py(_build_py):
@@ -50,7 +48,7 @@ def _stamp_version(filename: str) -> None:
         with open(filename) as f:
             for line in f:
                 if "__version__ =" in line:
-                    line = line.replace('"git"', "'%s'" % VERSION)
+                    line = line.replace('"git"', "'%s'" % version)
                     found = True
                 out.append(line)
     except OSError:
@@ -66,7 +64,7 @@ def _stamp_version(filename: str) -> None:
 setup(
     name="GitPython",
     cmdclass={"build_py": build_py, "sdist": sdist},
-    version=VERSION,
+    version=version,
     description="GitPython is a Python library used to interact with Git repositories",
     author="Sebastian Thiel, Michael Trier",
     author_email="byronimo@gmail.com, mtrier@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
+import os
+import sys
 from typing import Sequence
+
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.sdist import sdist as _sdist
-import os
-import sys
+
 
 with open(os.path.join(os.path.dirname(__file__), "VERSION"), encoding="utf-8") as ver_file:
     VERSION = ver_file.readline().strip()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def _read_content(path: str) -> str:
 version = _read_content("VERSION").strip()
 requirements = _read_content("requirements.txt").splitlines()
 test_requirements = _read_content("test-requirements.txt").splitlines()
+doc_requirements = _read_content("doc/requirements.txt").splitlines()
 long_description = _read_content("README.md")
 
 
@@ -75,7 +76,10 @@ setup(
     package_dir={"git": "git"},
     python_requires=">=3.7",
     install_requires=requirements,
-    extras_require={"test": test_requirements},
+    extras_require={
+        "test": test_requirements,
+        "doc": doc_requirements,
+    },
     zip_safe=False,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ ignore_outcome = true
 [testenv:html]
 description = Build HTML documentation
 base_python = py{39,310,311,312,38,37}
-deps = -r doc/requirements.txt
+extras = doc
 allowlist_externals = make
 commands =
     make BUILDDIR={env_tmp_dir}/doc/build -C doc clean


### PR DESCRIPTION
Much as GitPython has a `test` extra to aid development by installing testing and--currently--most linting dependencies, this adds a `doc` extra that installs Sphinx and its theme and plugins. The `test` extra is built by parsing `test-requirements.txt`, and similarly the new `doc` extra is built by parsing `doc/requirements.txt`. The previous approach of running `pip install -r doc/requirements.txt` continues to work.

The following are updated to use the new extra:

- The Read the Docs configuration in `.readthedocs.yaml`.
- Documentation build testing step in `pythonpackage.yml`.
- Documentation building tox environment in `tox.ini`.

Before doing this, I factored out shared logic in the way metadata files are read in `setup.py`, wrote that code in a more streamlined way, and removed what appear to be small unintentional complexities in how two unusual situations are handled:

- The entire content of `VERSION`, which *should* always be exactly one line, is now used (except leading and trailing whitespace) as the version.
- The requirements files and readme are, as the `VERSION` file already had been, now found relative to the `setup.py` file rather than the current directory, in the rare case that those two locations are different.

You might decide you actually *only* want that `setup.py` cleanup, and not the new `doc` extra. I believe it makes sense to have a `doc` extra because it is a convenient way to install documentation, and because adding a new extra for that is readily feasible without even though the project definition is not declarative, because the information is available for static inspection in its requirements file, which already exist. (In contrast, I have not proposed a new `lint` extra at this time, though I think we should have that, because it would currently involve either adding another requirements file or making it harder to statically inspect the dependencies with automated tools.)

However, to a large extent this comes down to personal preference, and there is a reason many projects use a requirements file for their documentation dependencies: it tends to be a reasonably okay way to pin them all exactly, including indirect (transitive) dependencies, for greater stability. Read the Docs [advocates this](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pin-your-transitive-dependencies). But GitPython is not doing this. Currently documentation builld dependencies deliberately support ranges to support building on different Python versions. That is compatible with pinning if a tool like `poetry` is used (when multiple sets of precisely pinned direct and transitive dependencies, for multiple versions and sometimes platforms, have to be maintained, one wants a tool that fully automates doing so). Also, I think there is no reason to think GitPython will pin documentation build dependencies in the future yet not pin other extra/optional dependencies such as those for testing and linting. I think there is some symmetry between these things, for GitPython (and for many other projects).

<details><summary><em>Theory you don't have to read that also isn't correct in real life</em></summary>
<hr>
<p>In principle:</p>
<ul>
<li><em>Applications</em> use a <code>requirements.txt</code> file, or something conceptually similar like <code>Pipfile.lock</code>, that lists all their Python package dependencies fully pinned, including indirect dependencies (which, for Python packages, are the same thing as transitive dependencies), and typically express unpinned or less pinned direct dependencies separately in a <code>requirements.in</code> file, or something conceptually similar like <code>Pipfile</code>.</li>
<br>
<li><em>Libraries</em> define their dependencies in <code>setup.py</code>, <code>setup.cfg</code>, or <code>pyproject.toml</code>, sometimes in a way affected by the choice of build backend, sometimes with the aid of dependency management tools such as <code>poetry</code> and sometimes not. The idea is that applications need specific pinned dependency versions to guarantee stability, while in contrast libraries need to accommodate the varying versions of whatever applications use them, either indirectly or through other libraries. </li>
</ul>
<p>The problems are that the distinction between an application and a library is more permeable than it may seem at first, and that there are various benefits of defining an application like a library (for example, a <code>requirements.txt</code> file will not facilitate automatically installing executable scripts, and will not facilitate finding the code from a different location, even a subdirectory within its source tree), and also that when automated tests are run on a library, it is being used like an application and there can even be a benefit to precisely pinning the test runner and other test dependencies.</p>
<hr>
</details>

However, if you prefer not to take the addition of the "doc" extra, but do want the other changes to `setup.py`, then I can drop the commit that actually does the "doc" extra and the PR can be retitled accordingly.

I have locally tested the parts of this change that are not automatically exercised by GitHub Actions checks and Read the Docs pull request builds:

- `python -m build` to build GitPython itself.
- Editable and non-editable installations.
- `git.__version__` when imported from a non-editable installation, both from a prebuilt wheel and with `pip` omitting `-e`.
- Ability to install locally with the `doc` extra on a Windows environment set up dissimilarly to how Windows is set up on GitHub Actions runners.
- Ability to run `make -C doc html` successfully when the only installation command run was `pip install -e '.[doc]'` (as it would be used locally).

[Here's the Read the Docs build status for this pull request](https://readthedocs.org/projects/gitpython/builds/23745411/) (passing at [74df5a8](https://github.com/gitpython-developers/GitPython/pull/1872/commits/74df5a8995b6f4e9ed053e126dda1cb6cfc465f5)).