### PR TITLE
Support relative worktree paths (git 2.48+ worktree.useRelativePaths)

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -1595,7 +1595,7 @@ class Git(metaclass=_GitMeta):
 
         turns into::
 
-            git rev-list --max-count=10 --header=master
+            git rev-list --max-count=10 --header master
 
         :return:
             Same as :meth:`execute`. If no args are given, used :meth:`execute`'s

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -295,7 +295,7 @@ class Repo:
                 sm_gitpath = find_worktree_git_dir(dotgit)
 
             if sm_gitpath is not None:
-                git_dir = expand_path(sm_gitpath, expand_vars)
+                git_dir = osp.normpath(sm_gitpath)
                 self._working_tree_dir = curpath
                 break
 

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -295,7 +295,8 @@ class Repo:
                 sm_gitpath = find_worktree_git_dir(dotgit)
 
             if sm_gitpath is not None:
-                git_dir = osp.normpath(sm_gitpath)
+                # worktrees can use relative paths as of Git 2.48, so we join to curpath
+                git_dir = osp.normpath(osp.join(curpath, sm_gitpath))
                 self._working_tree_dir = curpath
                 break
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -1094,7 +1094,7 @@ class TestRepo(TestBase):
         self.assertFalse(repo.is_valid_object(tag_sha, "commit"))
 
     @with_rw_directory
-    def test_git_work_tree_dotgit(self, rw_dir):
+    def test_git_work_tree_dotgit(self, rw_dir, use_relative_paths=False):
         """Check that we find .git as a worktree file and find the worktree
         based on it."""
         git = Git(rw_dir)
@@ -1106,7 +1106,11 @@ class TestRepo(TestBase):
         worktree_path = join_path_native(rw_dir, "worktree_repo")
         if Git.is_cygwin():
             worktree_path = cygpath(worktree_path)
-        rw_master.git.worktree("add", worktree_path, branch.name)
+        wt_add_kwargs = {"insert_kwargs_after": "add"}
+        # relative worktree paths introduced in git 2.48.0
+        if use_relative_paths and git.version_info[:3] >= (2, 48, 0):
+            wt_add_kwargs["relative_paths"] = True
+        rw_master.git.worktree("add", worktree_path, branch.name, **wt_add_kwargs)
 
         # This ensures that we can read the repo's gitdir correctly.
         repo = Repo(worktree_path)
@@ -1123,6 +1127,15 @@ class TestRepo(TestBase):
         self.assertIsInstance(origin, Remote)
 
         self.assertIsInstance(repo.heads["aaaaaaaa"], Head)
+
+    def test_git_work_tree_dotgit_relative(self):
+        """Check that we find .git as a worktree file containing a relative path
+        and find the worktree based on it."""
+        if Git().version_info[:3] < (2, 48, 0):
+            pytest.skip("relative worktree feature unsupported, needs git 2.48.0 or later")
+        # this class inherits from TestCase so we can't use pytest.mark.parametrize on
+        # test_git_work_tree_dotgit; delegate instead
+        self.test_git_work_tree_dotgit(use_relative_paths=True)
 
     @with_rw_directory
     def test_git_work_tree_env(self, rw_dir):


### PR DESCRIPTION
## Summary

Git 2.48 introduced the `worktree.useRelativePaths` config option. When enabled, `git worktree add` writes a *relative* `gitdir:` into the worktree's `.git` file — relative to the directory containing that `.git` file.

GitPython's `Repo.__init__` previously passed the value of that `gitdir:` line straight through `expand_path`, which calls `os.path.abspath` against the process's current working directory rather than against the worktree. Using the library when the cwd was not the worktree root therefore failed.

This change resolves the relative `gitdir` against `curpath` (the directory containing the `.git` file) before expanding. Absolute paths — i.e. the pre-2.48 default — are unaffected, because `os.path.join` ignores its first argument when the second is absolute.

This change also includes a minor doc fix that I came across when trying to better understand how git is called.

## Test plan

- [x] New test `TestRepo.test_git_work_tree_dotgit_relative`, which delegates to `test_git_work_tree_dotgit` but runs `git worktree add --relative-paths`. I verified that the test failed before implementation and now passes.
- [x] Existing `test_git_work_tree_dotgit` still passes, confirming absolute-path worktrees are unaffected.

## AI disclosure

Per `CONTRIBUTING.md`: this PR description and the commit message were drafted by Claude Code on behalf of @elovelan; though the final versions were manually reworded for clarity. All code was written _without_ AI (didn't start that way but I didn't like its test implementation, and the actual implementation was trivial).