### PR TITLE
Fix Git.{AutoInterrupt,CatFileContentStream} static typing

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -55,6 +55,7 @@ from typing import (
     TYPE_CHECKING,
     TextIO,
     Tuple,
+    TypeAlias,
     Union,
     cast,
     overload,
@@ -952,9 +953,9 @@ class Git(metaclass=_GitMeta):
                         f"{unsafe_option} is not allowed, use `allow_unsafe_options=True` to allow it."
                     )
 
-    AutoInterrupt = _AutoInterrupt
+    AutoInterrupt: TypeAlias = _AutoInterrupt
 
-    CatFileContentStream = _CatFileContentStream
+    CatFileContentStream: TypeAlias = _CatFileContentStream
 
     def __init__(self, working_dir: Union[None, PathLike] = None) -> None:
         """Initialize this instance with:

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -55,11 +55,15 @@ from typing import (
     TYPE_CHECKING,
     TextIO,
     Tuple,
-    TypeAlias,
     Union,
     cast,
     overload,
 )
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 from git.types import Literal, PathLike, TBD
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gitdb>=4.0.1,<5
-typing-extensions>=3.7.4.3;python_version<"3.8"
+typing-extensions>=3.10.0.2;python_version<"3.10"


### PR DESCRIPTION
Fixes #2038

This fixes `mypy` for `Git.AutoInterrupt` and `Git.CatFileContentStream`. Static type checking of these was broken inadvertently in #2037, as described in #2038. This is approach (2) described in #2038. Further details are in that bug report and in the commit messages.

As in #2037, I've made sure this doesn't break Sphinx (though it would be very strange if it did), by checking locally as well as in the RTD cloud build. The entries in the latter can be examined: [`AutoInterrupt`](https://gitpython--2039.org.readthedocs.build/en/2039/reference.html#git.cmd.Git.AutoInterrupt), [`CatFileContentStream`](https://gitpython--2039.org.readthedocs.build/en/2039/reference.html#git.cmd.Git.CatFileContentStream).

Because CI runs `mypy` but does not verify its output, I'll wait to mark this non-draft until I've looked at all relevant jobs' `mypy` steps. (But this may be before the jobs complete, since the jobs that run `mypy` do so before running `pytest`, not after.)

*Edit:* All `mypy` results on CI look as they did before, and then new errors that came in with #2037 are gone.