### PR TITLE
refactor(git/repo/base): use less strict types in is_ancestor

### DIFF
--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -824,7 +824,7 @@ class Repo:
 
         return res
 
-    def is_ancestor(self, ancestor_rev: Commit, rev: Commit) -> bool:
+    def is_ancestor(self, ancestor_rev: TBD, rev: TBD) -> bool:
         """Check if a commit is an ancestor of another.
 
         :param ancestor_rev:


### PR DESCRIPTION
Changes the type hints in the is_ancestor arguments to avoid warnings from type checkers (e.g. Pylance).