### PR TITLE
Fix ambiguous `_safer_popen_windows` comment

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -273,12 +273,12 @@ if sys.platform == "win32":
         if shell:
             # The original may be immutable, or the caller may reuse it. Mutate a copy.
             env = {} if env is None else dict(env)
-            env["NoDefaultCurrentDirectoryInExePath"] = "1"  # The "1" can be an value.
+            env["NoDefaultCurrentDirectoryInExePath"] = "1"  # The "1" can be any value.
 
         # When not using a shell, the current process does the search in a
         # CreateProcessW API call, so the variable must be set in our environment. With
         # a shell, that's unnecessary if https://github.com/python/cpython/issues/101283
-        # is patched. In Python versions where it is unpatched, and in the rare case the
+        # is patched. In Python versions where it is unpatched, in the rare case the
         # ComSpec environment variable is unset, the search for the shell itself is
         # unsafe. Setting NoDefaultCurrentDirectoryInExePath in all cases, as done here,
         # is simpler and protects against that. (As above, the "1" can be any value.)


### PR DESCRIPTION
This fixes some ambiguous wording in a comment in `_safer_popen_wording`, where it was unclear if the secondary problem – where it would be possible to run a wrong `cmd.exe`-type shell – would happen under two separate circumstances, or only when both circumstances occurred together. This adjusts its wording to make clear that it is the latter.

This also fixes a minor typo in another `_safer_popen_windows` comment.

This might be viewed as building on the improvements in b9d9e56 (#1859), but the changes here are to comments only.

(I'll merge this once CI passes on it.)