### PR TITLE
Remove the non-ARM macOS CI jobs

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-14", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-        - os: "macos-14"
+        - os: "macos-latest"
           python-version: "3.7"
         include:
         - experimental: false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-14", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - os: "macos-14"


### PR DESCRIPTION
This keeps only the `macos-14` jobs, which run on Apple Silicon M1, and removes the `macos-13` jobs, which ran on x86-64. This relates to the commented discussion in #1944. There would also be the option of keeping some of them, but removing all of them decreases the workload the most while also being the simplest.

It also uses the label `macos-latest` instead, which is currently equivalent to `maos-14`.

- Some information about the situation with `macos-latest` and the benefit of using it is presented in the second commit message.
- That these jobs really are running on macOS 14, and more importantly that they are really running on ARM64, can be verified by examining the output of "Set up job" step. [Here's an example.](https://github.com/EliahKagan/GitPython/actions/runs/10073515669/job/27847712218#step:1:8)

Other operating systems' jobs continue to run on x86-64 machines (and none on ARM, yet). Only macOS jobs are removed.

This change leaves Python 3.7 without any macOS test job. That is probably okay, since it has been end-of-life for some time, and it remains tested on Ubuntu and Windows.