### PR TITLE
Don't support building documentation on Python 3.7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -99,6 +99,7 @@ jobs:
       continue-on-error: false
 
     - name: Documentation
+      if: matrix.python-version != '3.7'
       run: |
         pip install ".[doc]"
         make -C doc html

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,3 @@
-sphinx >= 7.1.2, < 7.2 ; python_version >= "3.8"
-sphinx == 4.3.2 ; python_version < "3.8"
-sphinxcontrib-applehelp >= 1.0.2, <= 1.0.4 ; python_version < "3.8"
-sphinxcontrib-devhelp == 1.0.2 ; python_version < "3.8"
-sphinxcontrib-htmlhelp >= 2.0.0, <= 2.0.1 ; python_version < "3.8"
-sphinxcontrib-qthelp == 1.0.3 ; python_version < "3.8"
-sphinxcontrib-serializinghtml == 1.1.5 ; python_version < "3.8"
+sphinx >= 7.1.2, < 7.2
 sphinx_rtd_theme
 sphinx-autodoc-typehints


### PR DESCRIPTION
This removes the specially cased alternative lower versions of `sphinx` and its dependencies that, since #1954, were only for Python 3.7. As discussed in comments there, this simplifies the documentation dependencies and avoids a situation where the version of Python used to build the documentation has a noticeable effect on the generated result.

This also conditions running the "Documentation" step in the main CI test workflow (`pythonpackage.yml`) on the Python version not being 3.7 (otherwise the job would always fail).

The only change this makes to the support status of GitPython on Python 3.7 is to no longer support building documentation on 3.7. GitPython can still be installed and used on 3.7 (though usually this would not be a good idea, outside of testing, since Python 3.7 itself has not been supported by the Python Software Foundation for quite some time). In addition, the documentation, which can be built on any version >= 3.8 (including 3.13 starting in #1954) is no less relevant to usage on Python 3.7 than it was before.

This should not be able to have any effect on other Python versions, including Python 3.12, which GitPython currently uses for its Read the Docs builds. But just in case, and to guard against inadvertent syntax errors, [here's the successful PR preview build](https://app.readthedocs.org/projects/gitpython/builds/25346602/).