### PR TITLE
Cut xtrace noise from POSIX-ownership diagnostic steps

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -63,17 +63,15 @@ jobs:
 
     - name: Show POSIX file ownership
       run: |
-        for p in \
+        ls -ld -- \
           "$(pwd)" \
           "$(pwd)/.git" \
           "$(pwd)/git/ext/gitdb" \
           "$(pwd)/git/ext/gitdb/.git" \
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-          "${HOME:?HOME is not set}/.gitconfig"
-        do
-          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-        done
+          "${HOME:?HOME is not set}/.gitconfig" \
+          2>&1 || true
 
     - name: Show safe.directory entries
       # `actions/checkout`'s safe.directory add is only durable for the

--- a/.github/workflows/cygwin-test.yml
+++ b/.github/workflows/cygwin-test.yml
@@ -89,7 +89,7 @@ jobs:
       # `is_path_owned_by_current_user` reduces to, so this is the view that
       # determines whether `safe.directory` is consulted.
       run: |
-        for p in \
+        ls -ld -- \
           "$(pwd)" \
           "$(pwd)/.git" \
           "$(pwd)/git/ext/gitdb" \
@@ -98,10 +98,8 @@ jobs:
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
           "$(pwd)/.git/modules/gitdb/modules/smmap" \
-          "${HOME:?HOME is not set}/.gitconfig"
-        do
-          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-        done
+          "${HOME:?HOME is not set}/.gitconfig" \
+          2>&1 || true
 
     - name: Show NTFS file ownership
       # Authoritative NTFS Owner via Get-Acl, with no Cygwin SID-to-uid layer

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -94,17 +94,15 @@ jobs:
       # not be informative here. The NTFS Owner check below covers Windows.
       if: matrix.os-type != 'windows'
       run: |
-        for p in \
+        ls -ld -- \
           "$(pwd)" \
           "$(pwd)/.git" \
           "$(pwd)/git/ext/gitdb" \
           "$(pwd)/git/ext/gitdb/.git" \
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap" \
           "$(pwd)/git/ext/gitdb/gitdb/ext/smmap/.git" \
-          "${HOME:?HOME is not set}/.gitconfig"
-        do
-          ls -ld -- "$p" 2>/dev/null || echo "(missing: $p)"
-        done
+          "${HOME:?HOME is not set}/.gitconfig" \
+          2>&1 || true
 
     - name: Show NTFS file ownership
       # Windows only. Reads NTFS Owner directly via Get-Acl, which is the


### PR DESCRIPTION
In https://github.com/gitpython-developers/GitPython/pull/2154#pullrequestreview-4307636857 I noted that the new POSIX ownersip diagnostics are hard to read, but I wasn't sure of the best way to fix it. The solution turns out to be simple and doesn't require `set +x`.

The changes here, and commit message, are generated by Claude, as noted in the trailer. I've reviewed the changes and checked the output.