### PR TITLE
Preserve quoted leading and trailing single-line config var whitespace

### DIFF
--- a/test/fixtures/git_config_with_quotes_whitespace
+++ b/test/fixtures/git_config_with_quotes_whitespace
@@ -1,0 +1,2 @@
+[core]
+  commentString = "# "

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -412,6 +412,10 @@ class TestBase(TestCase):
         self.assertEqual(cr.get("user", "name"), "Cody Veal")
         self.assertEqual(cr.get("user", "email"), "cveal05@gmail.com")
 
+    def test_config_with_quotes_with_literal_whitespace(self):
+        cr = GitConfigParser(fixture_path("git_config_with_quotes_whitespace"), read_only=True)
+        self.assertEqual(cr.get("core", "commentString"), "# ")
+
     def test_get_values_works_without_requiring_any_other_calls_first(self):
         file_obj = self._to_memcache(fixture_path("git_config_multiple"))
         cr = GitConfigParser(file_obj, read_only=True)


### PR DESCRIPTION
#2035 fixed issue #1923 by removing separate double quotation marks appearing on a single-line configuration variable when parsing a configuration file. However, as noted in https://github.com/gitpython-developers/GitPython/pull/2035#discussion_r2133342762, it also stripped leading and trailing whitespace from the string obtained by removing the quotes.

In this PR:

1. 5f303202ee0666f5298ff39a5a129162b69ff790 adds a test case of a plausible--and in my view, decisive--scenario where such whitespace needs to be preserved and where a user would almost certainly expect it to preserve. This test would also have failed before [#2035](https://github.com/gitpython-developers/GitPython/pull/2035), due to the absence of quote removal. But it is the sort of value that one would expect to parse correctly now that [#1923](https://github.com/gitpython-developers/GitPython/issues/1923) is fixed, and which [#2035](https://github.com/gitpython-developers/GitPython/pull/2035) *almost* does parse correctly.
2. bd2b930503ad5d97322aa81d7610ab743d915f84 fixes the case by removing the `strip()` call while leaving the changes from [#2035](https://github.com/gitpython-developers/GitPython/pull/2035) otherwise intact. The test added in (1) fails until this change, and then passes.

See the commit message for further details.