### PR TITLE
Work around Cygwin CI failure #2004, except for `test_installation`

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v5
       with:
-        packages: python39 python39-pip python39-virtualenv git
+        packages: python39 python39-pip python39-virtualenv git wget
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Set up virtualenv
       run: |
-        python -m venv .venv
+        python3.9 -m venv .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
 
     - name: Update PyPA packages

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v5
       with:
-        packages: python39 python39-pip python39-virtualenv git
+        packages: python39 python39-pip python39-virtualenv python39-wheel git
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -58,8 +58,12 @@ jobs:
 
     - name: Set up virtualenv
       run: |
-        python3.9 -m venv .venv
+        python3.9 -m venv --without-pip .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
+
+    - name: Install pip in virtualenv
+      run: |
+        python -m ensurepip
 
     - name: Update PyPA packages
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
     - name: Force LF line endings
@@ -27,10 +27,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Cygwin
-      uses: egor-tensin/setup-cygwin@v4
+    - name: Install Cygwin
+      uses: cygwin/cygwin-install-action@v5
       with:
         packages: python39 python39-pip python39-virtualenv git
+        add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v5
       with:
-        packages: python39 python39-pip python39-virtualenv python39-wheel git
+        packages: python39 python39-pip python39-virtualenv git
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
     - name: Arrange for verbose output
@@ -61,9 +61,9 @@ jobs:
         python3.9 -m venv --without-pip .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
 
-    - name: Install pip in virtualenv
+    - name: Bootstrap pip in virtualenv
       run: |
-        python -m ensurepip
+        wget -qO- https://bootstrap.pypa.io/get-pip.py | python
 
     - name: Update PyPA packages
       run: |


### PR DESCRIPTION
I don't have a complete fix for #2004 yet, but since it's confirmed to fail on the main branch of this upstream repository (mentioned in https://github.com/gitpython-developers/GitPython/pull/1988#issuecomment-2680840638, though not due to #1988), I figured my partial fix might be worth putting into place. With these changes, the problem in the Cygwin test job turns from being unable to run any tests to being able to run all the tests but with one new failure compared to the way it was before #2004 (i.e. with one non-xfail failure).

This uses the official `pip` bootstrap script https://bootstrap.pypa.io/get-pip.py to install `pip` in the virtual environment. This allows the actual installation of GitPython and its dependencies, including all test dependencies, to complete without problems. Aside from tests that are expected to fail and are already marked xfail, all tests pass *except* for `test_installation`, which fails for the same reason. It presumably would also pass if the bootstrap script were used there too, but I believe the current intent of that test is to verify that installation succeeds when done in an ordinary way.

I am likewise reluctant to mark `test_installation` as xfail on Cygwin, unless that turns out to be truly necessary, because none of this happens on my local Cygwin environment on a Windows 10 development machine. It seems like it is triggered by some combination of changing packages and something wrong or otherwise specific about the Cygwin workflow.

This PR includes some changes to the workflow that are not actually necessary for the workaround it confers. The changes that *are* needed are:

- Refraining from having `venv` automatically attempt to install `pip`.
- Installing `pip` in the virtual environment explicitly using the bootstrap script.
- Installing the `wget` Cygwin package to download the bootstrap script without extra complexity or risking encoding/line-ending mismatches.

All the rest is to make the workflow run a little faster, and *maybe* be slightly more robust in ways that are not relevant to #2004 and not very important. The most significant of them is switching back to the Cygwin installation action we had previously been using, which is less configurable (it does not support installing Cygwin packages at specific versions, which we had needed to do at one time), but which is faster because it does not first have to install Chocolatey to use it as an intermediary for installing Cygwin.

I kept those changes here because I think it's easier to iterate on this if it is left in. But if you'd like I'd be pleased to undo the nonessential changes, which can always be brought back later and separately. I have tested in 7fd5f15a02dfdd5f6471f6f290483b7c4bff34bc to make sure that this really works, so undoing those changes could be as simple as adding that one commit.