### PR TITLE
Do some CI cleanup to make reports clearer and future changes easier

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -3,7 +3,7 @@ name: test-alpine
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     container:

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Cygwin
       uses: egor-tensin/setup-cygwin@v4
       with:
-        packages: python39=3.9.16-1 python39-pip python39-virtualenv git
+        packages: python39 python39-pip python39-virtualenv git
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -3,7 +3,7 @@ name: test-cygwin
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  test:
     runs-on: windows-latest
 
     strategy:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         os-type: [ubuntu, macos, windows]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,20 +12,21 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os-type: [ubuntu, macos, windows]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+        - os-type: macos
+          python-version: "3.7"
         include:
+        - os-ver: latest
+        - os-type: ubuntu
+          python-version: "3.7"
+          os-ver: "22.04"
         - experimental: false
-        - os: ubuntu-22.04
-          python-version: "3.7"
-          experimental: false
-        - os: windows-latest
-          python-version: "3.7"
-          experimental: false
 
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-type }}-${{ matrix.os-ver }}
 
     defaults:
       run:
@@ -43,7 +44,7 @@ jobs:
         allow-prereleases: ${{ matrix.experimental }}
 
     - name: Set up WSL (Windows)
-      if: startsWith(matrix.os, 'windows')
+      if: matrix.os-type == 'windows'
       uses: Vampire/setup-wsl@v4.0.0
       with:
         distribution: Alpine
@@ -80,7 +81,7 @@ jobs:
 
     # For debugging hook tests on native Windows systems that may have WSL.
     - name: Show bash.exe candidates (Windows)
-      if: startsWith(matrix.os, 'windows')
+      if: matrix.os-type == 'windows'
       run: |
         set +e
         bash.exe -c 'printenv WSL_DISTRO_NAME; uname -a'


### PR DESCRIPTION
Neither #1955 nor #1988 is ready yet, but both include commits that clean up CI and that I think are already valuable. Some of the changes make GitHub Actions checks easier to read (8a05390, 41377d5), while another removes some complexity that is no longer needed (73ddb22). So I cherry-picked those commits onto a new feature branch, which this PR proposes merging. If this is merged, I'll rebase those other PRs to drop the corresponding commits from them. Details on the changes are in the commit messages.