### PR TITLE
Add a first-class API to get the latest tag from a remote via `git ls-remote`

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -995,6 +995,28 @@ class Git(metaclass=_GitMeta):
             _warn_use_shell(extra_danger=False)
         return super().__getattribute__(name)
 
+    def latest_remote_tag(self, repository: PathLike) -> Optional[str]:
+        output = self.ls_remote("--tags", "--sort=-version:refname", repository)
+        if not output:
+            return None
+
+        for line in output.splitlines():
+            if not line:
+                continue
+            try:
+                _, ref = line.split("\t", 1)
+            except ValueError:
+                continue
+            if not ref.startswith("refs/tags/"):
+                continue
+            tag = ref[len("refs/tags/") :]
+            if tag.endswith("^{}"):
+                tag = tag[:-3]
+            if tag:
+                return tag
+
+        return None
+
     def __getattr__(self, name: str) -> Any:
         """A convenience method as it allows to call the command as if it was an object.
 


### PR DESCRIPTION
## Summary

Introduce a dedicated convenience method on `Git` for the issue use case (querying a remote URL/repo and returning its newest tag). This avoids requiring users to manually run `ls_remote(...)` and parse tab-delimited output themselves. The method should encapsulate stable parsing behavior and edge-case handling (empty output, annotated tag peeled refs, malformed lines).

## Files changed

- `git/cmd.py` (modified)

## Testing

- Not run in this environment.


Closes #1071