### PR TITLE
Deprecate default of Git.show(strip_newline_in_stdout=False)

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1210,6 +1210,13 @@ class Git(metaclass=_GitMeta):
         if self.GIT_PYTHON_TRACE and (self.GIT_PYTHON_TRACE != "full" or as_process):
             _logger.info(" ".join(redacted_command))
 
+        if strip_newline_in_stdout and command[:2] == ["git", "show"]:
+            warnings.warn(
+                "Git.show() has strip_newline_in_stdout=True by default, which probably isn't what you want and will "
+                "change in a future version. It is recommended to use Git.show(..., strip_newline_in_stdout=False)",
+                DeprecationWarning
+            )
+
         # Allow the user to have the command executed in their working dir.
         try:
             cwd = self._working_dir or os.getcwd()  # type: Union[None, str]

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1214,7 +1214,8 @@ class Git(metaclass=_GitMeta):
             warnings.warn(
                 "Git.show() has strip_newline_in_stdout=True by default, which probably isn't what you want and will "
                 "change in a future version. It is recommended to use Git.show(..., strip_newline_in_stdout=False)",
-                DeprecationWarning
+                DeprecationWarning,
+                stacklevel=1,
             )
 
         # Allow the user to have the command executed in their working dir.

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -51,7 +51,7 @@ class TestDiff(TestBase):
     @with_rw_directory
     def test_diff_with_staged_file(self, rw_dir):
         # SET UP INDEX WITH MULTIPLE STAGES
-        r = Repo.init(rw_dir)
+        r = Repo.init(rw_dir, initial_branch="master")
         fp = osp.join(rw_dir, "hello.txt")
         with open(fp, "w") as fs:
             fs.write("hello world")

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1193,7 +1193,7 @@ class TestRepo(TestBase):
     @with_rw_directory
     def test_empty_repo(self, rw_dir):
         """Assure we can handle empty repositories"""
-        r = Repo.init(rw_dir, mkdir=False)
+        r = Repo.init(rw_dir, mkdir=False, initial_branch="master")
         # It's ok not to be able to iterate a commit, as there is none.
         self.assertRaises(ValueError, r.iter_commits)
         self.assertEqual(r.active_branch.name, "master")
@@ -1352,7 +1352,7 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     def test_rebasing(self, rw_dir):
-        r = Repo.init(rw_dir)
+        r = Repo.init(rw_dir, initial_branch="master")
         fp = osp.join(rw_dir, "hello.txt")
         r.git.commit(
             "--allow-empty",

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1377,13 +1377,23 @@ class TestRepo(TestBase):
 
     @with_rw_directory
     def test_do_not_strip_newline_in_stdout(self, rw_dir):
+        r = self.create_repo_commit_hello_newline(rw_dir)
+        self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline_in_stdout=False), "hello\n")
+
+    def create_repo_commit_hello_newline(self, rw_dir):
         r = Repo.init(rw_dir)
         fp = osp.join(rw_dir, "hello.txt")
         with open(fp, "w") as fs:
             fs.write("hello\n")
         r.git.add(Git.polish_url(fp))
         r.git.commit(message="init")
-        self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline_in_stdout=False), "hello\n")
+        return r
+
+    @with_rw_directory
+    def test_warn_when_strip_newline_in_stdout(self, rw_dir):
+        r = self.create_repo_commit_hello_newline(rw_dir)
+        with pytest.warns(DeprecationWarning):
+            self.assertEqual(r.git.show("HEAD:hello.txt", strip_newline_in_stdout=True), "hello")
 
     @pytest.mark.xfail(
         sys.platform == "win32",


### PR DESCRIPTION
As per our discussion in #1377.

Also fix a few tests that were broken by my git being configured to create new repos with `main` as the initial branch, so that all my tests pass.

