### PR TITLE
Fix diff parsing to support mnemonicPrefix configuration

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -371,7 +371,7 @@ class Diff:
 
     # Precompiled regex.
     # Note: The path prefixes support both default (a/b) and mnemonicPrefix mode
-    # which can use prefixes like c/ (commit), w/ (worktree), i/ (index), o/ (object)
+    # which can use prefixes like c/ (commit), w/ (worktree), i/ (index), o/ (object), and h/ (HEAD)
     re_header = re.compile(
         rb"""
                                 ^diff[ ]--git

--- a/git/diff.py
+++ b/git/diff.py
@@ -116,7 +116,7 @@ def decode_path(path: bytes, has_ab_prefix: bool = True) -> Optional[bytes]:
         # Support standard (a/b) and mnemonicPrefix (c/w/i/o/h) prefixes
         # See git-config diff.mnemonicPrefix documentation
         valid_prefixes = (b"a/", b"b/", b"c/", b"w/", b"i/", b"o/", b"h/")
-        assert any(path.startswith(p) for p in valid_prefixes), f"Unexpected path prefix: {path[:10]}"
+        assert any(path.startswith(p) for p in valid_prefixes), f"Unexpected path prefix: {path[:10]!r}"
         path = path[2:]
 
     return path

--- a/git/diff.py
+++ b/git/diff.py
@@ -113,7 +113,10 @@ def decode_path(path: bytes, has_ab_prefix: bool = True) -> Optional[bytes]:
     path = _octal_byte_re.sub(_octal_repl, path)
 
     if has_ab_prefix:
-        assert path.startswith(b"a/") or path.startswith(b"b/")
+        # Support standard (a/b) and mnemonicPrefix (c/w/i/o/h) prefixes
+        # See git-config diff.mnemonicPrefix documentation
+        valid_prefixes = (b"a/", b"b/", b"c/", b"w/", b"i/", b"o/", b"h/")
+        assert any(path.startswith(p) for p in valid_prefixes), f"Unexpected path prefix: {path[:10]}"
         path = path[2:]
 
     return path
@@ -367,10 +370,12 @@ class Diff:
     """
 
     # Precompiled regex.
+    # Note: The path prefixes support both default (a/b) and mnemonicPrefix mode
+    # which can use prefixes like c/ (commit), w/ (worktree), i/ (index), o/ (object)
     re_header = re.compile(
         rb"""
                                 ^diff[ ]--git
-                                    [ ](?P<a_path_fallback>"?[ab]/.+?"?)[ ](?P<b_path_fallback>"?[ab]/.+?"?)\n
+                                    [ ](?P<a_path_fallback>"?[abciwoh]/.+?"?)[ ](?P<b_path_fallback>"?[abciwoh]/.+?"?)\n
                                 (?:^old[ ]mode[ ](?P<old_mode>\d+)\n
                                    ^new[ ]mode[ ](?P<new_mode>\d+)(?:\n|$))?
                                 (?:^similarity[ ]index[ ]\d+%\n

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -281,6 +281,38 @@ class TestDiff(TestBase):
         self.assertEqual(res[13].a_path, 'a/"with-quotes"')
         self.assertEqual(res[13].b_path, 'b/"with even more quotes"')
 
+    def test_diff_mnemonic_prefix(self):
+        """Test that diff parsing works with mnemonicPrefix enabled.
+        
+        When diff.mnemonicPrefix=true is set in git config, git uses different
+        prefixes for diff paths:
+        - c/ for commit
+        - w/ for worktree  
+        - i/ for index
+        - o/ for object
+        
+        This addresses issue #2013 where the regex only matched [ab]/ prefixes.
+        """
+        # Create a diff with mnemonicPrefix-style c/ and w/ prefixes
+        # Using valid 40-char hex SHAs
+        diff_mnemonic = b"""diff --git c/.vscode/launch.json w/.vscode/launch.json
+index 1234567890abcdef1234567890abcdef12345678..abcdef1234567890abcdef1234567890abcdef12 100644
+--- c/.vscode/launch.json
++++ w/.vscode/launch.json
+@@ -1,3 +1,3 @@
+-old content
++new content
+"""
+        diff_proc = StringProcessAdapter(diff_mnemonic)
+        diffs = Diff._index_from_patch_format(self.rorepo, diff_proc)
+        
+        # Should parse successfully (previously would fail or return empty)
+        self.assertEqual(len(diffs), 1)
+        diff = diffs[0]
+        # The path should be extracted correctly (without the c/ or w/ prefix)
+        self.assertEqual(diff.a_path, ".vscode/launch.json")
+        self.assertEqual(diff.b_path, ".vscode/launch.json")
+
     def test_diff_patch_format(self):
         # Test all of the 'old' format diffs for completeness - it should at least be
         # able to deal with it.

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -283,14 +283,14 @@ class TestDiff(TestBase):
 
     def test_diff_mnemonic_prefix(self):
         """Test that diff parsing works with mnemonicPrefix enabled.
-        
+
         When diff.mnemonicPrefix=true is set in git config, git uses different
         prefixes for diff paths:
         - c/ for commit
-        - w/ for worktree  
+        - w/ for worktree
         - i/ for index
         - o/ for object
-        
+
         This addresses issue #2013 where the regex only matched [ab]/ prefixes.
         """
         # Create a diff with mnemonicPrefix-style c/ and w/ prefixes
@@ -305,7 +305,7 @@ index 1234567890abcdef1234567890abcdef12345678..abcdef1234567890abcdef1234567890
 """
         diff_proc = StringProcessAdapter(diff_mnemonic)
         diffs = Diff._index_from_patch_format(self.rorepo, diff_proc)
-        
+
         # Should parse successfully (previously would fail or return empty)
         self.assertEqual(len(diffs), 1)
         diff = diffs[0]

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -290,28 +290,42 @@ class TestDiff(TestBase):
         - w/ for worktree
         - i/ for index
         - o/ for object
+        - h/ for HEAD
 
         This addresses issue #2013 where the regex only matched [ab]/ prefixes.
         """
-        # Create a diff with mnemonicPrefix-style c/ and w/ prefixes
-        # Using valid 40-char hex SHAs
-        diff_mnemonic = b"""diff --git c/.vscode/launch.json w/.vscode/launch.json
-index 1234567890abcdef1234567890abcdef12345678..abcdef1234567890abcdef1234567890abcdef12 100644
---- c/.vscode/launch.json
-+++ w/.vscode/launch.json
-@@ -1,3 +1,3 @@
--old content
-+new content
-"""
-        diff_proc = StringProcessAdapter(diff_mnemonic)
-        diffs = Diff._index_from_patch_format(self.rorepo, diff_proc)
+        # Test all mnemonicPrefix combinations
+        # Each tuple is (a_prefix, b_prefix) representing different comparison types
+        prefix_pairs = [
+            (b"c/", b"w/"),  # commit vs worktree
+            (b"c/", b"i/"),  # commit vs index
+            (b"i/", b"w/"),  # index vs worktree
+            (b"o/", b"w/"),  # object vs worktree
+            (b"h/", b"i/"),  # HEAD vs index
+            (b"h/", b"w/"),  # HEAD vs worktree
+        ]
 
-        # Should parse successfully (previously would fail or return empty)
-        self.assertEqual(len(diffs), 1)
-        diff = diffs[0]
-        # The path should be extracted correctly (without the c/ or w/ prefix)
-        self.assertEqual(diff.a_path, ".vscode/launch.json")
-        self.assertEqual(diff.b_path, ".vscode/launch.json")
+        for a_prefix, b_prefix in prefix_pairs:
+            with self.subTest(a_prefix=a_prefix, b_prefix=b_prefix):
+                diff_mnemonic = (
+                    b"diff --git " + a_prefix + b".vscode/launch.json " + b_prefix + b".vscode/launch.json\n"
+                    b"index 1234567890abcdef1234567890abcdef12345678.."
+                    b"abcdef1234567890abcdef1234567890abcdef12 100644\n"
+                    b"--- " + a_prefix + b".vscode/launch.json\n"
+                    b"+++ " + b_prefix + b".vscode/launch.json\n"
+                    b"@@ -1,3 +1,3 @@\n"
+                    b"-old content\n"
+                    b"+new content\n"
+                )
+                diff_proc = StringProcessAdapter(diff_mnemonic)
+                diffs = Diff._index_from_patch_format(self.rorepo, diff_proc)
+
+                # Should parse successfully (previously would fail or return empty)
+                self.assertEqual(len(diffs), 1)
+                diff = diffs[0]
+                # The path should be extracted correctly (without the prefix)
+                self.assertEqual(diff.a_path, ".vscode/launch.json")
+                self.assertEqual(diff.b_path, ".vscode/launch.json")
 
     def test_diff_patch_format(self):
         # Test all of the 'old' format diffs for completeness - it should at least be


### PR DESCRIPTION
## Summary

Fixes #2013

When `diff.mnemonicPrefix=true` is set in git config, git uses different prefixes for diff paths instead of the standard `a/` and `b/`:
- `c/` for commit
- `w/` for worktree
- `i/` for index
- `o/` for object
- `h/` for HEAD

Previously, the diff regex and `decode_path()` function only accepted `a/` and `b/` prefixes, causing `create_patch=True` diffs to fail parsing when users had this config enabled.

## Reproduction

As described in #2013:
```python
# With ~/.gitconfig containing:
# [diff]
#     mnemonicPrefix = true

repo = git.Repo('.')
ancestor_ref = repo.merge_base(repo.head, repo.refs['main'])
diff = ancestor_ref[0].diff(None, create_patch=True)  # Would fail to parse
```

## Changes

- Update `re_header` regex to accept `[abciwoh]/` prefixes instead of just `[ab]/`
- Update `decode_path()` assertion to accept all valid mnemonic prefixes
- Add test case for mnemonicPrefix-style diffs

## Testing

- New test `test_diff_mnemonic_prefix` verifies parsing works with `c/` and `w/` prefixes
- All existing diff tests pass (except one pre-existing failure on main unrelated to this change)

## References

- Git documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffmnemonicPrefix
- Issue: #2013