### PR TITLE
Fix CI `mypy` command on free-threaded Python

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -97,10 +97,11 @@ jobs:
 
     - name: Check types with mypy
       run: |
-        mypy --python-version=${{ matrix.python-version }}
+        mypy --python-version="${PYTHON_VERSION%t}"
       env:
         MYPY_FORCE_COLOR: "1"
         TERM: "xterm-256color"  # For color: https://github.com/python/mypy/issues/13817
+        PYTHON_VERSION: ${{ matrix.python-version }}
       # With new versions of mypy new issues might arise. This is a problem if there is
       # nobody able to fix them, so we have to ignore errors until that changes.
       continue-on-error: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Check types with mypy
       run: |
-        mypy --python-version="${PYTHON_VERSION%t}"
+        mypy --python-version="${PYTHON_VERSION%t}"  # Version only, with no "t" for free-threaded.
       env:
         MYPY_FORCE_COLOR: "1"
         TERM: "xterm-256color"  # For color: https://github.com/python/mypy/issues/13817


### PR DESCRIPTION
When the version is represented as `3.13t`, the `--python-version` option needs an operand of `3.13`, not `3.13t`.

(This, and the fix here, will automatically apply to later threaded Pythons, such as 3.14t, too.)

---

Before this change, [in the Python 3.13t run](https://github.com/gitpython-developers/GitPython/actions/runs/15509622156/job/43668845392#step:11:14):

```text
+ mypy --python-version=3.13t
usage: mypy [-h] [-v] [-V] [more options; see below]
            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: argument --python-version: Invalid python version '3.13t' (expected format: 'x.y')
```

This isn't new--it's always happened in the `mypy` step in the 3.13t job. We just never noticed it, because the `mypy` step always reports failure even when working correctly, because there are a number of unresolved type errors, most of which should not be suppressed but that neither I nor others have get gotten around yet to fixing, and some of which maybe should be suppressed but neither I nor others have gotten around yet to verifying are reasonable to suppress. (For quite some time, the `mypy` step has step-level `continue-on-error`, which causes it not to fail the job.)

There's no connection between this and #2037 or #2038/#2039, except in the broad conceptual sense that this and #2038 share as a contributing factor that it's easy not to notice unanticipated new problems with `mypy`. However, just in case, I have verified that the effect of #2039 applies the same to 3.13t as to 3.13, by first testing this on a feature branch that had not integrated #2039, and then rebasing.

No change is needed in `tox.ini`, even separately from that not yet listing a `py313t` environment, because `tox.ini` as currently written does not pass a `--python-version` argument to `mypy`.

I plan to merge this once everything passes on CI, after also verifying again that the output is as expected.

*Edit:* The effect is as expected and intended. I'll just wait for the rest of CI to pass before merging.