### PR TITLE
Add `Commit.patch` property to expose commit-to-parent diff text

### DIFF
--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -196,6 +196,13 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         if gpgsig is not None:
             self.gpgsig = gpgsig
 
+    @property
+    def patch(self) -> str:
+        """Textual patch comparing this commit against its first parent."""
+        if not self.parents:
+            return self.repo.git.diff_tree(self.hexsha, root=True, p=True)
+        return self.repo.git.diff("%s..%s" % (self.parents[0].hexsha, self.hexsha), p=True)
+
     @classmethod
     def _get_intermediate_items(cls, commit: "Commit") -> Tuple["Commit", ...]:
         return tuple(commit.parents)


### PR DESCRIPTION
## Summary

The issue is a missing API feature, not a runtime defect: `Commit` exposes structured diff stats (`commit.stats`) but does not expose the raw patch text for the same comparison. Users currently must manually call lower-level git commands for each commit. The `Commit` class should be extended with a `patch` property (or method) that returns unified diff text against its parent, with correct handling for merge/root commits.

## Files changed

- `git/objects/commit.py` (modified)

## Testing

- Not run in this environment.


Closes #1413