### PR TITLE
Enable Python 3.8 and 3.9 on M1 runners

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,10 +18,6 @@ jobs:
         exclude:
         - os: "macos-14"
           python-version: "3.7"
-        - os: "macos-14"
-          python-version: "3.8"
-        - os: "macos-14"
-          python-version: "3.9"
         include:
         - experimental: false
 


### PR DESCRIPTION
These were excluded in 9ad28c3 (#1817) due to https://github.com/actions/setup-python/issues/808, which was later fixed by https://github.com/actions/python-versions/pull/259.

Because Python 3.7 has been end-of-life for a while, it is very unlikely to have AArch64 builds added in `python-versions` for use on GitHub Actions CI runners (preinstalled or via `setup-python`).

---

This doesn't remove any jobs, so it contributes to the gradually increasing number of CI jobs, and the operating system with the most jobs that run the whole test suite is macOS, which is also the operating system for which the rate limits on runner usage (effectively, how many jobs can be run at the same time) are the most stringent. The effect is smaller than one might think, just because the M1 runners are so fast.

Nonetheless, it may make sense to remove some or even all `macos-13` jobs. The main practical difference is not the operating system version but the architecture, and the correctness of GitPython doesn't seem to be highly dependent on the architecture it is run on. For example, although #1826 did not include a test job emulating the big-endian s390x architecture, in my local testing in Alpine Linux for s390x running in a Docker container leveraging QEMU to emulate that architecture, all tests passed. (I did not run the performance tests, which would be too slow. Also, to clarify, I have not repeated this testing recently or attempted to run fuzz tests in that setup, just noting what the situation was as of #1826.)

If everything is working here then I could open another PR to remove at least some of the `macos-13` jobs. (If the number of jobs is considered excessive already, I could push another commit to this PR that does it.) Or that could wait until later, such as when deciding whether/when to remove Python 3.7 jobs, or when deciding what if anything to remove when adding Python 3.13 jobs (either experimental ones to test the beta, or when it is released).