### PR TITLE
Fix various version-related CI breakages

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Prepare Alpine Linux
       run: |
-        apk add sudo git git-daemon python3 py3-pip
+        apk add sudo git git-daemon python3 py3-pip py3-setuptools py3-virtualenv py3-wheel
         echo 'Defaults env_keep += "CI GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
         addgroup -g 127 docker
-        adduser -D -u 1001 runner
+        adduser -D -u 1001 runner  # TODO: Check if this still works on GHA as intended.
         adduser runner docker
       shell: sh -exo pipefail {0}  # Run this as root, not the "runner" user.
 
@@ -50,17 +50,14 @@ jobs:
         . .venv/bin/activate
         printf '%s=%s\n' 'PATH' "$PATH" 'VIRTUAL_ENV' "$VIRTUAL_ENV" >>"$GITHUB_ENV"
 
-    - name: Update PyPA packages
-      run: |
-        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
-        python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
-
     - name: Install project and test dependencies
       run: |
+        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
+        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -69,4 +66,5 @@ jobs:
 
     - name: Test with pytest
       run: |
+        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Prepare Alpine Linux
       run: |
         apk add sudo git git-daemon python3 py3-pip py3-virtualenv
-        echo 'Defaults env_keep += "CI ENV GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
+        echo 'Defaults env_keep += "CI GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
         addgroup -g 127 docker
         adduser -D -u 1001 runner  # TODO: Check if this still works on GHA as intended.
         adduser runner docker
@@ -47,19 +47,21 @@ jobs:
     - name: Set up virtualenv
       run: |
         python -m venv .venv
-        echo 'ENV=.venv/bin/activate' >> "$GITHUB_ENV"  # ENV (not BASH_ENV) for BusyBox sh.
 
     - name: Update PyPA packages
       run: |
         # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        . .venv/bin/activate
         python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
+        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
+        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -68,4 +70,5 @@ jobs:
 
     - name: Test with pytest
       run: |
+        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
     - name: Prepare Alpine Linux
       run: |
-        apk add sudo git git-daemon python3 py3-pip py3-setuptools py3-virtualenv py3-wheel
-        echo 'Defaults env_keep += "CI GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
+        apk add sudo git git-daemon python3 py3-pip py3-virtualenv
+        echo 'Defaults env_keep += "CI ENV GITHUB_* RUNNER_*"' >/etc/sudoers.d/ci_env
         addgroup -g 127 docker
         adduser -D -u 1001 runner  # TODO: Check if this still works on GHA as intended.
         adduser runner docker
@@ -47,17 +47,19 @@ jobs:
     - name: Set up virtualenv
       run: |
         python -m venv .venv
-        . .venv/bin/activate
-        printf '%s=%s\n' 'PATH' "$PATH" 'VIRTUAL_ENV' "$VIRTUAL_ENV" >>"$GITHUB_ENV"
+        echo 'ENV=.venv/bin/activate' >> "$GITHUB_ENV"  # ENV (not BASH_ENV) for BusyBox sh.
+
+    - name: Update PyPA packages
+      run: |
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -ow ^setuptools) wheel
 
     - name: Install project and test dependencies
       run: |
-        . .venv/bin/activate
         pip install ".[test]"
 
     - name: Show version and platform information
       run: |
-        . .venv/bin/activate
         uname -a
         command -v git python
         git version
@@ -66,5 +68,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        . .venv/bin/activate
         pytest --color=yes -p no:sugar --instafail -vv

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -55,10 +55,10 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Ensure the "pip" command is available
+    - name: Set up virtualenv
       run: |
-        # This is used unless, and before, an updated pip is installed.
-        ln -s pip3 /usr/bin/pip
+        python -m venv .venv
+        echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
 
     - name: Update PyPA packages
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,15 +11,19 @@ permissions:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-        - os: "macos-latest"
-          python-version: "3.7"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
         - experimental: false
+        - os: ubuntu-22.04
+          python-version: "3.7"
+          experimental: false
+        - os: windows-latest
+          python-version: "3.7"
+          experimental: false
+
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Set up WSL (Windows)
       if: startsWith(matrix.os, 'windows')
-      uses: Vampire/setup-wsl@v3.1.1
+      uses: Vampire/setup-wsl@v4.0.0
       with:
         distribution: Alpine
         additional-packages: bash

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -763,16 +763,13 @@ class TestGit(TestBase):
         from git.cmd import handle_process_output, safer_popen
 
         expected_line_count = 5002
-        line_counts = [None, 0, 0]
-        lines = [None, [], []]
+        actual_lines = [None, [], []]
 
         def stdout_handler(line):
-            line_counts[1] += 1
-            lines[1].append(line)
+            actual_lines[1].append(line)
 
         def stderr_handler(line):
-            line_counts[2] += 1
-            lines[2].append(line)
+            actual_lines[2].append(line)
 
         cmdline = [
             sys.executable,
@@ -789,8 +786,8 @@ class TestGit(TestBase):
 
         handle_process_output(proc, stdout_handler, stderr_handler, finalize_process)
 
-        self.assertEqual(line_counts[1], expected_line_count, repr(lines[1]))
-        self.assertEqual(line_counts[2], expected_line_count, repr(lines[2]))
+        self.assertEqual(len(actual_lines[1]), expected_line_count, repr(actual_lines[1]))
+        self.assertEqual(len(actual_lines[2]), expected_line_count, repr(actual_lines[2]))
 
     def test_execute_kwargs_set_agrees_with_method(self):
         parameter_names = inspect.signature(cmd.Git.execute).parameters.keys()

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -762,14 +762,17 @@ class TestGit(TestBase):
     def test_handle_process_output(self):
         from git.cmd import handle_process_output, safer_popen
 
-        line_count = 5002
-        count = [None, 0, 0]
+        expected_line_count = 5002
+        line_counts = [None, 0, 0]
+        lines = [None, [], []]
 
-        def counter_stdout(line):
-            count[1] += 1
+        def stdout_handler(line):
+            line_counts[1] += 1
+            lines[1].append(line)
 
-        def counter_stderr(line):
-            count[2] += 1
+        def stderr_handler(line):
+            line_counts[2] += 1
+            lines[2].append(line)
 
         cmdline = [
             sys.executable,
@@ -784,10 +787,10 @@ class TestGit(TestBase):
             shell=False,
         )
 
-        handle_process_output(proc, counter_stdout, counter_stderr, finalize_process)
+        handle_process_output(proc, stdout_handler, stderr_handler, finalize_process)
 
-        self.assertEqual(count[1], line_count)
-        self.assertEqual(count[2], line_count)
+        self.assertEqual(line_counts[1], expected_line_count, repr(lines[1]))
+        self.assertEqual(line_counts[2], expected_line_count, repr(lines[2]))
 
     def test_execute_kwargs_set_agrees_with_method(self):
         parameter_names = inspect.signature(cmd.Git.execute).parameters.keys()


### PR DESCRIPTION
This applies the fixes to GitPython that correspond to https://github.com/gitpython-developers/smmap/pull/58, as well as other fixes which were along the lines of the prediction in https://github.com/gitpython-developers/GitPython/commit/e51bf80ad576256f2fbeead41ea3f0b667c77055#commitcomment-150862474. Taken together, this fixes CI for GitPython.

The Cygwin and Alpine Linux failures were due to not using a virtual environment.

- In Cygwin, I had deliberately not done that, since we're not doing it the other non-container workflows, and I wanted the Cygwin workflow to be similar, with the hope that its job might even one day become a matrix job in `pythonpackage.yml`. But there had already been signs, accumulating over time, that this was not the way to go, such as the extra step to make sure there would be a `pip` command in the global environment. Ultimately, what not using a venv broke was `pytest-cov`, which didn't have a dependency it needed, even after all dependencies appeared to install okay. Using a venv fixed that automatically.

- In Alpine Linux, I was deliberately using a virtual environment, since `python` in Alpine Linux discourages using `pip` to install packages in the global environment managed by the system, which by default is automatically rejected, and which would not necessarily work well even if forced to happen. However, at some point, the virtual environment stopped actually being activated. This causes that error, which had previously only occurred in this workflow while it was originally being developled, to return.

  I am not clear on specifically why this happened, but I think it is due to the interaction between:

  1. The environment variables that are documented to be set when a venv is activated.
  2. Subtle distinctions between activating a venv in the usual way and setting those variables (maybe).
  3. How setting variables for steps via `GITHUB_ENV` composes with `sudo` passthrough.

  Of those, the third is the most significant: `sudo` is being used as the `shell` for most steps in this job, in order to run code as a non-root user (since some tests do not work when run as root and are not, if I recall correctly, intended to). But it was not configured to pass through variables related to Python virtual environments. I'm not sure what changed, exactly, but in hindsight I don't think I could ever have proved that it was *supposed* to work as I intended, when implemented the way I had. The fix here is slightly ugly in that it explicitly activates the venv in each of the steps that are supposed to use it, but I believe this is more simple and robust than alternatives I considered.

As for the other, unrelated Alpine problem in WSL, where the image didn't downloading, upgrading the setup-wsl action fixed it. (To do this, I cherry-picked a commit from the Dependabot PR that had proposed it.)

See commit messages for full details on each of the changes themselves.