### PR TITLE
Describe `Submodule.__init__` parent_commit parameter

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -143,7 +143,9 @@ class Submodule(IndexObject, TraversableIterableObj):
             See the `url` parameter.
 
         :param parent_commit:
-            See :meth:`set_parent_commit`.
+            The :class:`~git.objects.commit.Commit` whose tree is supposed to contain
+            the ``.gitmodules`` blob, or ``None`` to always point to the most recent
+            commit. See :meth:`set_parent_commit` for details.
 
         :param url:
             The URL to the remote repository which is the submodule.
@@ -1260,7 +1262,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         contain the ``.gitmodules`` blob.
 
         :param commit:
-            Commit-ish reference pointing at the root_tree, or ``None`` to always point
+            Commit-ish reference pointing at the root tree, or ``None`` to always point
             to the most recent commit.
 
         :param check:


### PR DESCRIPTION
This includes a brief description of the `Submodule.__init__` *parent_commit* parameter in its docstring, rather than only referring to the `set_parent_commit` method, whose semantics differ due to conversation and validation, and which accepts more types than just `Commit` or `None`.

The wording is based on wording in `set_parent_commit`, adjusted for the difference in types, and `set_parent_commit` remains reference for further details.

This builds on 1f03e7f (#1859) in improving the situation described in #1869.