### PR TITLE
lint: switch order Ruff's hooks `fix` -> `format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.2
+  rev: v0.4.3
   hooks:
-  - id: ruff-format
-    exclude: ^git/ext/
   - id: ruff
     args: ["--fix"]
+    exclude: ^git/ext/
+  - id: ruff-format
     exclude: ^git/ext/
 
 - repo: https://github.com/shellcheck-py/shellcheck-py


### PR DESCRIPTION
Since `fix` may do some additional changes, it makes sense to first run fixing and the formatting so you may need to run pre-commit only once in case fixing wont be compatible with formatting