### PR TITLE
Run more submodule tests on Cygwin (fix flaky xfails)

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -61,6 +61,26 @@ jobs:
         . .venv/bin/activate
         pip install '.[test]'
 
+    - name: Show file ownership and safe.directory entries
+      run: |
+        echo "==================== File ownership ===================="
+        for p in \
+            "$(pwd)" \
+            "$(pwd)/.git" \
+            "$(pwd)/git/ext/gitdb" \
+            "$(pwd)/git/ext/gitdb/.git" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+            "${HOME:-}" \
+            "${HOME:-}/.gitconfig"; do
+          if [ -n "$p" ]; then
+            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
+          fi
+        done
+        echo
+        echo "==================== safe.directory entries ===================="
+        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
     - name: Show version and platform information
       run: |
         . .venv/bin/activate

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -29,9 +29,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        # Temporary, for testing. The standing decision is to NOT pre-clone
-        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
-        submodules: recursive
 
     - name: Set workspace ownership
       run: |

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -29,6 +29,9 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        # Temporary, for testing. The standing decision is to NOT pre-clone
+        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
+        submodules: recursive
 
     - name: Set workspace ownership
       run: |

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -61,25 +61,28 @@ jobs:
         . .venv/bin/activate
         pip install '.[test]'
 
-    - name: Show file ownership and safe.directory entries
+    - name: Show POSIX file ownership
       run: |
-        echo "==================== File ownership ===================="
         for p in \
-            "$(pwd)" \
-            "$(pwd)/.git" \
-            "$(pwd)/git/ext/gitdb" \
-            "$(pwd)/git/ext/gitdb/.git" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-            "${HOME:-}" \
-            "${HOME:-}/.gitconfig"; do
-          if [ -n "$p" ]; then
-            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-          fi
+          "$(pwd)" \
+          "$(pwd)/.git" \
+          "$(pwd)/git/ext/gitdb" \
+          "$(pwd)/git/ext/gitdb/.git" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+          "${HOME:?HOME is not set}/.gitconfig"
+        do
+          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
         done
-        echo
-        echo "==================== safe.directory entries ===================="
-        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
+    - name: Show safe.directory entries
+      # `actions/checkout`'s safe.directory add is only durable for the
+      # checkout itself (it writes under a throwaway HOME override and
+      # then discards it), so by the time this step runs the runner
+      # user's `~/.gitconfig` has no entries -- and the Alpine container
+      # chowns the workspace to runner:docker to match the test user, so
+      # git accepts the ownership without one. Expected: `(none)`.
+      run: git config --global --get-all safe.directory || echo "(none)"
 
     - name: Show version and platform information
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -20,41 +20,36 @@ jobs:
 
     runs-on: windows-latest
 
-    env: &cygwin-env
+    env:
       CHERE_INVOKING: "1"
       CYGWIN_NOWINPATH: "1"
 
-    defaults: &cygwin-defaults
+    defaults:
       run:
         shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
-    - &force-lf
-      name: Force LF line endings
+    - name: Force LF line endings
       run: |
         git config --global core.autocrlf false  # Affects the non-Cygwin git.
       shell: pwsh  # Do this outside Cygwin, to affect actions/checkout.
 
-    - &checkout
-      uses: actions/checkout@v6
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-    - &install-cygwin
-      name: Install Cygwin
+    - name: Install Cygwin
       uses: cygwin/cygwin-install-action@v6
       with:
         packages: git python39 python-pip-wheel python-setuptools-wheel python-wheel-wheel
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
-    - &verbose-output
-      name: Arrange for verbose output
+    - name: Arrange for verbose output
       run: |
         # Arrange for verbose output but without shell environment setup details.
         echo 'set -x' >~/.bash_profile
 
-    - &safe-directory
-      name: Special configuration for Cygwin git
+    - name: Special configuration for Cygwin git
       run: |
         git config --global --add safe.directory "$(pwd)"
         git config --global --add safe.directory "$(pwd)/.git"
@@ -62,13 +57,11 @@ jobs:
         git config --global --add safe.directory "$(pwd)/git/ext/gitdb/gitdb/ext/smmap"
         git config --global core.autocrlf false
 
-    - &prepare-repo
-      name: Prepare this repo for tests
+    - name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh
 
-    - &git-identity
-      name: Set git user identity and command aliases for the tests
+    - name: Set git user identity and command aliases for the tests
       run: |
         git config --global user.email "travis@ci.com"
         git config --global user.name "Travis Runner"
@@ -76,24 +69,20 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - &setup-venv
-      name: Set up virtual environment
+    - name: Set up virtual environment
       run: |
         python3.9 -m venv .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
 
-    - &update-pypa
-      name: Update PyPA packages
+    - name: Update PyPA packages
       run: |
         python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 
-    - &install-deps
-      name: Install project and test dependencies
+    - name: Install project and test dependencies
       run: |
         pip install '.[test]'
 
-    - &ownership-posix-display
-      name: Show POSIX file ownership
+    - name: Show POSIX file ownership
       # Cygwin's `ls -ld` reports the NTFS Owner SID via Cygwin's SID-to-uid
       # mapping (well-known SIDs by their RID, machine-local accounts by
       # 0x30000+RID). That mapping is what Cygwin git's
@@ -114,8 +103,7 @@ jobs:
           ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
         done
 
-    - &ownership-ntfs-display
-      name: Show NTFS file ownership
+    - name: Show NTFS file ownership
       # Authoritative NTFS Owner via Get-Acl, with no Cygwin SID-to-uid layer
       # in between -- useful for confirming what the Cygwin view reports as
       # "Administrators" is the BUILTIN\Administrators SID (S-1-5-32-544).
@@ -145,8 +133,7 @@ jobs:
           }
         }
 
-    - &safe-directory-display
-      name: Show safe.directory entries
+    - name: Show safe.directory entries
       run: git config --global --get-all safe.directory
 
     - name: Show version and platform information
@@ -160,104 +147,3 @@ jobs:
     - name: Test with pytest (${{ matrix.additional-pytest-args }})
       run: |
         pytest --color=yes -p no:sugar --instafail -vv ${{ matrix.additional-pytest-args }}
-
-  diag-token:
-    runs-on: windows-latest
-
-    env: *cygwin-env
-
-    defaults: *cygwin-defaults
-
-    steps:
-    - *force-lf
-    - *checkout
-    - *install-cygwin
-
-    - name: PowerShell-side token state and file-creation tests
-      shell: pwsh
-      run: |
-        $repo = "D:\a\GitPython\GitPython"
-        Write-Host "==================== whoami /all (PowerShell) ===================="
-        whoami /all
-        Write-Host ""
-        Write-Host "==================== Test A: PowerShell New-Item directory ===================="
-        $td = "$repo\test-pwsh-mkdir"
-        New-Item -ItemType Directory -Path $td -Force | Out-Null
-        $acl = Get-Acl -LiteralPath $td
-        Write-Host "Owner of $td : $($acl.Owner)"
-        Remove-Item $td -Force
-        Write-Host ""
-        Write-Host "==================== Test D: PowerShell -> Git Bash -> PowerShell New-Item ===================="
-        $td4 = "$repo\test-pwsh-bash-pwsh-mkdir"
-        $scriptPath = "$repo\inner-mkdir.ps1"
-        "New-Item -ItemType Directory -Path '$td4' -Force | Out-Null" |
-          Set-Content -Path $scriptPath -Encoding utf8
-        $env:MSYS2_ARG_CONV_EXCL = '*'
-        try {
-          & "C:\Program Files\Git\bin\bash.exe" -c "powershell.exe -NoProfile -ExecutionPolicy Bypass -File '$scriptPath'" 2>&1 | Out-Null
-        } finally {
-          Remove-Item Env:MSYS2_ARG_CONV_EXCL -ErrorAction SilentlyContinue
-        }
-        if (Test-Path -LiteralPath $td4) {
-          $acl = Get-Acl -LiteralPath $td4
-          Write-Host "Owner of $td4 (PowerShell -> bash -> PowerShell New-Item) : $($acl.Owner)"
-          Remove-Item $td4 -Force
-        } else {
-          Write-Host "Owner of $td4 (PowerShell -> bash -> PowerShell New-Item) : (directory not created)"
-        }
-        Remove-Item $scriptPath -Force -ErrorAction SilentlyContinue
-
-    - name: Cygwin-side token state and file-creation tests
-      run: |
-        set +e
-        echo "==================== id (Cygwin) ===================="
-        id
-        echo
-        echo "==================== Test B: Cygwin mkdir ===================="
-        td="$(pwd)/test-cygwin-mkdir"
-        mkdir "$td"
-        echo "Owner: $(stat -c '%U(%u)' "$td")"
-        rmdir "$td"
-        echo
-        echo "==================== Test C: Cygwin-spawned Git for Windows git init ===================="
-        td3="$(pwd)/test-cygwin-spawns-wingit"
-        mkdir "$td3"
-        ( cd "$td3" && /cygdrive/c/Program\ Files/Git/bin/git.exe init -q )
-        echo "Owner of $td3 (Cygwin-mkdir)             : $(stat -c '%U(%u)' "$td3")"
-        echo "Owner of $td3/.git (Cygwin->Win git init): $(stat -c '%U(%u)' "$td3/.git")"
-        rm -rf "$td3"
-        true
-
-  reproduce-safe-dir:
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256]
-      fail-fast: false
-
-    runs-on: windows-latest
-
-    env: *cygwin-env
-
-    defaults: *cygwin-defaults
-
-    steps:
-    - *force-lf
-    - *checkout
-    - *install-cygwin
-    - *verbose-output
-    - *safe-directory
-    - *prepare-repo
-    - *git-identity
-    - *setup-venv
-    - *update-pypa
-    - *install-deps
-    - *ownership-posix-display
-    - *ownership-ntfs-display
-    - *safe-directory-display
-
-    - name: Run submodule tests
-      run: |
-        python -m pytest -vv \
-          test/test_docs.py::Tutorials::test_submodules \
-          test/test_repo.py::TestRepo::test_submodules \
-          test/test_submodule.py::TestSubmodule::test_root_module

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -20,46 +20,53 @@ jobs:
 
     runs-on: windows-latest
 
-    env:
+    env: &cygwin-env
       CHERE_INVOKING: "1"
       CYGWIN_NOWINPATH: "1"
 
-    defaults:
+    defaults: &cygwin-defaults
       run:
         shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr "{0}"
 
     steps:
-    - name: Force LF line endings
+    - &force-lf
+      name: Force LF line endings
       run: |
         git config --global core.autocrlf false  # Affects the non-Cygwin git.
       shell: pwsh  # Do this outside Cygwin, to affect actions/checkout.
 
-    - uses: actions/checkout@v6
+    - &checkout
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-    - name: Install Cygwin
+    - &install-cygwin
+      name: Install Cygwin
       uses: cygwin/cygwin-install-action@v6
       with:
         packages: git python39 python-pip-wheel python-setuptools-wheel python-wheel-wheel
         add-to-path: false  # No need to change $PATH outside the Cygwin environment.
 
-    - name: Arrange for verbose output
+    - &verbose-output
+      name: Arrange for verbose output
       run: |
         # Arrange for verbose output but without shell environment setup details.
         echo 'set -x' >~/.bash_profile
 
-    - name: Special configuration for Cygwin git
+    - &safe-directory
+      name: Special configuration for Cygwin git
       run: |
         git config --global --add safe.directory "$(pwd)"
         git config --global --add safe.directory "$(pwd)/.git"
         git config --global core.autocrlf false
 
-    - name: Prepare this repo for tests
+    - &prepare-repo
+      name: Prepare this repo for tests
       run: |
         ./init-tests-after-clone.sh
 
-    - name: Set git user identity and command aliases for the tests
+    - &git-identity
+      name: Set git user identity and command aliases for the tests
       run: |
         git config --global user.email "travis@ci.com"
         git config --global user.name "Travis Runner"
@@ -67,16 +74,19 @@ jobs:
         # and cause subsequent tests to fail
         cat test/fixtures/.gitconfig >> ~/.gitconfig
 
-    - name: Set up virtual environment
+    - &setup-venv
+      name: Set up virtual environment
       run: |
         python3.9 -m venv .venv
         echo 'BASH_ENV=.venv/bin/activate' >>"$GITHUB_ENV"
 
-    - name: Update PyPA packages
+    - &update-pypa
+      name: Update PyPA packages
       run: |
         python -m pip install -U pip 'setuptools; python_version<"3.12"' wheel
 
-    - name: Install project and test dependencies
+    - &install-deps
+      name: Install project and test dependencies
       run: |
         pip install '.[test]'
 
@@ -91,3 +101,34 @@ jobs:
     - name: Test with pytest (${{ matrix.additional-pytest-args }})
       run: |
         pytest --color=yes -p no:sugar --instafail -vv ${{ matrix.additional-pytest-args }}
+
+  reproduce-safe-dir:
+    strategy:
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256]
+      fail-fast: false
+
+    runs-on: windows-latest
+
+    env: *cygwin-env
+
+    defaults: *cygwin-defaults
+
+    steps:
+    - *force-lf
+    - *checkout
+    - *install-cygwin
+    - *verbose-output
+    - *safe-directory
+    - *prepare-repo
+    - *git-identity
+    - *setup-venv
+    - *update-pypa
+    - *install-deps
+
+    - name: Run submodule tests
+      run: |
+        python -m pytest -vv \
+          test/test_docs.py::Tutorials::test_submodules \
+          test/test_repo.py::TestRepo::test_submodules \
+          test/test_submodule.py::TestSubmodule::test_root_module

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -39,6 +39,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        # Temporary, for testing. The standing decision is to NOT pre-clone
+        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
+        submodules: recursive
 
     - &install-cygwin
       name: Install Cygwin

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -39,9 +39,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        # Temporary, for testing. The standing decision is to NOT pre-clone
-        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
-        submodules: recursive
 
     - &install-cygwin
       name: Install Cygwin

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -90,6 +90,65 @@ jobs:
       run: |
         pip install '.[test]'
 
+    - &ownership-display
+      name: Show file ownership and safe.directory entries
+      run: |
+        echo "==================== File ownership (Cygwin view, ls -ld) ===================="
+        for p in \
+            "$(pwd)" \
+            "$(pwd)/.git" \
+            "$(pwd)/git/ext/gitdb" \
+            "$(pwd)/git/ext/gitdb/.git" \
+            "$(pwd)/.git/modules/gitdb" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+            "$(pwd)/.git/modules/gitdb/modules/smmap" \
+            "${HOME:-}" \
+            "${HOME:-}/.gitconfig"; do
+          if [ -n "$p" ]; then
+            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
+          fi
+        done
+        echo
+        echo "==================== File ownership (Win32 view, Get-Acl) ===================="
+        # Cygwin's ls -ld and stat go through Cygwin's SID-to-uid mapping
+        # (well-known SIDs by their RID, machine-local accounts by 0x30000+RID).
+        # The mapping is deterministic, but going via Win32 Get-Acl gives the
+        # NTAccount form of the NTFS Owner SID directly, with no Cygwin layer
+        # in between -- useful for confirming that what Cygwin reports as
+        # "Administrators" really is the BUILTIN\Administrators SID (S-1-5-32-544)
+        # rather than some local-machine account that Cygwin happens to map to
+        # the same uid. The workflow sets CYGWIN_NOWINPATH=1, so Windows paths
+        # are not on Cygwin's $PATH; invoke powershell.exe by absolute path.
+        ps_exe=/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe
+        if [ -x "$ps_exe" ]; then
+          for p in \
+              "$(pwd)" \
+              "$(pwd)/.git" \
+              "$(pwd)/git/ext/gitdb" \
+              "$(pwd)/git/ext/gitdb/.git" \
+              "$(pwd)/.git/modules/gitdb" \
+              "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+              "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+              "$(pwd)/.git/modules/gitdb/modules/smmap" \
+              "${HOME:-}/.gitconfig"; do
+            if [ -n "$p" ] && [ -e "$p" ]; then
+              wp=$(cygpath -w "$p")
+              # Escape single-quotes for PowerShell single-quoted string literal: ' -> ''
+              wp_escaped=${wp//\'/\'\'}
+              owner=$("$ps_exe" -NoProfile -NonInteractive -Command \
+                "try { (Get-Acl -LiteralPath '${wp_escaped}').Owner } catch { 'ERROR: ' + \$_.Exception.Message }" \
+                2>/dev/null | tr -d '\r')
+              printf "  %-44s  %s\n" "$owner" "$wp"
+            fi
+          done
+        else
+          echo "($ps_exe not found -- skipping Win32 view)"
+        fi
+        echo
+        echo "==================== safe.directory entries ===================="
+        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
     - name: Show version and platform information
       run: |
         uname -a
@@ -192,6 +251,7 @@ jobs:
     - *setup-venv
     - *update-pypa
     - *install-deps
+    - *ownership-display
 
     - name: Run submodule tests
       run: |

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -61,6 +61,8 @@ jobs:
       run: |
         git config --global --add safe.directory "$(pwd)"
         git config --global --add safe.directory "$(pwd)/.git"
+        git config --global --add safe.directory "$(pwd)/git/ext/gitdb"
+        git config --global --add safe.directory "$(pwd)/git/ext/gitdb/gitdb/ext/smmap"
         git config --global core.autocrlf false
 
     - &prepare-repo

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -102,6 +102,73 @@ jobs:
       run: |
         pytest --color=yes -p no:sugar --instafail -vv ${{ matrix.additional-pytest-args }}
 
+  diag-token:
+    runs-on: windows-latest
+
+    env: *cygwin-env
+
+    defaults: *cygwin-defaults
+
+    steps:
+    - *force-lf
+    - *checkout
+    - *install-cygwin
+
+    - name: PowerShell-side token state and file-creation tests
+      shell: pwsh
+      run: |
+        $repo = "D:\a\GitPython\GitPython"
+        Write-Host "==================== whoami /all (PowerShell) ===================="
+        whoami /all
+        Write-Host ""
+        Write-Host "==================== Test A: PowerShell New-Item directory ===================="
+        $td = "$repo\test-pwsh-mkdir"
+        New-Item -ItemType Directory -Path $td -Force | Out-Null
+        $acl = Get-Acl -LiteralPath $td
+        Write-Host "Owner of $td : $($acl.Owner)"
+        Remove-Item $td -Force
+        Write-Host ""
+        Write-Host "==================== Test D: PowerShell -> Git Bash -> PowerShell New-Item ===================="
+        $td4 = "$repo\test-pwsh-bash-pwsh-mkdir"
+        $scriptPath = "$repo\inner-mkdir.ps1"
+        "New-Item -ItemType Directory -Path '$td4' -Force | Out-Null" |
+          Set-Content -Path $scriptPath -Encoding utf8
+        $env:MSYS2_ARG_CONV_EXCL = '*'
+        try {
+          & "C:\Program Files\Git\bin\bash.exe" -c "powershell.exe -NoProfile -ExecutionPolicy Bypass -File '$scriptPath'" 2>&1 | Out-Null
+        } finally {
+          Remove-Item Env:MSYS2_ARG_CONV_EXCL -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $td4) {
+          $acl = Get-Acl -LiteralPath $td4
+          Write-Host "Owner of $td4 (PowerShell -> bash -> PowerShell New-Item) : $($acl.Owner)"
+          Remove-Item $td4 -Force
+        } else {
+          Write-Host "Owner of $td4 (PowerShell -> bash -> PowerShell New-Item) : (directory not created)"
+        }
+        Remove-Item $scriptPath -Force -ErrorAction SilentlyContinue
+
+    - name: Cygwin-side token state and file-creation tests
+      run: |
+        set +e
+        echo "==================== id (Cygwin) ===================="
+        id
+        echo
+        echo "==================== Test B: Cygwin mkdir ===================="
+        td="$(pwd)/test-cygwin-mkdir"
+        mkdir "$td"
+        echo "Owner: $(stat -c '%U(%u)' "$td")"
+        rmdir "$td"
+        echo
+        echo "==================== Test C: Cygwin-spawned Git for Windows git init ===================="
+        td3="$(pwd)/test-cygwin-spawns-wingit"
+        mkdir "$td3"
+        ( cd "$td3" && /cygdrive/c/Program\ Files/Git/bin/git.exe init -q )
+        echo "Owner of $td3 (Cygwin-mkdir)             : $(stat -c '%U(%u)' "$td3")"
+        echo "Owner of $td3/.git (Cygwin->Win git init): $(stat -c '%U(%u)' "$td3/.git")"
+        rm -rf "$td3"
+        true
+
   reproduce-safe-dir:
     strategy:
       matrix:

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -90,64 +90,62 @@ jobs:
       run: |
         pip install '.[test]'
 
-    - &ownership-display
-      name: Show file ownership and safe.directory entries
+    - &ownership-posix-display
+      name: Show POSIX file ownership
+      # Cygwin's `ls -ld` reports the NTFS Owner SID via Cygwin's SID-to-uid
+      # mapping (well-known SIDs by their RID, machine-local accounts by
+      # 0x30000+RID). That mapping is what Cygwin git's
+      # `is_path_owned_by_current_user` reduces to, so this is the view that
+      # determines whether `safe.directory` is consulted.
       run: |
-        echo "==================== File ownership (Cygwin view, ls -ld) ===================="
         for p in \
-            "$(pwd)" \
-            "$(pwd)/.git" \
-            "$(pwd)/git/ext/gitdb" \
-            "$(pwd)/git/ext/gitdb/.git" \
-            "$(pwd)/.git/modules/gitdb" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-            "$(pwd)/.git/modules/gitdb/modules/smmap" \
-            "${HOME:-}" \
-            "${HOME:-}/.gitconfig"; do
-          if [ -n "$p" ]; then
-            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-          fi
+          "$(pwd)" \
+          "$(pwd)/.git" \
+          "$(pwd)/git/ext/gitdb" \
+          "$(pwd)/git/ext/gitdb/.git" \
+          "$(pwd)/.git/modules/gitdb" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+          "$(pwd)/.git/modules/gitdb/modules/smmap" \
+          "${HOME:?HOME is not set}/.gitconfig"
+        do
+          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
         done
-        echo
-        echo "==================== File ownership (Win32 view, Get-Acl) ===================="
-        # Cygwin's ls -ld and stat go through Cygwin's SID-to-uid mapping
-        # (well-known SIDs by their RID, machine-local accounts by 0x30000+RID).
-        # The mapping is deterministic, but going via Win32 Get-Acl gives the
-        # NTAccount form of the NTFS Owner SID directly, with no Cygwin layer
-        # in between -- useful for confirming that what Cygwin reports as
-        # "Administrators" really is the BUILTIN\Administrators SID (S-1-5-32-544)
-        # rather than some local-machine account that Cygwin happens to map to
-        # the same uid. The workflow sets CYGWIN_NOWINPATH=1, so Windows paths
-        # are not on Cygwin's $PATH; invoke powershell.exe by absolute path.
-        ps_exe=/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe
-        if [ -x "$ps_exe" ]; then
-          for p in \
-              "$(pwd)" \
-              "$(pwd)/.git" \
-              "$(pwd)/git/ext/gitdb" \
-              "$(pwd)/git/ext/gitdb/.git" \
-              "$(pwd)/.git/modules/gitdb" \
-              "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
-              "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-              "$(pwd)/.git/modules/gitdb/modules/smmap" \
-              "${HOME:-}/.gitconfig"; do
-            if [ -n "$p" ] && [ -e "$p" ]; then
-              wp=$(cygpath -w "$p")
-              # Escape single-quotes for PowerShell single-quoted string literal: ' -> ''
-              wp_escaped=${wp//\'/\'\'}
-              owner=$("$ps_exe" -NoProfile -NonInteractive -Command \
-                "try { (Get-Acl -LiteralPath '${wp_escaped}').Owner } catch { 'ERROR: ' + \$_.Exception.Message }" \
-                2>/dev/null | tr -d '\r')
-              printf "  %-44s  %s\n" "$owner" "$wp"
-            fi
-          done
-        else
-          echo "($ps_exe not found -- skipping Win32 view)"
-        fi
-        echo
-        echo "==================== safe.directory entries ===================="
-        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
+    - &ownership-ntfs-display
+      name: Show NTFS file ownership
+      # Authoritative NTFS Owner via Get-Acl, with no Cygwin SID-to-uid layer
+      # in between -- useful for confirming what the Cygwin view reports as
+      # "Administrators" is the BUILTIN\Administrators SID (S-1-5-32-544).
+      shell: pwsh
+      run: |
+        $paths = @(
+          "$pwd",
+          "$pwd\.git",
+          "$pwd\git\ext\gitdb",
+          "$pwd\git\ext\gitdb\.git",
+          "$pwd\.git\modules\gitdb",
+          "$pwd\git\ext\gitdb\gitdb\ext\smmap",
+          "$pwd\git\ext\gitdb\gitdb\ext\smmap\.git",
+          "$pwd\.git\modules\gitdb\modules\smmap",
+          "$env:USERPROFILE\.gitconfig"
+        )
+        foreach ($p in $paths) {
+          if (Test-Path -LiteralPath $p) {
+            try {
+              $owner = (Get-Acl -LiteralPath $p).Owner
+            } catch {
+              $owner = "ERROR: $($_.Exception.Message)"
+            }
+            "{0,-44}  {1}" -f $owner, $p
+          } else {
+            "(missing: $p)"
+          }
+        }
+
+    - &safe-directory-display
+      name: Show safe.directory entries
+      run: git config --global --get-all safe.directory
 
     - name: Show version and platform information
       run: |
@@ -251,7 +249,9 @@ jobs:
     - *setup-venv
     - *update-pypa
     - *install-deps
-    - *ownership-display
+    - *ownership-posix-display
+    - *ownership-ntfs-display
+    - *safe-directory-display
 
     - name: Run submodule tests
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -87,25 +87,63 @@ jobs:
       run: |
         pip install '.[test]'
 
-    - name: Show file ownership and safe.directory entries
+    - name: Show POSIX file ownership
+      # Linux and macOS only. On Windows, Git Bash's `ls -ld` reports a
+      # uniform uid+gid for every path regardless of NTFS Owner (MSYS2's
+      # SID-to-uid mapping doesn't have Cygwin's fidelity), so it would
+      # not be informative here. The NTFS Owner check below covers Windows.
+      if: matrix.os-type != 'windows'
       run: |
-        echo "==================== File ownership ===================="
         for p in \
-            "$(pwd)" \
-            "$(pwd)/.git" \
-            "$(pwd)/git/ext/gitdb" \
-            "$(pwd)/git/ext/gitdb/.git" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
-            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-            "${HOME:-}" \
-            "${HOME:-}/.gitconfig"; do
-          if [ -n "$p" ]; then
-            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-          fi
+          "$(pwd)" \
+          "$(pwd)/.git" \
+          "$(pwd)/git/ext/gitdb" \
+          "$(pwd)/git/ext/gitdb/.git" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+          "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+          "${HOME:?HOME is not set}/.gitconfig"
+        do
+          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
         done
-        echo
-        echo "==================== safe.directory entries ===================="
-        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
+    - name: Show NTFS file ownership
+      # Windows only. Reads NTFS Owner directly via Get-Acl, which is the
+      # authoritative view for Windows-side ownership questions; the POSIX
+      # view via Git Bash's MSYS2 layer is not a reliable proxy here.
+      if: matrix.os-type == 'windows'
+      shell: pwsh
+      run: |
+        $paths = @(
+          "$pwd",
+          "$pwd\.git",
+          "$pwd\git\ext\gitdb",
+          "$pwd\git\ext\gitdb\.git",
+          "$pwd\git\ext\gitdb\gitdb\ext\smmap",
+          "$pwd\git\ext\gitdb\gitdb\ext\smmap\.git",
+          "$env:USERPROFILE\.gitconfig"
+        )
+        foreach ($p in $paths) {
+          if (Test-Path -LiteralPath $p) {
+            try {
+              $owner = (Get-Acl -LiteralPath $p).Owner
+            } catch {
+              $owner = "ERROR: $($_.Exception.Message)"
+            }
+            "{0,-44}  {1}" -f $owner, $p
+          } else {
+            "(missing: $p)"
+          }
+        }
+
+    - name: Show safe.directory entries
+      # `actions/checkout`'s safe.directory add is only durable for the
+      # checkout itself (it writes under a throwaway HOME override and
+      # then discards it), so by the time this step runs the runner
+      # user's `~/.gitconfig` has no entries -- and git accepts the
+      # workspace's ownership anyway: Git for Windows via its
+      # Admins-group exemption on the windows matrix; on Linux/macOS
+      # the workspace is owned by the test user. Expected: `(none)`.
+      run: git config --global --get-all safe.directory || echo "(none)"
 
     - name: Show version and platform information
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,9 +53,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        # Temporary, for testing. The standing decision is to NOT pre-clone
-        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
-        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -87,6 +87,26 @@ jobs:
       run: |
         pip install '.[test]'
 
+    - name: Show file ownership and safe.directory entries
+      run: |
+        echo "==================== File ownership ===================="
+        for p in \
+            "$(pwd)" \
+            "$(pwd)/.git" \
+            "$(pwd)/git/ext/gitdb" \
+            "$(pwd)/git/ext/gitdb/.git" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
+            "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
+            "${HOME:-}" \
+            "${HOME:-}/.gitconfig"; do
+          if [ -n "$p" ]; then
+            ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
+          fi
+        done
+        echo
+        echo "==================== safe.directory entries ===================="
+        git config --global --get-all safe.directory 2>&1 || echo "(none)"
+
     - name: Show version and platform information
       run: |
         uname -a

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,6 +53,9 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        # Temporary, for testing. The standing decision is to NOT pre-clone
+        # submodules on CI; see https://github.com/gitpython-developers/GitPython/pull/1715
+        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -6,9 +6,6 @@
 import gc
 import os
 import os.path
-import sys
-
-import pytest
 
 from test.lib import TestBase
 from test.lib.helper import with_rw_directory
@@ -478,11 +475,6 @@ class Tutorials(TestBase):
 
         repo.git.clear_cache()
 
-    @pytest.mark.xfail(
-        sys.platform == "cygwin",
-        reason="Cygwin GitPython can't find SHA for submodule",
-        raises=ValueError,
-    )
     def test_submodules(self):
         # [1-test_submodules]
         repo = self.rorepo

--- a/test/test_fixture_health.py
+++ b/test/test_fixture_health.py
@@ -1,0 +1,91 @@
+# This module is part of GitPython and is released under the
+# 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
+
+"""Verify that fixture directories are usable by git.
+
+If a directory the test suite relies on is rejected by git for "dubious
+ownership" -- because the directory's owner doesn't match the running user
+and there is no ``safe.directory`` entry overriding the check -- three
+submodule-related tests fail in confusing ways. The checks here name the
+root cause clearly so a misconfigured environment is recognizable from the
+test output.
+
+The rejection is most often a CI-workflow problem (the workflow's
+``safe.directory`` list doesn't cover the path); on a developer's own
+clone, it usually reflects an ownership mismatch (sudo clone, restored
+backup, container mount, networked filesystem) rather than a config gap.
+
+These tests do not exercise GitPython's production code. They verify the
+conditions under which production code is exercised are valid.
+
+A check is skipped, rather than failed, if a fixture directory is missing or
+has no ``.git`` marker, since that condition is more naturally diagnosed as
+"``init-tests-after-clone.sh`` hasn't been run" than as a problem with
+``safe.directory``.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Directories git must trust for the test suite to operate normally. The
+# current set is the GitPython working tree plus the working trees of its
+# gitdb submodule and the smmap submodule nested inside gitdb. New entries
+# should be added here whenever the test suite gains a dependency on git
+# accepting another directory.
+FIXTURE_DIRS = [
+    pytest.param(REPO_ROOT, id="repo_root"),
+    pytest.param(REPO_ROOT / "git" / "ext" / "gitdb", id="gitdb"),
+    pytest.param(
+        REPO_ROOT / "git" / "ext" / "gitdb" / "gitdb" / "ext" / "smmap",
+        id="smmap",
+    ),
+]
+
+
+@pytest.mark.parametrize("fixture_dir", FIXTURE_DIRS)
+def test_fixture_dir_is_trusted_by_git(fixture_dir: Path) -> None:
+    """git accepts ``fixture_dir`` as its own repository owned by a trusted user.
+
+    Run ``git -C <fixture_dir> rev-parse --show-toplevel`` and assert it
+    succeeds and reports ``fixture_dir`` itself as the toplevel. Failure
+    typically means the directory's on-disk ownership doesn't match the
+    running user and the CI workflow's ``safe.directory`` list is missing
+    an entry that would override the check.
+    """
+    if not fixture_dir.exists():
+        pytest.skip(f"{fixture_dir} not present (run `git submodule update --init --recursive` from the repo root)")
+    if not (fixture_dir / ".git").exists():
+        pytest.skip(
+            f"{fixture_dir} has no .git marker "
+            "(submodule not initialized; run "
+            "`git submodule update --init --recursive` from the repo root)"
+        )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(fixture_dir), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("git is not installed or not on PATH")
+    assert result.returncode == 0, (
+        f"git refuses to operate in {fixture_dir}.\n"
+        f"stderr: {result.stderr.strip()}\n"
+        "The directory's owner doesn't match the running user and no "
+        "`safe.directory` entry overrides the check. On CI, the "
+        "workflow's `safe.directory` list typically needs an entry for "
+        "this path. Locally, this is unexpected and usually indicates "
+        "an ownership problem worth investigating."
+    )
+    reported = Path(result.stdout.strip())
+    assert reported.samefile(fixture_dir), (
+        f"git reports the toplevel as {reported}, "
+        f"not as {fixture_dir} itself. "
+        "This usually means the directory is not an initialized git "
+        "repository (its `.git` marker may be stale or pointing elsewhere)."
+    )

--- a/test/test_fixture_health.py
+++ b/test/test_fixture_health.py
@@ -3,25 +3,15 @@
 
 """Verify that fixture directories are usable by git.
 
-If a directory the test suite relies on is rejected by git for "dubious
-ownership" -- because the directory's owner doesn't match the running user
-and there is no ``safe.directory`` entry overriding the check -- three
-submodule-related tests fail in confusing ways. The checks here name the
-root cause clearly so a misconfigured environment is recognizable from the
-test output.
+If a fixture directory is missing, isn't an initialized git repository,
+or is rejected by git for "dubious ownership", dependent tests
+elsewhere in the suite fail in opaque ways. The checks here name the
+preconditions directly so a misconfigured environment is recognizable
+from the test output rather than from a cascade of unrelated-seeming
+failures.
 
-The rejection is most often a CI-workflow problem (the workflow's
-``safe.directory`` list doesn't cover the path); on a developer's own
-clone, it usually reflects an ownership mismatch (sudo clone, restored
-backup, container mount, networked filesystem) rather than a config gap.
-
-These tests do not exercise GitPython's production code. They verify the
-conditions under which production code is exercised are valid.
-
-A check is skipped, rather than failed, if a fixture directory is missing or
-has no ``.git`` marker, since that condition is more naturally diagnosed as
-"``init-tests-after-clone.sh`` hasn't been run" than as a problem with
-``safe.directory``.
+These tests do not exercise GitPython's production code. They verify
+the conditions under which production code is exercised are valid.
 """
 
 import subprocess
@@ -38,6 +28,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # accepting another directory.
 FIXTURE_DIRS = [
     pytest.param(REPO_ROOT, id="repo_root"),
+    pytest.param(REPO_ROOT / "git" / "ext" / "gitdb", id="gitdb"),
+    pytest.param(
+        REPO_ROOT / "git" / "ext" / "gitdb" / "gitdb" / "ext" / "smmap",
+        id="smmap",
+    ),
+]
+
+# Submodule working trees that must be present and initialized for the
+# test suite to operate normally: gitdb at `git/ext/gitdb`, and smmap
+# nested inside gitdb at `git/ext/gitdb/gitdb/ext/smmap`. The paths
+# below are anchored at REPO_ROOT (the GitPython source tree), not at
+# any rorepo redirection target.
+SUBMODULE_DIRS = [
     pytest.param(REPO_ROOT / "git" / "ext" / "gitdb", id="gitdb"),
     pytest.param(
         REPO_ROOT / "git" / "ext" / "gitdb" / "gitdb" / "ext" / "smmap",
@@ -88,4 +91,41 @@ def test_fixture_dir_is_trusted_by_git(fixture_dir: Path) -> None:
         f"not as {fixture_dir} itself. "
         "This usually means the directory is not an initialized git "
         "repository (its `.git` marker may be stale or pointing elsewhere)."
+    )
+
+
+@pytest.mark.parametrize("submodule_dir", SUBMODULE_DIRS)
+def test_required_submodule_is_initialized(submodule_dir: Path) -> None:
+    """The submodule's working tree is present and initialized.
+
+    Failure means the source tree is a git clone but the submodule's
+    working tree hasn't been populated. Skipped when the source tree
+    itself isn't a git clone (e.g. an extracted release tarball), since
+    ``git submodule update`` cannot operate there; setups that handle
+    submodules in a separately-prepared tree (via
+    ``GIT_PYTHON_TEST_GIT_REPO_BASE``) are exempted from this check.
+    """
+    if not (REPO_ROOT / ".git").exists():
+        pytest.skip(
+            "Source tree is not a git clone (no .git in REPO_ROOT); submodules "
+            "cannot be initialized via `git submodule update` here. Setups "
+            "that prepare submodules in a separately-pointed tree (via "
+            "GIT_PYTHON_TEST_GIT_REPO_BASE) are exempted from this check."
+        )
+    # The assertion messages below recommend `git submodule update --init
+    # --recursive` rather than `init-tests-after-clone.sh`, even though the
+    # latter is the documented entry point for first-time test setup. Two
+    # reasons: the script performs `git reset --hard` operations that can
+    # destroy local work, and #1713 showed the script itself can carry
+    # submodule-init regressions, in which case recommending it would lead
+    # developers in a circle. The direct git command is a safe minimal fix
+    # for this test's specific failure mode and bypasses any such regression.
+    assert submodule_dir.is_dir(), (
+        f"Submodule working tree missing: {submodule_dir}.\n"
+        "Run `git submodule update --init --recursive` from the repo root."
+    )
+    assert (submodule_dir / ".git").exists(), (
+        f"Submodule directory exists but has no .git marker: {submodule_dir}.\n"
+        "The submodule hasn't been initialized. "
+        "Run `git submodule update --init --recursive` from the repo root."
     )

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -877,11 +877,6 @@ class TestRepo(TestBase):
         target_type = GitCmdObjectDB
         self.assertIsInstance(self.rorepo.odb, target_type)
 
-    @pytest.mark.xfail(
-        sys.platform == "cygwin",
-        reason="Cygwin GitPython can't find submodule SHA",
-        raises=ValueError,
-    )
     def test_submodules(self):
         self.assertEqual(len(self.rorepo.submodules), 1)  # non-recursive
         self.assertGreaterEqual(len(list(self.rorepo.iter_submodules())), 2)

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -508,9 +508,9 @@ class TestSubmodule(TestBase):
         with rm.config_writer():
             pass
 
-        # Deep traversal gitdb / async.
+        # Deep traversal yields gitdb and its nested smmap.
         rsmsp = [sm.path for sm in rm.traverse()]
-        assert len(rsmsp) >= 2  # gitdb and async [and smmap], async being a child of gitdb.
+        assert rsmsp == ["git/ext/gitdb", "gitdb/ext/smmap"]
 
         # Cannot set the parent commit as root module's path didn't exist.
         self.assertRaises(ValueError, rm.set_parent_commit, "HEAD")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -481,11 +481,6 @@ class TestSubmodule(TestBase):
         self._do_base_tests(rwrepo)
 
     @pytest.mark.xfail(
-        sys.platform == "cygwin",
-        reason="Cygwin GitPython can't find submodule SHA",
-        raises=ValueError,
-    )
-    @pytest.mark.xfail(
         HIDE_WINDOWS_KNOWN_ERRORS,
         reason=(
             '"The process cannot access the file because it is being used by another process"'


### PR DESCRIPTION
In #1455, which got Cygwin tests running on GitHub Actions, DWesl mentioned:

> I have three test failures left that I don't understand, and hope someone here knows what's going on.

Byron's review mentioned:

> The failures are all related to submodule handling, and I think that functionality isn't necessarily widely used anymore.

Further discussion raised the question of whether this was the case, as well as workarounds for using submodules on Cygwin even if submodule-specific functionality is broken. The tests were marked `xfail` (54bae76, 0eda0a5, 7f3689d) and the PR was merged.

It turns out the GitPython submodule functionality is not broken on Cygwin, and neither are the tests! Instead, the problem is that the `rorepo` fixture is GitPython's own repository, and when `actions/checkout` clones GitPython, the top-level `gitdb` directory is owned by the `Administrators` rather than the `runneradmin` user. Git for Windows special-cases this, judging that repositories owned by the `Administrators` group are safe for members of that group to trust. Cygwin git does not special-case this, so more `safe.directory` entries are needed to assuage it.

The key to identifying the cause of the problem is that only tests that use `self.rorepo` and attempt submodule operations, but not those using `@with_rw_repo` and attempting submodule operations, failed in this way. The nature of the problem was obscured by several oddities, though the fourth and final oddity is also what revealed it:

1. The subtleties of `safe.directory` protections on Windows are unintuitive and complex even in cases where they work fully as intended, only one Git implementation is involved, and CI behavior is likely to match local behavior, none of which hold here.
2. Whether `actions/checkout` clones the submodules, or leaves them to be cloned by `init-tests-after-clone.sh`, is irrelevant to all aspects of this problem. This is even though the action uses Git for Windows, while the init script (in a Cygwin job) uses Cygwin git. The `git/ext/gitdb` directory is created when checking out GitPython itself, and it is owned by `Administrators`.
3. The dubious ownership happens in a `git cat-file --batch-check` invocation we intend to reuse across operations. The git subprocess quits before reading its input. Currently GitPython issues a message about *possible* dubious ownership in this situation, since that's the most common cause. But it is not the only possible cause of that message from GitPython--so if one does not expect that the error is due to `safe.directory` protections, then one might dismiss that.
4. We run `git cat-file --batch-check` and send refs through the pipe. But if there is dubious ownership, then the git process quits before reading its input. So there is a race condition: our write may fail with `EPIPE` and raise `BrokenPipeError`, or our read may complete with EOF, such that we pass `b""` to `_parse_object_header`, which raises `ValueError`.

`BrokenPipeError` is a subclass of `IOError`, and we currently swallow `IOError` in some of the places where this happens. The `ValueError` case is overwhelmingly more common. That's the `xfail` decorations from #1455 covered. Recently, `EPIPE` wins the race slightly more often than in the past, and we've had to rerun tests a number of times. It would be possible to add more exception types to the `xfail` decorations, but a better approach is to verify the complete details of what is going wrong and why, add more regression tests, and fix the problem properly, removing the `xfail`s. This PR does those things.

The fix is very simple: we already have a CI step that adds paths to the Cygwin git `safe.directory` configuration, and the fix is to add the missing paths related to submodules. But the tests are somewhat nontrivial, and the partially reverted instrumentation to fully confirm the cause and facilitate easier debugging in the future is also somewhat nontrivial.

*The code changes and commit messages in this PR were made with Claude Code, as disclosed in commit message trailers.* I've reviewed and substantially adjusted the code changes. I've also reviewed and honed the commit messages through many rounds of revision, including manual edits. A few of the commit messages are long and dense. I have made sure to spend more time with those, to ensure I believe the details are warranted, since even though I am well known for writing long detailed commit messages, I understand this is something people are more wary of when LLMs are involved (since they can generate large amounts of text quickly). As for this PR description, no part of it is LLM-generated, though I did use Claude for proofreading.

---

The commit messages describe the situation, the evidence for it, and the fix from the perspective of tracing what has occurred. One aspect of the bug--the behavior of `safe.directory` protections on Windows when multiple git implementations are used and the repository has submodules that it must operate on--is particularly non-obvious, unintuitive, and interesting, and it may end up being relevant to future improvements here in GitPython, as well as to submodule portability subtleties that might arise in the future in gitoxide. Hence this section.

On POSIX, the owner and group owner of a file are separate concepts, with each file being owned by one user and group-owned by one group. But on Windows there is a unified concept of Owner. Unlike on a Unix-like system, on Windows a user or a group can own a file in the same sense of "own." Users usually own the files they create, but one of the exceptions to this is that users who are members of the `Administrators` group create files that are owned by the `Administrators` group. This exception is actually more specific than that: it only applies when the user is actually running with their unfiltered (full) token in which the `Administrators` group is active. Usually, members of the `Administrators` group on Windows run with UAC enabled and configured to require elevation to act with their full administrative powers. But the `runneradmin` user that runs Windows CI jobs runs with a full admin token, so files it creates are owned by `Administrators`.

Git uses ownership as a powerful trust signal. It will operate on repositories it thinks the user running it owns, since the configuration and hooks in such a repository are presumably safe. Git checks if some important repository paths, such as the repo's top-level directory and its `.git` dir, have the user running it as their owner. If they do, it trusts the repository. For any not owned, it checks if they match any values of the `safe.directory` configuration variable. If any are neither owned by the user nor match entries in `safe.directory`, then Git refuses to operate. But this gets weird on Windows, where the directories might be owned by something that isn't a user at all:

- Git for Windows lets members of the `Administrators` group operate on repositories whose ownership matches what those users might very well create themselves. If the user is in `Administrators`, and a directory is owned by `Administrators`, then Git for Windows considers it to be owned by the user for purpose of assessing trust.

- Cygwin git does not do this. It doesn't generally need to. If you start a program built against `cygwin1.dll`--whether that program is `git` or anything else--it changes the owner of the process token to the user, and then the owner inherited by securable objects (such as files) the process creates is the user instead of whatever it was before. So a member of the `Administrators` group, acting with the full powers thereof, can run Cygwin git with `Administrators` as the process token owner initially--but the process token owner is changed to the user, almost immediately, before Cygwin git's `main()` function is called. For this reason, Cygwin git typically has no need to treat repositories owned by the `Administrators` group specially--it never creates such a repository.

 When we clone a repository that has a submodule, we may or may not also clone the submodule. If we do, we might clone it at the same time, or later. But *whatever happens*, so long as the top-level repository is able to be checked out, we first get the top-level repository with an empty directory at the submodule root. Whatever ownership we are creating files with, we create the submodule root with that ownership.
 
 In all our Windows CI jobs, including the Cygwin jobs, we use `actions/checkout` to clone. While `actions/checkout` is capable of cloning repositories using the GitHub REST API, it only uses this as a fallback strategy. It first checks if a recent enough version of `git` is available and, if so, uses it. On all our Windows CI jobs, including the Cygwin jobs, `actions/checkout` clones the GitPython repository using Git for Windows.
 
 Thus, no matter how its submodules are cloned, the top-level directory of `gitdb` is owned by the `Administrators` group. Cygwin git would therefore refuse to operate on it. But the GitPython test suite uses the GitPython repository itself, as well as its direct submodule gitdb and its nested submodule smmap, as test fixtures. Because Cygwin git wouldn't operate on the gitdb submodule, tests that use it were failing.
 
 Most submodule tests didn't have a problem, because they use `@with_rw_repo`, which creates a new clone, instead of `self.rorepo`, which uses the repository in place. On Cygwin, `@with_rw_repo` clones the repository with Cygwin `git`. As described above, when Cygwin git clones repositories, it clones them as the user.
 
 More remarkably, while I have added `safe.directory` entries for the nested smmap module, this is actually not strictly necessary--smmap never had dubious ownership! The reason is that *only* the `gitdb` directory created in the top-level GitPython checkout is owned by `Administrators`. No contents of submodules, not even of the gitdb submodule, are checked out as owned by `Administrators`. This is the case even if `actions/checkout` is made to clone them all by setting `submodules: recursive`. (I tested with this to be sure. But I did not keep this, since we have good reasons to validate that our init script will clone the submodules even if they were not cloned before. See #1713 and #1715 on this.) That is to say that none of the files created when cloning submodules are owned by `Administrators` *even when Git for Windows creates them in the same top-level `git clone` command*.
 
 How can this be? Historically, the machinery that operated on submodules was implemented in scripts. Over time, it basically all came to be implemented in C, except that the `git-submodule` subcommand itself remains implemented by `git-submodule.sh`. Today, the major functionality of the script is to parse options, apply defaults, look up some information about the current repository, and call `git submodule--helper` to do the real work. In Git for Windows, the C code that does the real work is in native Windows programs such as `git.exe`. But `git-submodule.sh` is a shell script. Its interpreter is `sh.exe` from the MSYS2 "Git Bash" environment that Git for Windows ships.
 
 MSYS2 is like Cygwin (MSYS2 is a fork of MSYS, which is a fork of Cygwin). Just as Cygwin programs link to `cygwin1.dll`, which does various setup--including, as described above, *resetting the process's token owner to the user*--MSYS2 programs link to `msys-2.0.dll`, which does that very same thing. Therefore, a user who is a member of the `Administrators` group can run git with `Administrators` as its process token owner, but in any chain of subprocesses that goes through a shell invocation, everything at or below that invocation will operate with it reset to the user.