### PR TITLE
Test free-threaded Python (but only on Linux)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,8 +17,12 @@ jobs:
         exclude:
         - os-type: macos
           python-version: "3.7"  # Not available for the ARM-based macOS runners.
+        - os-type: macos
+          python-version: "3.13t"
         - os-type: windows
           python-version: "3.13"  # FIXME: Fix and enable Python 3.13 on Windows (#1955).
+        - os-type: windows
+          python-version: "3.13t"
         include:
         - os-ver: latest
         - os-type: ubuntu

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os-type: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         exclude:
         - os-type: macos
           python-version: "3.7"  # Not available for the ARM-based macOS runners.
@@ -40,7 +40,16 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: |-
+        !endsWith(matrix.python-version, 't')
       uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: ${{ matrix.experimental }}
+
+    - name: Set up Python ${{ matrix.python-version }} (free-threaded)
+      if: endsWith(matrix.python-version, 't')
+      uses: Quansight-Labs/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: ${{ matrix.experimental }}


### PR DESCRIPTION
Fixes #2005

See commit messages for details:

- f1dbe33 describes why this uses the approach of using a different action (rather than `@main` or `@...` where `...` is an OID) for the `3.13t` job, and why that is expressed by splitting the step instead of introducing a new matrix variable.
- fd78857 describes why this only introduces it for Linux. The reason is not entirely the same as proposed in [#2005](https://github.com/gitpython-developers/GitPython/issues/2005), since it turns out that testing on other systems--in the way we do so here--works without any special effort.

(As elsewhere, due to #2004, the Cygwin test job should be expected to fail here until #2009 is merged. That is not related to the changes here.)