### PR TITLE
Add the `.git` subdir as another `safe.directory` on Cygwin CI

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39=3.9.16-1 python39-pip python39-virtualenv git
+        packages: python39=3.9.16-1 python39-pip python39-virtualenv git=2.43.0-1
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39=3.9.16-1 python39-pip python39-virtualenv git=2.43.0-1
+        packages: python39=3.9.16-1 python39-pip python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |
@@ -40,6 +40,7 @@ jobs:
     - name: Special configuration for Cygwin git
       run: |
         git config --global --add safe.directory "$(pwd)"
+        git config --global --add safe.directory "$(pwd)/.git"
         git config --global core.autocrlf false
 
     - name: Prepare this repo for tests


### PR DESCRIPTION
As shown in [this run on my fork](https://github.com/EliahKagan/GitPython/actions/runs/9246034785/job/25433125087#step:13:7106), the CI test job for Cygwin is failing now. This fixes that.

The first commit in this pull request just demonstrates that the failure is due to the upgrade of the Cygwin `git` package from 2.43.0-1 to 2.45.1-1. Although that commit makes test pass, I recommend against following that approach, mainly because the new version contains [multiple security updates](https://github.com/git/git/commit/83f1add914c6b4682de1e944ec0d1ac043d53d78) (coming in with the upstream [2.45.1](https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.45.1.txt) version, not with any downstream patches), but also because the older version will eventually be dropped from the Cygwin repositories.

The better workaround is in the second commit here, which adds the `.git` subdirectory of the cloned `GitPython` directory as a value of the multi-valued `safe.directory` Git configuration variable. Its parent directory is already added, which was previously sufficient, but not anymore.

I suspect that, rather than this being any bug in the downstream package, this is actually the correct behavior due to one of the several security fixes in the new version of Git, though I have not verified that. So maybe this is really not a workaround, but a permanent fix.

I believe the reason there is no need to modify any other workflow is that the other workflows don't need to add any `safe.directory` paths at all: they either clone the repository with the necessary ownership in the first place or, in the case of the Alpine Linux job, [set the ownership](https://github.com/EliahKagan/GitPython/blob/adf4bf0a81c3a24a97306e256a3aadb950f765ed/.github/workflows/alpine-test.yml#L30-L33) with `chown`.
