### PR TITLE
Mark `test_installation` xfail on Cygwin CI

### DIFF
--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -4,11 +4,19 @@
 import ast
 import os
 import subprocess
+import sys
+
+import pytest
 
 from test.lib import TestBase, VirtualEnvironment, with_rw_directory
 
 
 class TestInstallation(TestBase):
+    @pytest.mark.xfail(
+        sys.platform == "cygwin" and "CI" in os.environ,
+        reason="Trouble with pip on Cygwin CI, see issue #2004",
+        raises=subprocess.CalledProcessError,
+    )
     @with_rw_directory
     def test_installation(self, rw_dir):
         venv = self._set_up_venv(rw_dir)


### PR DESCRIPTION
Together with #2007, this works around #2004, allowing all tests to pass on Cygwin CI.

In #2007, installation of the environment in which tests run was fixed by downloading and running the `get-pip.py` bootstrap script. If we were to modify our helper that sets up the (separate) virtual environment in `test_installation` so that it does the same thing (or conditionally does so on CI, since the problem does not seem to happen in local installations), that would likely "fix" this more thoroughly, allowing the test to pass.

But part of the goal of the installation test is to test that installation works in a typical environment on the platform it runs on. So it is not obivous that making it pass in that way would be an improvement compared to marking it `xfail` with the exception type that occurs due to #2004. So this just does that, for now.

I don't know if this should be considered to close #2004 or not.