### PR TITLE
fixed doc to not faulty do #1924

### DIFF
--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -469,11 +469,11 @@ class Tutorials(TestBase):
         # ![30-test_references_and_objects]
 
         # [31-test_references_and_objects]
-        git = repo.git
-        git.checkout("HEAD", b="my_new_branch")  # Create a new branch.
-        git.branch("another-new-one")
-        git.branch("-D", "another-new-one")  # Pass strings for full control over argument order.
-        git.for_each_ref()  # '-' becomes '_' when calling it.
+        git_cmd = repo.git
+        git_cmd.checkout("HEAD", b="my_new_branch")  # Create a new branch.
+        git_cmd.branch("another-new-one")
+        git_cmd.branch("-D", "another-new-one")  # Pass strings for full control over argument order.
+        git_cmd.for_each_ref()  # '-' becomes '_' when calling it.
         # ![31-test_references_and_objects]
 
         repo.git.clear_cache()


### PR DESCRIPTION
Small change on documentation to make it clear how to use the `repo.git` object (not to confuse `import git`).

This is not a fix for #1924, but was related due to this documentation string.