### PR TITLE
Test Python 3.13 regularly on Ubuntu and macOS on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,10 +13,12 @@ jobs:
     strategy:
       matrix:
         os-type: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
         - os-type: macos
-          python-version: "3.7"
+          python-version: "3.7"  # Not available for the ARM-based macOS runners.
+        - os-type: windows
+          python-version: "3.13"  # FIXME: Fix and enable Python 3.13 on Windows (#1955).
         include:
         - os-ver: latest
         - os-type: ubuntu


### PR DESCRIPTION
This enables testing Python 3.13 in the main CI test workflow for Ubuntu and macOS, as discussed in comments in #1989, but not Windows yet (pending #1955).

I think it makes sense to test these on CI, because:

- They're working now, and if they stop working, we would want to know.
- While Python 3.13 shouldn't be added as a classifier in `setup.py` yet since it's not fully working on Windows, testing other platforms on CI makes it easier for users to know they are meant (and believed) to work.
- The Ubuntu and macOS job are fast, so this probably isn't adding too much load, delay, energy usage, etc.