### PR TITLE
Fix Cygwin installation on CI for `pip`

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -47,13 +47,12 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Set up virtualenv
+    - name: Set up virtual environment
       run: |
         python -m venv .venv
 
     - name: Update PyPA packages
       run: |
-        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
         . .venv/bin/activate
         python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -7,8 +7,6 @@ permissions:
 
 jobs:
   test:
-    runs-on: windows-latest
-
     strategy:
       matrix:
         selection: [fast, perf]
@@ -19,6 +17,8 @@ jobs:
           additional-pytest-args: test/performance
 
       fail-fast: false
+
+    runs-on: windows-latest
 
     env:
       CHERE_INVOKING: "1"
@@ -32,7 +32,7 @@ jobs:
     - name: Force LF line endings
       run: |
         git config --global core.autocrlf false  # Affects the non-Cygwin git.
-      shell: bash  # Use Git Bash instead of Cygwin Bash for this step.
+      shell: pwsh  # Do this outside Cygwin, to affect actions/checkout.
 
     - uses: actions/checkout@v4
       with:
@@ -67,7 +67,7 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Set up virtualenv
+    - name: Set up virtual environment
       run: |
         python3.9 -m venv --without-pip .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
@@ -78,7 +78,6 @@ jobs:
 
     - name: Update PyPA packages
       run: |
-        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
         python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 
     - name: Install project and test dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -71,7 +71,6 @@ jobs:
 
     - name: Update PyPA packages
       run: |
-        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
         python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 
     - name: Install project and test dependencies


### PR DESCRIPTION
This changes to the `*-wheel` Cygwin packages on Cygwin CI, providing the necessary files for `ensurepip` to work by fixing the error described in https://github.com/gitpython-developers/GitPython/issues/2004#issuecomment-2680952800. This is a true fix for #2004, and thus an improvement on the workarounds in #2007 and #2009. In particular, this allows `test_installation` to run and pass; accordingly, it is no longer marked `xfail`. (Whether this would also fix the problem for Python 3.12 when an effort like #1988 is picked back up is uncertain.) See 8e24edfb4688180287c970b023516c2b71946778 for full details.

This also does some minor housekeeping of the CI workflows in 66955cc76a9b33716baa6bdcc575d0446cf9175e.