### PR TITLE
config: resolve relative includes from relative config paths

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -32,6 +32,7 @@ from typing import (
     List,
     Dict,
     Sequence,
+    Set,
     TYPE_CHECKING,
     Tuple,
     TypeVar,
@@ -631,11 +632,17 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             files_to_read = list(self._file_or_files)
         # END ensure we have a copy of the paths to handle
 
-        seen = set(files_to_read)
+        def path_key(file_path: Union[PathLike, IO]) -> Union[str, IO]:
+            if isinstance(file_path, (str, os.PathLike)):
+                return osp.normpath(osp.abspath(file_path))
+            return file_path
+
+        seen: Set[Union[str, IO]] = {path_key(file_path) for file_path in files_to_read}
         num_read_include_files = 0
         while files_to_read:
             file_path = files_to_read.pop(0)
             file_ok = False
+            abs_file_path: Union[str, None] = None
 
             if hasattr(file_path, "seek"):
                 # Must be a file-object.
@@ -644,6 +651,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 self._read(file_path, file_path.name)
             else:
                 try:
+                    abs_file_path = osp.normpath(osp.abspath(file_path))
                     with open(file_path, "rb") as fp:
                         file_ok = True
                         self._read(fp, fp.name)
@@ -660,9 +668,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                         if not file_ok:
                             continue
                         # END ignore relative paths if we don't know the configuration file path
-                        file_path = cast(PathLike, file_path)
-                        assert osp.isabs(file_path), "Need absolute paths to be sure our cycle checks will work"
-                        include_path = osp.join(osp.dirname(file_path), include_path)
+                        assert abs_file_path is not None, "Need a source path to resolve relative include paths"
+                        include_path = osp.join(osp.dirname(abs_file_path), include_path)
                     # END make include path absolute
                     include_path = osp.normpath(include_path)
                     if include_path in seen or not os.access(include_path, os.R_OK):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -247,6 +247,24 @@ class TestBase(TestCase):
             check_test_value(cr, tv)
 
     @with_rw_directory
+    def test_config_include_from_relative_config_path(self, rw_dir):
+        fpa = osp.join(rw_dir, "a")
+        fpb = osp.join(rw_dir, "b")
+
+        with GitConfigParser(fpa, read_only=False) as cw:
+            cw.set_value("a", "value", "a")
+            cw.set_value("include", "path", "b")
+
+        with GitConfigParser(fpb, read_only=False) as cw:
+            cw.set_value("b", "value", "b")
+            cw.set_value("include", "path", "a")
+
+        with GitConfigParser(osp.relpath(fpa), read_only=True) as cr:
+            assert cr.get_value("a", "value") == "a"
+            assert cr.get_value("b", "value") == "b"
+            assert cr.get_values("include", "path") == ["b", "a"]
+
+    @with_rw_directory
     def test_multiple_include_paths_with_same_key(self, rw_dir):
         """Test that multiple 'path' entries under [include] are all respected.
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -249,20 +249,22 @@ class TestBase(TestCase):
     @with_rw_directory
     def test_config_include_from_relative_config_path(self, rw_dir):
         fpa = osp.join(rw_dir, "a")
-        fpb = osp.join(rw_dir, "b")
+        nested_dir = osp.join(rw_dir, "subdir")
+        os.makedirs(nested_dir)
+        fpb = osp.join(nested_dir, "b")
 
         with GitConfigParser(fpa, read_only=False) as cw:
             cw.set_value("a", "value", "a")
-            cw.set_value("include", "path", "b")
+            cw.set_value("include", "path", "subdir/b")
 
         with GitConfigParser(fpb, read_only=False) as cw:
             cw.set_value("b", "value", "b")
-            cw.set_value("include", "path", "a")
+            cw.set_value("include", "path", "../a")
 
         with GitConfigParser(osp.relpath(fpa), read_only=True) as cr:
             assert cr.get_value("a", "value") == "a"
             assert cr.get_value("b", "value") == "b"
-            assert cr.get_values("include", "path") == ["b", "a"]
+            assert cr.get_values("include", "path") == ["subdir/b", "../a"]
 
     @with_rw_directory
     def test_multiple_include_paths_with_same_key(self, rw_dir):


### PR DESCRIPTION
Fixes #2103

## Summary

- Normalize path-based config inputs before using them for include cycle detection.
- Resolve relative `include.path` entries from that normalized source path when the root config file was supplied as a relative path.
- Add regression coverage with a relative root config and a relative include cycle.

## Testing

- `.venv/bin/pytest --no-cov -q test/test_config.py`
- `.venv/bin/pytest --no-cov -q test/test_config.py test/test_repo.py::TestRepo::test_config_reader`
- `.venv/bin/pytest --no-cov -q test/test_refs.py::TestRefs::test_set_tracking_branch_with_import`
- `.venv/bin/ruff check git/config.py test/test_config.py`
- `.venv/bin/ruff format --check git/config.py test/test_config.py`
- `.venv/bin/mypy git/config.py`
- `git diff --check`