### PR TITLE
Fix Improper Import Order Breaking `fuzz_submodule` Fuzzer

### DIFF
--- a/fuzzing/fuzz-targets/fuzz_submodule.py
+++ b/fuzzing/fuzz-targets/fuzz_submodule.py
@@ -4,11 +4,12 @@ import os
 import tempfile
 from configparser import ParsingError
 from utils import is_expected_exception_message, get_max_filename_length
-from git import Repo, GitCommandError, InvalidGitRepositoryError
 
 if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cover
     path_to_bundled_git_binary = os.path.abspath(os.path.join(os.path.dirname(__file__), "git"))
     os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = path_to_bundled_git_binary
+
+from git import Repo, GitCommandError, InvalidGitRepositoryError
 
 if not sys.warnoptions:  # pragma: no cover
     # The warnings filter below can be overridden by passing the -W option


### PR DESCRIPTION
ClusterFuzz runs of the `fuzz_submodule` target have been failing because the `git` import was placed before the condition that sets the Git executable path 😞 

The order in which `git` is imported matters because it attempts to find a Git executable as the import is loaded (via `refresh()` in `git/__init__.py`.) As per #1909, we configure the ClusterFuzz environment to use a bundled Git executable via the env variable condition in all fuzz targets.