### PR TITLE
Affirm that gitdb and smmap advisories can also be created

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,6 @@ Only the latest version of GitPython can receive security updates. If a vulnerab
 
 ## Reporting a Vulnerability
 
-Please report private portions of a vulnerability to <https://github.com/gitpython-developers/GitPython/security/advisories/new>. Doing so helps to receive updates and collaborate on the matter, without disclosing it publicliy right away.
+Please report private portions of a vulnerability to <https://github.com/gitpython-developers/GitPython/security/advisories/new>. Doing so helps to receive updates and collaborate on the matter, without disclosing it publicly right away.
+
+Vulnerabilities in GitPython's dependencies [gitdb](https://github.com/gitpython-developers/gitdb/blob/main/SECURITY.md) or [smmap](https://github.com/gitpython-developers/smmap/blob/main/SECURITY.md), which primarily exist to support GitPython, can be reported here as well, at that same link. The affected package (`GitPython`, `gitdb`, or `smmap`) can be included in the report, if known.


### PR DESCRIPTION
This expands `SECURITY.md` to affirm the claims in the new `SECURITY.md` files in gitdb and smmap that vulnerabilities found in them can be reported in the GitPython repository with the same link as one would use to report a GitPython vulnerability, as well as to note how the distinction between affected package can be specified when it is known at the time a vulnerability is reported.

Along with https://github.com/gitpython-developers/smmap/pull/59 and https://github.com/gitpython-developers/gitdb/pull/117, this fixes https://github.com/gitpython-developers/gitdb/issues/116.