### PR TITLE
Validate config key names before writing

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -72,6 +72,9 @@ CONDITIONAL_INCLUDE_REGEXP = re.compile(r"(?<=includeIf )\"(gitdir|gitdir/i|onbr
 See: https://git-scm.com/docs/git-config#_conditional_includes
 """
 
+UNSAFE_CONFIG_CHARS_RE = re.compile(r"[\r\n\x00]")
+"""Characters that cannot be safely written in config names or values."""
+
 
 class MetaParserBuilder(abc.ABCMeta):  # noqa: B024
     """Utility class wrapping base-class methods into decorators that assure read-only
@@ -778,6 +781,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def add_section(self, section: "cp._SectionName") -> None:
         """Assures added options will stay in order."""
+        self._assure_config_name_safe(section, "section")
         return super().add_section(section)
 
     @property
@@ -884,9 +888,13 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
 
     def _value_to_string_safe(self, value: Union[str, bytes, int, float, bool]) -> str:
         value_str = self._value_to_string(value)
-        if re.search(r"[\r\n\x00]", value_str):
+        if UNSAFE_CONFIG_CHARS_RE.search(value_str):
             raise ValueError("Git config values must not contain CR, LF, or NUL")
         return value_str
+
+    def _assure_config_name_safe(self, name: "cp._SectionName", label: str) -> None:
+        if isinstance(name, str) and UNSAFE_CONFIG_CHARS_RE.search(name):
+            raise ValueError("Git config %s names must not contain CR, LF, or NUL" % label)
 
     @needs_values
     @set_dirty_and_flush_changes
@@ -896,6 +904,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         option: str,
         value: Union[str, bytes, int, float, bool, None] = None,
     ) -> None:
+        self._assure_config_name_safe(section, "section")
+        self._assure_config_name_safe(option, "option")
         if value is not None:
             value = self._value_to_string_safe(value)
         return super().set(section, option, value)
@@ -920,6 +930,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :return:
             This instance
         """
+        self._assure_config_name_safe(section, "section")
+        self._assure_config_name_safe(option, "option")
         value_str = self._value_to_string_safe(value)
         if not self.has_section(section):
             self.add_section(section)
@@ -948,6 +960,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         :return:
             This instance
         """
+        self._assure_config_name_safe(section, "section")
+        self._assure_config_name_safe(option, "option")
         value_str = self._value_to_string_safe(value)
         if not self.has_section(section):
             self.add_section(section)
@@ -968,6 +982,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
         """
         if not self.has_section(section):
             raise ValueError("Source section '%s' doesn't exist" % section)
+        self._assure_config_name_safe(new_name, "section")
         if self.has_section(new_name):
             raise ValueError("Destination section '%s' already exists" % new_name)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -164,6 +164,37 @@ class TestBase(TestCase):
             self.assertFalse(git_config.has_section("core"))
 
     @with_rw_directory
+    def test_set_value_rejects_unsafe_section_and_option_names(self, rw_dir):
+        config_path = osp.join(rw_dir, "config")
+        bad_keys = ("user]\n[core", "user]\r[core", "user]\x00[core")
+
+        with GitConfigParser(config_path, read_only=False) as git_config:
+            git_config.add_section("user")
+            for bad_key in bad_keys:
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.add_section(bad_key)
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.set(bad_key, "hooksPath", "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.set("user", bad_key, "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.set_value(bad_key, "hooksPath", "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.set_value("user", bad_key, "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.add_value(bad_key, "hooksPath", "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.add_value("user", bad_key, "/tmp/hooks")
+                with pytest.raises(ValueError, match="CR, LF, or NUL"):
+                    git_config.rename_section("user", bad_key)
+
+            git_config.set_value("user", "name", "safe")
+
+        with GitConfigParser(config_path, read_only=True) as git_config:
+            self.assertEqual(git_config.get_value("user", "name"), "safe")
+            self.assertFalse(git_config.has_section("core"))
+
+    @with_rw_directory
     def test_set_and_add_value_reject_unsafe_value_characters(self, rw_dir):
         config_path = osp.join(rw_dir, "config")
         bad_values = ("foo\rbar", "foo\nbar", "foo\x00bar", b"foo\nbar")


### PR DESCRIPTION
### Tasks

* [x] refackiew

----

Codex created this PR on behalf of Byron. Byron will review it before any merge decision.

## Summary

- Reject CR, LF, and NUL in config section and option names before writing.
- Apply the same guard to `add_section()`, `set()`, `set_value()`, `add_value()`, and destination names in `rename_section()`.
- Add a regression test for section and option name injection while confirming safe writes still work.

## Git reference

Git itself rejects config keys containing newlines. I checked Git source commit `94f057755b7941b321fd11fec1b2e3ca5313a4e0`, where `config.c` reports invalid keys containing newlines, and local `git version 2.50.1` rejects newline-bearing config keys.

## Validation

- `uv run --with gitdb --with pytest --with pytest-cov --with ddt --with pytest-mock --with pytest-instafail --with pytest-sugar python -m pytest test/test_config.py::TestBase::test_set_value_rejects_unsafe_section_and_option_names --no-cov`
- `uv run --with gitdb --with pytest --with pytest-cov --with ddt --with pytest-mock --with pytest-instafail --with pytest-sugar python -m pytest test/test_config.py --no-cov`
- `uv run --with ruff ruff check git/config.py test/test_config.py`
- `codex review --uncommitted`
- `codex review --commit e226e42b38c7684cb10e1d13f264b08977892039`
