### PR TITLE
`IndexFile._to_relative_path` - fix case where absolute path gets stripped of trailing slash

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -655,7 +655,10 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             raise InvalidGitRepositoryError("require non-bare repository")
         if not osp.normpath(str(path)).startswith(str(self.repo.working_tree_dir)):
             raise ValueError("Absolute path %r is not in git repository at %r" % (path, self.repo.working_tree_dir))
-        return os.path.relpath(path, self.repo.working_tree_dir)
+        result = os.path.relpath(path, self.repo.working_tree_dir)
+        if str(path).endswith(os.sep) and not result.endswith(os.sep):
+            result += os.sep
+        return result
 
     def _preprocess_add_items(
         self, items: Union[PathLike, Sequence[Union[PathLike, Blob, BaseIndexEntry, "Submodule"]]]


### PR DESCRIPTION
I encountered this issue on MacOS, python 3.7 and later

Added fix and appropriate unit test.

Stripping of trailing slash seems to be happening in `os.path.relpath`, altough I am not sure whether that is expected behaviour. In case it is not expected, and ever gets fixed, I added an additional check (` and not result.endswith(os.sep)`) to make sure that the trailing slash doesn't get duplicated.