### PR TITLE
Remove explicit empty `""` handling in ConfigParser

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -501,9 +501,6 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                         if pos != -1 and optval[pos - 1].isspace():
                             optval = optval[:pos]
                     optval = optval.strip()
-                    if optval == '""':
-                        optval = ""
-                    # END handle empty string
                     optname = self.optionxform(optname.rstrip())
                     if len(optval) > 1 and optval[0] == '"' and optval[-1] != '"':
                         is_multi_line = True

--- a/test/fixtures/git_config_with_empty_quotes
+++ b/test/fixtures/git_config_with_empty_quotes
@@ -1,0 +1,2 @@
+[core]
+  filemode = ""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -416,6 +416,10 @@ class TestBase(TestCase):
         self.assertEqual(cr.get("user", "name"), "Cody Veal")
         self.assertEqual(cr.get("user", "email"), "cveal05@gmail.com")
 
+    def test_config_with_empty_quotes(self):
+        cr = GitConfigParser(fixture_path("git_config_with_empty_quotes"), read_only=True)
+        self.assertEqual(cr.get("core", "filemode"), "", "quotes can form a literal empty string as value")
+
     def test_config_with_quotes_with_literal_whitespace(self):
         cr = GitConfigParser(fixture_path("git_config_with_quotes_whitespace_inside"), read_only=True)
         self.assertEqual(cr.get("core", "commentString"), "# ")


### PR DESCRIPTION
One of the benefits of #2035 is that it automatically handles a quoted empty value, i.e. `name = ""`, correctly. Previously, this was handled as a special case, so that it would work even though other quoted values did not work (#1923). Since #2035, it is not necessary to handle it specially. Accordingly, this PR:

- Adds a regression test for values represented as `""` (4ebe407493363a814f590a97f3734364e6c5c1e1).
- Removes the obsolete special-case logic (2f225244286567b72c865fc7c0219c7dc043575f).