### PR TITLE
Dockerize "Direct Execution of Fuzz Targets"

### DIFF
--- a/fuzzing/local-dev-helpers/Dockerfile
+++ b/fuzzing/local-dev-helpers/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Use the same Python version as OSS-Fuzz to accidental incompatibilities in test code
-FROM python:3.8-slim
+FROM python:3.8-bookworm
 
 LABEL project="GitPython Fuzzing Local Dev Helper"
 
@@ -11,12 +11,12 @@ COPY . .
 
 # Update package managers, install necessary packages, and cleanup unnecessary files in a single RUN to keep the image smaller.
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git && \
+    apt-get install -y git clang && \
     python -m pip install --upgrade pip && \
     python -m pip install atheris && \
     python -m pip install -e . && \
     apt-get clean && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* /root/.cache
+    rm -rf /var/lib/apt/lists/*
 
 CMD ["bash"]

--- a/fuzzing/local-dev-helpers/Dockerfile
+++ b/fuzzing/local-dev-helpers/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+# Use the same Python version as OSS-Fuzz to accidental incompatibilities in test code
+FROM python:3.8-slim
+
+LABEL project="GitPython Fuzzing Local Dev Helper"
+
+WORKDIR /src
+
+COPY . .
+
+# Update package managers, install necessary packages, and cleanup unnecessary files in a single RUN to keep the image smaller.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git && \
+    python -m pip install --upgrade pip && \
+    python -m pip install atheris && \
+    python -m pip install -e . && \
+    apt-get clean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /root/.cache
+
+CMD ["bash"]


### PR DESCRIPTION
Adds a Dockerfile to enable easily executing the fuzz targets directly inside a container environment instead of directly on a host machine. This addresses concerns raised in PR #1901 related to how `fuzz_tree.py` writes to the real `/tmp` directory of the file system it is executed on as part of setting up its own test fixtures, but also makes for an easier to use development workflow.

I also added a warning to the `fuzzing/READEME` strongly suggesting users only execute the targets inside of Docker.

See this related comment on PR #1901 for additional context: https://github.com/gitpython-developers/GitPython/pull/1901#issuecomment-2063818998