### PR TITLE
feat: Add support for hasconfig git rule.

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -66,7 +66,7 @@ _logger = logging.getLogger(__name__)
 CONFIG_LEVELS: ConfigLevels_Tup = ("system", "user", "global", "repository")
 """The configuration level of a configuration file."""
 
-CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbranch):(.+)\"")
+CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbranch|hasconfig:remote\.\*\.url):(.+)\"")
 """Section pattern to detect conditional includes.
 
 See: https://git-scm.com/docs/git-config#_conditional_includes
@@ -590,7 +590,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
                 if fnmatch.fnmatchcase(branch_name, value):
                     paths += self.items(section)
-
+            elif keyword == "hasconfig:remote.*.url":
+                for remote in self._repo.remotes:
+                    if fnmatch.fnmatch(remote.url, value):
+                        paths += self.items(section)
+                        break
         return paths
 
     def read(self) -> None:  # type: ignore[override]

--- a/git/config.py
+++ b/git/config.py
@@ -592,7 +592,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     paths += self.items(section)
             elif keyword == "hasconfig:remote.*.url":
                 for remote in self._repo.remotes:
-                    if fnmatch.fnmatch(remote.url, value):
+                    if fnmatch.fnmatchcase(remote.url, value):
                         paths += self.items(section)
                         break
         return paths


### PR DESCRIPTION
Support adding custom paths for the following git config:

```
# Anonymous user override
[includeIf "hasconfig:remote.*.url:**/**github.com*/**"]
	path = ~/.personal.gitconfig
```

According to the documentation:

> As for the naming of this keyword, it is for forwards compatibility with a naming scheme that supports more variable-based include conditions, but currently Git only supports the exact keyword described above.

So I have matched the condition exactly word to word with `hasconfig:remote.*.url`. I then go over the list of remotes and find using `fnmatchcase` the correct remote (not sure if `fnmatch`. 

Maybe a list of open points here:

- I'm not sure if the wildcard format and the fnmatch function are equivalent. Is it necessary to match these two 100%? Maybe a maintainer would have more experience with
- Should I write more test cases?
- Write a couple of cases which are handled by both git binary and gitpython and compare the two.

Closes #2017 