### PR TITLE
Git test environment consistency

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import os
+from test.lib import fixture_path
+
+# ensure all tests run with consistent config since some settings break tests
+# we could also use pytest-env for this but it's less consistent across OSs
+
+os.environ["GIT_CONFIG_NOSYSTEM"] = "true"
+os.environ["GIT_CONFIG_GLOBAL"] = fixture_path("git_config_defaults")
+os.environ.pop("GIT_CONFIG_COUNT", None)
+os.environ.pop("GIT_CONFIG_SYSTEM", None)

--- a/test/fixtures/git_config_defaults
+++ b/test/fixtures/git_config_defaults
@@ -1,0 +1,8 @@
+# defaulted via env var in conftest.py to avoid user-specific configs breaking tests
+
+[init]
+  defaultBranch = master
+
+[user]
+	name = Sebastian Thiel
+	email = byronimo@gmail.com

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -83,8 +83,7 @@ class Tutorials(TestBase):
         self.assertEqual(repo.tags["0.3.5"], repo.tag("refs/tags/0.3.5"))  # You can access tags in various ways too.
         self.assertEqual(repo.refs.master, repo.heads["master"])  # .refs provides all refs, i.e. heads...
 
-        if "TRAVIS" not in os.environ:
-            self.assertEqual(repo.refs["origin/master"], repo.remotes.origin.refs.master)  # ... remotes ...
+        self.assertEqual(cloned_repo.refs["origin/master"], cloned_repo.remotes.origin.refs.master)  # ... remotes ...
         self.assertEqual(repo.refs["0.3.5"], repo.tags["0.3.5"])  # ... and tags.
         # ![8-test_init_repo_object]
 


### PR DESCRIPTION
When implementing #2151, I ran into a few issues running tests due to:

1. By default, GitHub now forks only the default branch when forking a repo. One of the docs tests was relying on `origin/master` existing, which is unlikely in a fork scenario, since the common pattern is to set `origin` to the fork and `upstream` to the primary repo.
2. I have a few "convenience" features in my configuration such as `main` as the default repo branch name and `fetch.prune=true`. These break some of the tests so it seemed like it might be a good idea to always use a consistent config file.