### PR TITLE
Fuzzing: Gracefully Handle Uninteresting Error to Fix OSS-Fuzz Issue

### DIFF
--- a/fuzzing/fuzz-targets/fuzz_submodule.py
+++ b/fuzzing/fuzz-targets/fuzz_submodule.py
@@ -84,6 +84,8 @@ def TestOneInput(data):
         except Exception as e:
             if isinstance(e, ValueError) and "embedded null byte" in str(e):
                 return -1
+            elif isinstance(e, OSError) and "File name too long" in str(e):
+                return -1
             else:
                 return handle_exception(e)
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71095

Fuzzing data can generate filenames that trigger:
> OSError: [Errno 36] File name too long

The changes here add handling for these exceptions because they di not indicate a bug and should not crash the fuzzer.