### PR TITLE
Fix iter_change_type diff renamed property to prevent warning

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -325,7 +325,7 @@ class DiffIndex(List[T_Diff]):
                 yield diffidx
             elif change_type == "C" and diffidx.copied_file:
                 yield diffidx
-            elif change_type == "R" and diffidx.renamed:
+            elif change_type == "R" and diffidx.renamed_file:
                 yield diffidx
             elif change_type == "M" and diffidx.a_blob and diffidx.b_blob and diffidx.a_blob != diffidx.b_blob:
                 yield diffidx

--- a/test/deprecation/test_basic.py
+++ b/test/deprecation/test_basic.py
@@ -31,7 +31,7 @@ from typing import Generator, TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from git.diff import Diff
+    from git.diff import Diff, DiffIndex
     from git.objects.commit import Commit
 
 # ------------------------------------------------------------------------
@@ -52,6 +52,12 @@ def diff(commit: "Commit") -> Generator["Diff", None, None]:
     """Fixture to supply a single-file diff."""
     (diff,) = commit.diff(NULL_TREE)  # Exactly one file in the diff.
     yield diff
+
+
+@pytest.fixture
+def diffs(commit: "Commit") -> Generator["DiffIndex", None, None]:
+    """Fixture to supply a DiffIndex."""
+    yield commit.diff(NULL_TREE)
 
 
 def test_diff_renamed_warns(diff: "Diff") -> None:
@@ -122,3 +128,10 @@ def test_iterable_obj_inheriting_does_not_warn() -> None:
 
         class Derived(IterableObj):
             pass
+
+
+def test_diff_iter_change_type(diffs: "DiffIndex") -> None:
+    """The internal DiffIndex.iter_change_type function issues no deprecation warning."""
+    with assert_no_deprecation_warning():
+        for change_type in diffs.change_type:
+            [*diffs.iter_change_type(change_type=change_type)]


### PR DESCRIPTION
Hello 👋,
in https://github.com/gitpython-developers/GitPython/pull/1886 and https://github.com/gitpython-developers/GitPython/commit/e7dec7d0eecc362f02418820a146735a68430fbd a proper warning message was introduced for the usage of `Diff.renamed` pointing to use `Diff.renamed_file`.
However, the usage of this property wasn't changed in the `iter_change_type` (since 3 years at that), so the internals use deprecated code 😞 

https://github.com/gitpython-developers/GitPython/blob/9fbfb718bf2e66f6f842e496cf304112b438e864/git/diff.py#L328-L329

Given that the code wasn't reported yet, perhaps I'm doing something wrong using the `iter_change_type` and there are better ways 👀 I'm using a custom MkDocs hook to run GitPython and check for renames to automatically create redirects mappings for paths, and another plugin handles the redirect creation for the static pages.
Here is the line which triggered the warning 
- https://github.com/Gothic-Modding-Community/gmc/blob/b15fc318827d18ae1c2b67a4a73bc3d74c08b0ea/overrides/.hooks/git_redirects.py#L128

And the CI:
- https://github.com/Gothic-Modding-Community/gmc/actions/runs/9248064690/job/25437812921#step:8:21

> [!WARNING]
> As this is a one line change, I took the liberty to omit setting up an environment and just used the GitHub GUI to make a small change.
> I also didn't investigate deeper to check if the `iter_change_type` has any tests.

Thanks for your time :v: