### PR TITLE
Fix typo in _get_exe_extensions PATHEXT fallback

### DIFF
--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -112,7 +112,7 @@ def find_submodule_git_dir(d: PathLike) -> Optional[PathLike]:
             path = content[8:]
 
             if Git.is_cygwin():
-                # Cygwin creates submodules prefixed with `/cygdrive/...` suffixes.
+                # Cygwin creates submodules prefixed with `/cygdrive/...`.
                 # Cygwin git understands Cygwin paths much better than Windows ones.
                 # Also the Cygwin tests are assuming Cygwin paths.
                 path = cygpath(path)

--- a/git/util.py
+++ b/git/util.py
@@ -339,7 +339,7 @@ def _get_exe_extensions() -> Sequence[str]:
     if PATHEXT:
         return tuple(p.upper() for p in PATHEXT.split(os.pathsep))
     elif sys.platform == "win32":
-        return (".BAT", "COM", ".EXE")
+        return (".BAT", ".COM", ".EXE")
     else:
         return ()
 


### PR DESCRIPTION
This applies two minor Cygwin-related clarifications, one of which is theoretically a bugfix though it affects conceptually non-public code that is currently not used in a way that could invoke the bug. Some specific details are in commit messages.

The second commit, 988d97b, which fixes `COM` to `.COM` in the fallback for the `PATHEXT` environment variable--whose omission is almost certainly a typo, going back to the function's introduction in e6e23ed (#533)--is theoretically a bugfix. But as noted there, this code is only called when the Python interpreter is a native Windows program, but the function it is a part of is only called when the Python interpreter is *not* a native Windows program. (Also, it would be pretty unusual for the `git` executable to have a `.com` extension.)

---

There are some further changes related to Cygwin detection that may make sense to make in the future, some of which might be best to make after adding relevant tests. The ones that are narrowly related to the change here are that:

- This value of `PATHEXT` here is still unusual, because order matters and this lists `.BAT` before `.COM` and `.EXE`, and because it is missing [`.CMD`, which is part of what a minimal value for it should typically contain](https://github.com/python/cpython/pull/20088#discussion_r426796510). I am uncertain if this strange order is intentional.
- It may also make sense for the list to include `.VBS`, `.JS`, `.WS`, and `.MSC` for compatibility with the fallback behavior of the Windows `cmd.exe` shell when `PATHEXT` is unset, [which is what `shutil.which` does](https://github.com/python/cpython/pull/20088#discussion_r425274424). (I have verified the result of Eryk Sun's debugger check in WinDbg on recent builds of Windows 10 and Windows 11; they are the same.)
- `py_where` should really be removed and replaced either with a call to `shutil.which`, which did not exist at the time `py_where` was introduced and would almost certainly have been used at that time if it had--or with other logic that works an altogether different way. Which should be done depends on the intent of the public `Git.is_cygwin_git` class method, which is the only code in GitPython that uses the `is_cygwin_git` function in `git/util.py`, for which the `py_where` helper exists.

This PR doesn't try to cover any of that. It's really just applying some clarifications that didn't seem like they fit in any other PR that I would do soon.

Regarding the last point about `Git.is_cygwin_git`, if the goal is to detect Cygwin git even on native Windows systems, then the code it uses will have to be significantly revised. That is because currently it always returns `False` on such systems. In addition, as noted in the `py_where` docstring and elsewhere, shell and non-shell path search differ from each other on native Windows, such that neither the nonpublic ad-hoc `py_where` nor the public general `shutil.which` will reliably tell us where `git` is. However, if a path search doesn't need to be done on native Windows, then it can be replaced with `shutil.which` unless some use has come to depend on (perhaps accidentally introduced) distinctive behavior of `py_where`.

I plan to open an issue about that larger matter, which I am unlikely to work on anytime soon, but that perhaps someone would be interested to take on. (If you know what `Git.is_cygwin_git`'s semantics are supposed to be, then I can make use of that information in the forthcoming issue, but I can still open it even if its intent is currently uncertain.)