### PR TITLE
Gracefully handle `PermissionError` exceptions that crash fuzzer

### DIFF
--- a/fuzzing/fuzz-targets/fuzz_submodule.py
+++ b/fuzzing/fuzz-targets/fuzz_submodule.py
@@ -78,6 +78,7 @@ def TestOneInput(data):
             IsADirectoryError,
             NotADirectoryError,
             BrokenPipeError,
+            PermissionError,
         ):
             return -1
         except Exception as e:


### PR DESCRIPTION
Fuzzing inputs sometimes produce directory paths that are protected inside the fuzzer execution environment. This is not an issue in GitPython's code, so it should not crash the fuzzer.

Fixes OSS-Fuzz Issue 69456:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69870