### PR TITLE
Update the comment about `--mixed` and paths

### DIFF
--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -99,8 +99,8 @@ class HEAD(SymbolicReference):
         if index:
             mode = "--mixed"
 
-            # It appears some git versions declare mixed and paths deprecated.
-            # See http://github.com/Byron/GitPython/issues#issue/2.
+            # Explicit "--mixed" when passing paths is deprecated since git 1.5.4.
+            # See https://github.com/gitpython-developers/GitPython/discussions/1876.
             if paths:
                 mode = None
             # END special case


### PR DESCRIPTION
This updates the comment in `HEAD.reset` about why `--mixed` is omitted from the git command constructed to perform a reset where paths are being passed, adding specific information about the git versions where this is deprecated, and changing the more-info link from an old GitPython issue that is no longer retrievable to #1876.

See #1876 for details.