### PR TITLE
Use WSL1 on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,6 +49,7 @@ jobs:
       if: matrix.os-type == 'windows'
       uses: Vampire/setup-wsl@v4.1.1
       with:
+        wsl-version: 1
         distribution: Alpine
         additional-packages: bash
 


### PR DESCRIPTION
This avoids an occasional HTTP 403 error updating WSL for WSL2.

For details on that issue and possible approaches, see https://github.com/gitpython-developers/GitPython/pull/2008#pullrequestreview-2665805369.