### PR TITLE
fix: IndexFile.diff(None) returns empty on new repo with no commits

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1569,7 +1569,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         # Diff against working copy - can be handled by superclass natively.
         try:
-            self.repo.head.commit
+            _ = self.repo.head.commit
             return super().diff(other, paths, create_patch, **kwargs)
         except ValueError:
             # No commits yet - diff against null tree instead

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1568,4 +1568,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
             raise ValueError("other must be None, Diffable.INDEX, a Tree or Commit, was %r" % other)
 
         # Diff against working copy - can be handled by superclass natively.
-        return super().diff(other, paths, create_patch, **kwargs)
+        try:
+            self.repo.head.commit
+            return super().diff(other, paths, create_patch, **kwargs)
+        except ValueError:
+            # No commits yet - diff against null tree instead
+            return self.diff(git_diff.NULL_TREE, paths, create_patch, **kwargs)


### PR DESCRIPTION
Fixes #2025

## Problem
Calling repo.index.diff(None) after init → add → write 
on a new repo with no commits returns empty DiffIndex.

## Root Cause
The superclass diff() fails silently when no HEAD commit exists.

## Fix
Detect missing HEAD commit (ValueError) and fall back 
to NULL_TREE diff instead.