### PR TITLE
Instrument test utility functions to increase fuzzer efficiency

### DIFF
--- a/fuzzing/fuzz-targets/fuzz_diff.py
+++ b/fuzzing/fuzz-targets/fuzz_diff.py
@@ -17,16 +17,19 @@ with atheris.instrument_imports():
 class BytesProcessAdapter:
     """Allows bytes to be used as process objects returned by subprocess.Popen."""
 
+    @atheris.instrument_func
     def __init__(self, input_string):
         self.stdout = io.BytesIO(input_string)
         self.stderr = io.BytesIO()
 
+    @atheris.instrument_func
     def wait(self):
         return 0
 
     poll = wait
 
 
+@atheris.instrument_func
 def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
 


### PR DESCRIPTION
Fuzz Introspector was reporting a high percentage of fuzz blockers in the `fuzz_diff` test. This means the fuzzing engine was unable to gain visibility into functions lower in the call stack than the blocking functions, making it less effective at producing interesting input data.

This clears a large percentage of the fuzz blockers by adding fuzzer instrumentation to them via the `@atheris.instrument_func` decorator.

**Fuzz Introspector Before & After Screenshots**

<details><summary>Before</summary>

<img width="1274" alt="image" src="https://github.com/gitpython-developers/GitPython/assets/17415134/e64f3774-360f-4951-977f-7b1c55809d17">

</details> 

<details><summary>After</summary>

<img width="1303" alt="image" src="https://github.com/gitpython-developers/GitPython/assets/17415134/0e7bceb8-a338-4417-b495-9f37dffd551c">


</details> 