### PR TITLE
Clarify `USE_SHELL` warning helper signature

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -550,7 +550,7 @@ _USE_SHELL_DANGER_MESSAGE = (
 )
 
 
-def _warn_use_shell(extra_danger: bool) -> None:
+def _warn_use_shell(*, extra_danger: bool) -> None:
     warnings.warn(
         _USE_SHELL_DANGER_MESSAGE if extra_danger else _USE_SHELL_DEFAULT_MESSAGE,
         DeprecationWarning,
@@ -566,12 +566,12 @@ class _GitMeta(type):
 
     def __getattribute(cls, name: str) -> Any:
         if name == "USE_SHELL":
-            _warn_use_shell(False)
+            _warn_use_shell(extra_danger=False)
         return super().__getattribute__(name)
 
     def __setattr(cls, name: str, value: Any) -> Any:
         if name == "USE_SHELL":
-            _warn_use_shell(value)
+            _warn_use_shell(extra_danger=value)
         super().__setattr__(name, value)
 
     if not TYPE_CHECKING:
@@ -988,7 +988,7 @@ class Git(metaclass=_GitMeta):
 
     def __getattribute__(self, name: str) -> Any:
         if name == "USE_SHELL":
-            _warn_use_shell(False)
+            _warn_use_shell(extra_danger=False)
         return super().__getattribute__(name)
 
     def __getattr__(self, name: str) -> Any:


### PR DESCRIPTION
This is a minor refactor of how `_warn_use_shell` can be, and is, invoked.

The `_warn_use_shell` helper function in `git.cmd` takes a single `bool`-valued argument `extra_danger`, which is conceptually associated with having a `True` value of `USE_SHELL`, but the association is not necessarily obvious. Specifically:

- For the warning given when reading `USE_SHELL` on the `Git` class or through an instance, `extra_danger` is always `False`. This is so even if the `USE_SHELL` value is currently `True`, because the danger that arises from `True` occurs internally.
- For the warning given when writing `USE_SHELL`, which can only be done on the `Git` class and not on or through an instance, `extra_danger` is the value set for the attribute. This is because setting `USE_SHELL` to `True` incurs the danger described in [#1896](https://github.com/gitpython-developers/GitPython/discussions/1896).

When reading the code, which passed `extra_danger` positionally, the meaning of the parameter may not always have been obvious.

This makes the `extra_danger` parameter keyword-only, and passes it by keyword in all invocations, so that its meaning is clearer.