### PR TITLE
Fix Repo() autodiscovery in linked worktrees when GIT_DIR is set

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -242,6 +242,28 @@ class Repo:
             # It's important to normalize the paths, as submodules will otherwise
             # initialize their repo instances with paths that depend on path-portions
             # that will not exist after being removed. It's just cleaner.
+            if (
+                osp.isfile(osp.join(curpath, "gitdir"))
+                and osp.isfile(osp.join(curpath, "commondir"))
+                and osp.isfile(osp.join(curpath, "HEAD"))
+            ):
+                git_dir = curpath
+
+                if "GIT_WORK_TREE" in os.environ:
+                    self._working_tree_dir = os.getenv("GIT_WORK_TREE")
+                else:
+                    # Linked worktree administrative directories store the path to the
+                    # worktree's .git file in their gitdir file (without "gitdir: " prefix).
+                    with open(osp.join(git_dir, "gitdir")) as fp:
+                        worktree_gitfile = fp.read().strip()
+
+                    if not osp.isabs(worktree_gitfile):
+                        worktree_gitfile = osp.normpath(osp.join(git_dir, worktree_gitfile))
+
+                    self._working_tree_dir = osp.dirname(worktree_gitfile)
+
+                break
+
             if is_git_dir(curpath):
                 git_dir = curpath
                 # from man git-config : core.worktree

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1127,6 +1127,42 @@ class TestRepo(TestBase):
             self.assertEqual(r.working_dir, repo_dir)
 
     @with_rw_directory
+    def test_git_work_tree_env_in_linked_worktree(self, rw_dir):
+        """Check that Repo() autodiscovers a linked worktree when GIT_DIR is set."""
+        git = Git(rw_dir)
+        if git.version_info[:3] < (2, 5, 1):
+            raise RuntimeError("worktree feature unsupported (test needs git 2.5.1 or later)")
+
+        rw_master = self.rorepo.clone(join_path_native(rw_dir, "master_repo"))
+        branch = rw_master.create_head("bbbbbbbb")
+        worktree_path = join_path_native(rw_dir, "worktree_repo")
+        if Git.is_cygwin():
+            worktree_path = cygpath(worktree_path)
+
+        rw_master.git.worktree("add", worktree_path, branch.name)
+
+        git_dir = Git(worktree_path).rev_parse("--git-dir")
+
+        patched_env = dict(os.environ)
+        patched_env["GIT_DIR"] = git_dir
+        patched_env.pop("GIT_WORK_TREE", None)
+        patched_env.pop("GIT_COMMON_DIR", None)
+
+        with mock.patch.dict(os.environ, patched_env, clear=True):
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(worktree_path)
+
+                explicit = Repo(os.getcwd())
+                autodiscovered = Repo()
+
+                self.assertTrue(osp.samefile(explicit.working_tree_dir, worktree_path))
+                self.assertTrue(osp.samefile(autodiscovered.working_tree_dir, worktree_path))
+                self.assertTrue(osp.samefile(autodiscovered.working_tree_dir, explicit.working_tree_dir))
+            finally:
+                os.chdir(old_cwd)
+
+    @with_rw_directory
     def test_rebasing(self, rw_dir):
         r = Repo.init(rw_dir)
         fp = osp.join(rw_dir, "hello.txt")


### PR DESCRIPTION
Fixes #2022

This PR fixes repository autodiscovery in linked worktrees when GIT_DIR is set.

## Summary

Fix `Repo()` autodiscovery when `GIT_DIR` points to a linked worktree git directory.

Previously, calling `Repo()` inside a linked worktree with `GIT_DIR=$(git rev-parse --git-dir)` could fail with `InvalidGitRepositoryError`, while `Repo(os.getcwd())` resolved the repository correctly.

## Changes

* add regression coverage for autodiscovery in linked worktrees when `GIT_DIR` is set
* detect linked worktree git directories during repository discovery
* derive the working tree directory correctly from the linked worktree metadata

## Reproduction

Inside a linked worktree:

```
export GIT_DIR=$(git rev-parse --git-dir)
python -c "from git import Repo; Repo()"
```

Before: raises `InvalidGitRepositoryError`
After: resolves repository correctly
