### PR TITLE
typing fixes - DiffIndex generic type and IndexFile items

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -187,7 +187,7 @@ class Diffable:
         paths: Union[PathLike, List[PathLike], Tuple[PathLike, ...], None] = None,
         create_patch: bool = False,
         **kwargs: Any,
-    ) -> "DiffIndex":
+    ) -> "DiffIndex[Diff]":
         """Create diffs between two items being trees, trees and index or an index and
         the working tree. Detects renames automatically.
 
@@ -581,7 +581,7 @@ class Diff:
         return None
 
     @classmethod
-    def _index_from_patch_format(cls, repo: "Repo", proc: Union["Popen", "Git.AutoInterrupt"]) -> DiffIndex:
+    def _index_from_patch_format(cls, repo: "Repo", proc: Union["Popen", "Git.AutoInterrupt"]) -> DiffIndex["Diff"]:
         """Create a new :class:`DiffIndex` from the given process output which must be
         in patch format.
 
@@ -674,7 +674,7 @@ class Diff:
         return index
 
     @staticmethod
-    def _handle_diff_line(lines_bytes: bytes, repo: "Repo", index: DiffIndex) -> None:
+    def _handle_diff_line(lines_bytes: bytes, repo: "Repo", index: DiffIndex["Diff"]) -> None:
         lines = lines_bytes.decode(defenc)
 
         # Discard everything before the first colon, and the colon itself.
@@ -747,7 +747,7 @@ class Diff:
             index.append(diff)
 
     @classmethod
-    def _index_from_raw_format(cls, repo: "Repo", proc: "Popen") -> "DiffIndex":
+    def _index_from_raw_format(cls, repo: "Repo", proc: "Popen") -> "DiffIndex[Diff]":
         """Create a new :class:`DiffIndex` from the given process output which must be
         in raw format.
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -658,7 +658,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         return os.path.relpath(path, self.repo.working_tree_dir)
 
     def _preprocess_add_items(
-        self, items: Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]
+        self, items: Union[PathLike, Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]]
     ) -> Tuple[List[PathLike], List[BaseIndexEntry]]:
         """Split the items into two lists of path strings and BaseEntries."""
         paths = []
@@ -749,7 +749,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
     def add(
         self,
-        items: Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]],
+        items: Union[PathLike, Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]],
         force: bool = True,
         fprogress: Callable = lambda *args: None,
         path_rewriter: Union[Callable[..., PathLike], None] = None,
@@ -976,7 +976,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     @default_index
     def remove(
         self,
-        items: Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]],
+        items: Union[PathLike, Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]],
         working_tree: bool = False,
         **kwargs: Any,
     ) -> List[str]:
@@ -1036,7 +1036,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
     @default_index
     def move(
         self,
-        items: Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]],
+        items: Union[PathLike, Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]],
         skip_errors: bool = False,
         **kwargs: Any,
     ) -> List[Tuple[str, str]]:

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1478,7 +1478,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         paths: Union[PathLike, List[PathLike], Tuple[PathLike, ...], None] = None,
         create_patch: bool = False,
         **kwargs: Any,
-    ) -> git_diff.DiffIndex:
+    ) -> git_diff.DiffIndex[git_diff.Diff]:
         """Diff this index against the working copy or a :class:`~git.objects.tree.Tree`
         or :class:`~git.objects.commit.Commit` object.
 


### PR DESCRIPTION
Example issue with DiffIndex:
```python
repo = git.Repo(path_dir)
diff = repo.index.diff(None)
modified_files = [d for d in repo.index.diff(None)]
reveal_type(modified_files) # list[Unknown] instead of list[Diff]
```
Example issue with IndexFile:
```python
path: os.PathLike = ...
repo = git.Repo(path_dir)
# Argument of type "PathLike[Unknown]"
# cannot be assigned to parameter "items" of type "Sequence[git.types.PathLike | Blob | BaseIndexEntry | Submodule]" in function "add"
# "PathLike[Unknown]" is incompatible with "Sequence[git.types.PathLike | Blob | BaseIndexEntry | Submodule]"
repo.index.add(path)
```
