### PR TITLE
Use newer ruff style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     additional_dependencies: [tomli]
     exclude: ^test/fixtures/
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.0
+  rev: v0.11.12
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: ["--fix"]
     exclude: ^git/ext/
   - id: ruff-format
@@ -23,7 +23,7 @@ repos:
     exclude: ^test/fixtures/polyglot$|^git/ext/
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: end-of-file-fixer
     exclude: ^test/fixtures/|COPYING|LICENSE
@@ -33,6 +33,6 @@ repos:
   - id: check-merge-conflict
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: v0.19
+  rev: v0.24.1
   hooks:
   - id: validate-pyproject

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -207,7 +207,7 @@ def handle_process_output(
                 )
             if stderr_handler:
                 error_str: Union[str, bytes] = (
-                    "error: process killed because it timed out." f" kill_after_timeout={kill_after_timeout} seconds"
+                    f"error: process killed because it timed out. kill_after_timeout={kill_after_timeout} seconds"
                 )
                 if not decode_streams and isinstance(p_stderr, BinaryIO):
                     # Assume stderr_handler needs binary input.
@@ -1319,7 +1319,7 @@ class Git(metaclass=_GitMeta):
                 out, err = proc.communicate()
                 watchdog.cancel()
                 if kill_check.is_set():
-                    err = 'Timeout: the command "%s" did not complete in %d ' "secs." % (
+                    err = 'Timeout: the command "%s" did not complete in %d secs.' % (
                         " ".join(redacted_command),
                         timeout,
                     )

--- a/git/refs/log.py
+++ b/git/refs/log.py
@@ -126,7 +126,7 @@ class RefLogEntry(Tuple[str, str, Actor, Tuple[int, int], str]):
         elif len(fields) == 2:
             info, msg = fields
         else:
-            raise ValueError("Line must have up to two TAB-separated fields." " Got %s" % repr(line_str))
+            raise ValueError("Line must have up to two TAB-separated fields. Got %s" % repr(line_str))
         # END handle first split
 
         oldhexsha = info[:40]

--- a/git/repo/fun.py
+++ b/git/repo/fun.py
@@ -405,7 +405,7 @@ def rev_parse(repo: "Repo", rev: str) -> AnyGitObject:
             # END end handle tag
         except (IndexError, AttributeError) as e:
             raise BadName(
-                f"Invalid revision spec '{rev}' - not enough " f"parent commits to reach '{token}{int(num)}'"
+                f"Invalid revision spec '{rev}' - not enough parent commits to reach '{token}{int(num)}'"
             ) from e
         # END exception handling
     # END parse loop

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -747,7 +747,7 @@ class TestGit(TestBase):
 
         path = osp.join(rw_dir, "failing-script.sh")
         with open(path, "wt") as stream:
-            stream.write("#!/usr/bin/env sh\n" "echo FOO\n")
+            stream.write("#!/usr/bin/env sh\necho FOO\n")
         os.chmod(path, 0o777)
 
         rw_repo = Repo.init(osp.join(rw_dir, "repo"))

--- a/test/test_quick_doc.py
+++ b/test/test_quick_doc.py
@@ -173,7 +173,7 @@ class QuickDoc(TestBase):
         # [15-test_cloned_repo_object]
         def print_files_from_git(root, level=0):
             for entry in root:
-                print(f'{"-" * 4 * level}| {entry.path}, {entry.type}')
+                print(f"{'-' * 4 * level}| {entry.path}, {entry.type}")
                 if entry.type == "tree":
                     print_files_from_git(entry, level + 1)
 


### PR DESCRIPTION
This updates `ruff` in `.pre-commit-config.yaml` from 0.6.0 to 0.11.12, changes its `id` from the legacy `ruff` alias to `ruff-check` (which is better distinguished from `ruff-format`, which we also have a hook for), and applies the few style changes it newly recommends throughout the code. The style changes seem to make things slightly clearer overall.

This also updates some other pre-commit hooks, but those don't require any changes to the code.

Currently the `ruff` dependency in `requirements-dev.txt` doesn't specify a version, so no change is needed there. This update may be seen as bringing the `pre-commit` version in line with what users will usually have locally with `pip install -e ".[test]"`.

The `pre-commit` hooks are how linting is currently done on CI, so this is updating `ruff` for CI. That's the most significant effect of this change. (`pre-commit` is run for linting on CI probably much more often than it is used locally, to manage pre-commit hooks or otherwise, in GitPython development.)

---

This works locally and [on CI](https://github.com/gitpython-developers/GitPython/actions/runs/15351790822/job/43201580519?pr=2031#step:4:92), but I'll still wait for all checks to pass before merging.