### PR TITLE
correctly handle `uname-cmd` that doesn't point to an executable file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,5 +55,6 @@ Contributors are:
 -Eliah Kagan <eliah.kagan _at_ gmail.com>
 -Ethan Lin <et.repositories _at_ gmail.com>
 -Jonas Scharpf <jonas.scharpf _at_ checkmk.com>
+-Gordon Marx
 
 Portions derived from other open source works and are clearly marked.

--- a/git/util.py
+++ b/git/util.py
@@ -463,7 +463,13 @@ def _is_cygwin_git(git_executable: str) -> bool:
                 git_dir = osp.dirname(res[0]) if res else ""
 
             # Just a name given, not a real path.
+            # Let's see if the same path has uname
             uname_cmd = osp.join(git_dir, "uname")
+            if not (osp.isfile(uname_cmd) and os.access(uname_cmd, os.X_OK)):
+                _logger.debug(f"File {uname_cmd} either does not exist or is not executable.")
+                _is_cygwin_cache[git_executable] = is_cygwin
+                return is_cygwin
+
             process = subprocess.Popen([uname_cmd], stdout=subprocess.PIPE, universal_newlines=True)
             uname_out, _ = process.communicate()
             # retcode = process.poll()

--- a/git/util.py
+++ b/git/util.py
@@ -465,7 +465,7 @@ def _is_cygwin_git(git_executable: str) -> bool:
             # Just a name given, not a real path.
             uname_cmd = osp.join(git_dir, "uname")
 
-            if not (pathlib.Path(uname_cmd).exists() and os.access(uname_cmd, os.X_OK)):
+            if not (pathlib.Path(uname_cmd).isfile() and os.access(uname_cmd, os.X_OK)):
                 _logger.debug(f"Failed checking if running in CYGWIN: {uname_cmd} is not an executable")
                 _is_cygwin_cache[git_executable] = is_cygwin
                 return is_cygwin

--- a/git/util.py
+++ b/git/util.py
@@ -463,13 +463,7 @@ def _is_cygwin_git(git_executable: str) -> bool:
                 git_dir = osp.dirname(res[0]) if res else ""
 
             # Just a name given, not a real path.
-            # Let's see if the same path has uname
             uname_cmd = osp.join(git_dir, "uname")
-            if not (osp.isfile(uname_cmd) and os.access(uname_cmd, os.X_OK)):
-                _logger.debug(f"File {uname_cmd} either does not exist or is not executable.")
-                _is_cygwin_cache[git_executable] = is_cygwin
-                return is_cygwin
-
             process = subprocess.Popen([uname_cmd], stdout=subprocess.PIPE, universal_newlines=True)
             uname_out, _ = process.communicate()
             # retcode = process.poll()

--- a/git/util.py
+++ b/git/util.py
@@ -490,7 +490,7 @@ def is_cygwin_git(git_executable: PathLike) -> bool: ...
 
 
 def is_cygwin_git(git_executable: Union[None, PathLike]) -> bool:
-    if sys.platform == "win32":  # TODO: See if we can use `sys.platform != "cygwin"`.
+    if sys.platform != "cygwin":
         return False
     elif git_executable is None:
         return False

--- a/git/util.py
+++ b/git/util.py
@@ -464,6 +464,12 @@ def _is_cygwin_git(git_executable: str) -> bool:
 
             # Just a name given, not a real path.
             uname_cmd = osp.join(git_dir, "uname")
+
+            if not (pathlib.Path(uname_cmd).exists() and os.access(uname_cmd, os.X_OK)):
+                _logger.debug(f"Failed checking if running in CYGWIN: {uname_cmd} is not an executable")
+                _is_cygwin_cache[git_executable] = is_cygwin
+                return is_cygwin
+
             process = subprocess.Popen([uname_cmd], stdout=subprocess.PIPE, universal_newlines=True)
             uname_out, _ = process.communicate()
             # retcode = process.poll()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -34,6 +34,7 @@ from git.util import (
     LockFile,
     cygpath,
     decygpath,
+    is_cygwin_git,
     get_user_id,
     remove_password_if_present,
     rmtree,
@@ -347,6 +348,24 @@ class TestCygpath:
     def test_decygpath(self, wpath, cpath):
         wcpath = decygpath(cpath)
         assert wcpath == wpath.replace("/", "\\"), cpath
+
+
+class TestIsCygwinGit:
+    """Tests for :func:`is_cygwin_git`"""
+
+    def test_on_path_executable(self):
+        match sys.platform:
+            case "cygwin":
+                assert is_cygwin_git("git")
+            case _:
+                assert not is_cygwin_git("git")
+
+    def test_none_executable(self):
+        assert not is_cygwin_git(None)
+
+    def test_with_missing_uname(self):
+        """Test for handling when `uname` isn't in the same directory as `git`"""
+        assert not is_cygwin_git("/bogus_path/git")
 
 
 class _Member:


### PR DESCRIPTION
I also ran into the issue from https://github.com/gitpython-developers/GitPython/issues/1979. My proposed solution is that `GitPython` should only try to run `uname_cmd` if it points to an executable file. I also wrote a short test class for the `is_cygwin_git` function. I don't have a machine with Cygwin, so I can't test that it actually does work, but I trust the [Python docs](https://docs.python.org/3/library/sys.html#sys.platform) when they say that on Cygwin, `sys.platform` will be `cygwin`.