### PR TITLE
Use actual return type in annotation for method submodule_update

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -520,7 +520,7 @@ class Repo:
         """
         return RootModule(self).traverse(*args, **kwargs)
 
-    def submodule_update(self, *args: Any, **kwargs: Any) -> Iterator[Submodule]:
+    def submodule_update(self, *args: Any, **kwargs: Any) -> RootModule:
         """Update the submodules, keeping the repository consistent as it will
         take the previous state into consideration.
 


### PR DESCRIPTION
Fixes #2077 "Return type mismatch in repo.submodule_update()"