### PR TITLE
Add porcelain-style convenience APIs on `Repo` (`create_branch` and `merge`)

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -170,6 +170,12 @@ class Repo:
     """Subclasses may easily bring in their own custom types by placing a constructor or
     type here."""
 
+    def create_branch(self, *args: Any, **kwargs: Any) -> Head:
+        return self.create_head(*args, **kwargs)
+
+    def merge(self, *args: Any, **kwargs: Any) -> str:
+        return self.git.merge(*args, **kwargs)
+
     def __init__(
         self,
         path: Optional[PathLike] = None,


### PR DESCRIPTION
## Summary

Introduce higher-level, intuitive repository operations directly on `Repo` to reduce reliance on plumbing-level sequences. This file is where `Repo` methods live, including existing branch/head creation helpers, so it is the correct location for ergonomic aliases.

## Files changed

- `git/repo/base.py` (modified)

## Testing

- Not run in this environment.


Closes #901