### PR TITLE
Document init script behavior with multiple master remotes

### DIFF
--- a/init-tests-after-clone.sh
+++ b/init-tests-after-clone.sh
@@ -40,6 +40,11 @@ fi
 git tag __testing_point__
 
 # The tests need a branch called master.
+#
+# If master is locally absent but more than one remote has it, checkout fails
+# by default even if all remotes agree, and we fall back to creating it at
+# HEAD. The reflog we populate below then traces HEAD's history rather than
+# a remote master's, but master is reset to __testing_point__ either way.
 git checkout master -- || git checkout -b master
 
 # The tests need a reflog history on the master branch.


### PR DESCRIPTION
## Summary

- Add a comment to `init-tests-after-clone.sh` explaining what happens when `master` is locally absent but present on more than one remote: `git checkout master --` refuses to pick one (even when all of the remote-tracking branches agree on a commit), and the script falls back to `git checkout -b master`, creating the branch at the current `HEAD`. The reflog built up by the subsequent `git reset --hard HEAD~1` calls then traces `HEAD`'s history instead of a remote `master`'s. This is harmless because `master` is reset to `__testing_point__` afterward, but it is unintuitive enough to be worth noting in the script itself.

Closes #2145.

## Test plan

- [x] `sh -n init-tests-after-clone.sh` passes
- [x] `shellcheck init-tests-after-clone.sh` passes
- [x] Diff is comment-only; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)