### PR TITLE
Specify explicit `contents: read` workflow permissions

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -2,6 +2,9 @@ name: test-alpine
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -2,6 +2,9 @@ name: test-cygwin
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specify explicit `contents: read` workflow permissions

Three CI workflows that need only `contents: read` permissions and no other permissions did not have explicit permissions set, and would therefore be given default permissions configured for the repository, which might be more expansive than the workflows need.

[It is recommended][1] to set explicit workflow permissions. This does that, specifying permissions as `pythonpackage.yml` already did, and closing three `actions/missing-workflow-permissions` CodeQL alerts (new since #2032 enabled scanning of GHA workflows).

[1]: https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/

---

I'll merge this once I verify that all CI checks still pass.