### PR TITLE
Split Cygwin CI into non-`performance` and `performance` test jobs

### DIFF
--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -16,7 +16,7 @@ jobs:
         - selection: fast
           additional-pytest-args: --ignore=test/performance
         - selection: perf
-          additional-pytest-args: test/performance/
+          additional-pytest-args: test/performance
 
       fail-fast: false
 

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -93,6 +93,6 @@ jobs:
         python --version
         python -c 'import os, sys; print(f"sys.platform={sys.platform!r}, os.name={os.name!r}")'
 
-    - name: Test with pytest
+    - name: Test with pytest (${{ matrix.additional-pytest-args }})
       run: |
         pytest --color=yes -p no:sugar --instafail -vv ${{ matrix.additional-pytest-args }}

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      matrix:
+        selection: [fast, perf]
+        include:
+        - selection: fast
+          additional-pytest-args: --ignore=test/performance
+        - selection: perf
+          additional-pytest-args: test/performance/
+
       fail-fast: false
 
     env:
@@ -87,4 +95,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --color=yes -p no:sugar --instafail -vv
+        pytest --color=yes -p no:sugar --instafail -vv ${{ matrix.additional-pytest-args }}


### PR DESCRIPTION
One job is for all tests except the `performance` tests, while the other job is for only the `performance` tests.

The idea is to decrease the total time it takes for all CI jobs to complete in most cases, by splitting the long-running (currently usually about 13 minute) Cygwin job into two less-long jobs.

[This seems to work well.](https://github.com/EliahKagan/GitPython/actions/runs/15510202755/job/43670134782) The performance tests take longer than all the other tests combined. Even with the other steps--mainly setting up Cygwin--taking about 2.5 minutes, this still completes significantly faster than before by allowing the jobs to run in parallel.

A secondary advantage is that incomplete results of tests that are more often of interest can be seen sooner. (I say that's secondary because it could alternatively have been achieved by using a plugin that allow the order of the tests to be specified, and running the performance tests last.)

I'll wait for them to complete here in this PR, and I'll look at the timings, to make sure that wasn't a fluke (also because I would not want to merge a PR whose CI isn't passing, without good reason).

---

*Edit:* Yes, the longer of the jobs still completes 4 minutes sooner than the combined test would have completed. (Extrapolating this to future runs presumes that there will not usually be a huge queue of jobs for a Windows runner, or that there will not be a huge queue in the situations where one most wants jobs to complete faster. I think this is a reasonable assumption, but definitely one that should be open to challenge or revision.) All non-xfail tests continue to pass and the output remains readable.

However, before merging this, I'm going to experiment with showing the arguments in the step name, which I suspect may make the jobs easier to distinguish from each other when glancing at their steps.