### PR TITLE
use `sys.platform == "cygwin"` to figure out when we are using cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 # Transient editor files
 *.swp
 *~
+\#*#
+.#*#
 
 # Editor configuration
 nbproject

--- a/AUTHORS
+++ b/AUTHORS
@@ -55,5 +55,6 @@ Contributors are:
 -Eliah Kagan <eliah.kagan _at_ gmail.com>
 -Ethan Lin <et.repositories _at_ gmail.com>
 -Jonas Scharpf <jonas.scharpf _at_ checkmk.com>
+-Gordon Marx
 
 Portions derived from other open source works and are clearly marked.

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -32,7 +32,6 @@ from git.exc import (
 from git.util import (
     cygpath,
     expand_path,
-    is_cygwin_git,
     patch_env,
     remove_password_if_present,
     stream_copy,
@@ -661,7 +660,7 @@ class Git(metaclass=_GitMeta):
 
     @classmethod
     def is_cygwin(cls) -> bool:
-        return is_cygwin_git(cls.GIT_PYTHON_GIT_EXECUTABLE)
+        return cls.GIT_PYTHON_GIT_EXECUTABLE is not None and sys.platform == "cygwin"
 
     @overload
     @classmethod


### PR DESCRIPTION
The current logic for detecting cygwin is:
- if `sys.platform == "win32"`, then it's not cygwin
- if the passed-in git executable is None, then it's not cygwin git
- finally, is there a `uname` executable in the same folder as the git executable, and if so, does the output of that command include `"CYGWIN"`? if so, then it's cygwin

In the [python 3.7 docs for sys.platform](https://docs.python.org/3.7/library/sys.html#sys.platform), Cygwin systems have `sys.platform == "cygwin"`. Since Python 3.7 is the oldest version still supported by GitPython, it stands to reason that we can rely on that being true for all supported Python versions.

The logic I propose is:
- if the git executable you passed in is None, it's not cygwin git
- if `sys.platform == 'cygwin'`, then it's cygwin git

This is simple enough for a single expression, so I replaced the body of the `is_cygwin` function with that expression and removed `is_cygwin_git` and friends completely.

I don't know if there's such a thing as `sys.platform == 'cygwin'` and the `git` not being cygwin `git`, but if there is, I don't think the existing code deals with that anyway, so this seems to return the same result and would fail in the same way.