### PR TITLE
docs(cmd): clarify Git.execute() string vs list command argument

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1119,9 +1119,16 @@ class Git(metaclass=_GitMeta):
         information (stdout).
 
         :param command:
-            The command argument list to execute.
-            It should be a sequence of program arguments, or a string. The
-            program to execute is the first item in the args sequence or string.
+            The command to execute. A sequence of program arguments is the
+            recommended form when `shell` is ``False`` (the default), e.g.
+            ``["git", "log", "-n", "1"]``.
+
+            A string is accepted, but with `shell` set to ``False`` it is passed
+            as a single executable name to :class:`subprocess.Popen`. For example,
+            ``"git log -n 1"`` looks for an executable literally named
+            ``git log -n 1`` and will fail with :class:`GitCommandNotFound`. To
+            split a command string into argv tokens, pass ``shlex.split(...)`` as
+            a sequence or set `shell` to ``True`` (see the warning below).
 
         :param istream:
             Standard input filehandle passed to :class:`subprocess.Popen`.


### PR DESCRIPTION
## What changed

Rewrites the `:param command:` docstring on `Git.execute()` in `git/cmd.py` to clarify the string-vs-sequence semantics. The previous wording ("the program to execute is the first item in the args sequence or string") was misleading: with `shell=False` (the default), `subprocess.Popen` treats the entire string as a single executable name, so `"git log -n 1"` looks for an executable literally named "git log -n 1" and raises `GitCommandNotFound`.

The new docstring:
- Recommends the sequence form (`["git", "log", "-n", "1"]`) for the default `shell=False` case.
- Documents that a string is accepted but is passed as a single executable name when `shell=False`, with the exact failure mode users see in #2016.
- Points users at `shlex.split(...)` (sequence) or `shell=True` (with the existing warning) for the case where they want a string that gets tokenised.

Closes #2016

## Why

This is the third recurrence of this confusion that surfaces in issues — string commands look like the obvious shape for "run this git invocation", and the failure mode is opaque. The `subprocess.Popen` semantics are doing exactly what they always do; the GitPython docstring was the surface that misled users into expecting otherwise. Updating it costs ~10 lines and short-circuits the next round of issues.

I deliberately kept this docs-only. Auto-splitting a string when it contains spaces would be a behavior change that could break existing callers who do pass a single executable path with whitespace. The acknowledged label on the issue suggests maintainer interest without committing to a specific behavior fix; clarifying the docs is the smallest useful step.

## Verification

`python -c "import git; help(git.cmd.Git.execute)"` renders the new param block cleanly. `python -m py_compile git/cmd.py` is clean. No tests were modified or broken.
