### PR TITLE
Add missing `Repo.tracked_files` convenience property

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ or low-level like git-plumbing.
 It provides abstractions of git objects for easy access of repository data often backed by calling the `git`
 command-line program.
 
+For file discovery convenience, repositories expose both `Repo.untracked_files` and `Repo.tracked_files`.
+
 ### DEVELOPMENT STATUS
 
 This project is in **maintenance mode**, which means that

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -170,6 +170,11 @@ class Repo:
     """Subclasses may easily bring in their own custom types by placing a constructor or
     type here."""
 
+    @property
+    def tracked_files(self) -> List[str]:
+        """Files currently tracked by git."""
+        return self.git.ls_files().splitlines()
+
     def __init__(
         self,
         path: Optional[PathLike] = None,


### PR DESCRIPTION
## Summary

The issue is not a runtime defect, but an API/documentation gap: `Repo` exposes `untracked_files` but has no symmetric `tracked_files` property, which makes common usage inconsistent and discoverability poor. Users currently need to know and call plumbing manually (e.g., `repo.git.ls_files()`), and this is not clearly documented in the API reference.

## Files changed

- `git/repo/base.py` (modified)
- `README.md` (modified)

## Testing

- Not run in this environment.


Closes #857