### PR TITLE
Fixed an error updating shallow submodules

### DIFF
--- a/git/remote.py
+++ b/git/remote.py
@@ -316,7 +316,7 @@ class FetchInfo(IterableObj):
         ERROR,
     ) = [1 << x for x in range(8)]
 
-    _re_fetch_result = re.compile(r"^ *(.) (\[[\w \.$@]+\]|[\w\.$@]+) +(.+) -> ([^ ]+)(    \(.*\)?$)?")
+    _re_fetch_result = re.compile(r"^ *(?:.{0,3})(.) (\[[\w \.$@]+\]|[\w\.$@]+) +(.+) -> ([^ ]+)(    \(.*\)?$)?")
 
     _flag_map: Dict[flagKeyLiteral, int] = {
         "!": ERROR,


### PR DESCRIPTION
When we try to execute 
submodule_update(recursive=True, init=True) 
in Repo class with shallow submodules, command
git fetch --progress -v origin 
sometimes print log such as
=5 = [up to date]      zm/160_uwp              -> origin/zm/160_uwp
but it doesn't satisfy filter:
r"^ *(.) (\[[\w \.$@]+\]|[\w\.$@]+) +(.+) -> ([^ ]+)( \(.*\)?$)?"
and throw exception.
 I've updated it so that it works correctly.