### PR TITLE
Fix commit hooks respecting core.hooksPath

### DIFF
--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -64,6 +64,16 @@ def hook_path(name: str, git_dir: PathLike) -> str:
     return osp.join(git_dir, "hooks", name)
 
 
+def _commit_hook_path(name: str, index: "IndexFile") -> str:
+    """:return: path to the named commit hook, respecting Git's core.hooksPath."""
+    hp = index.repo.git.rev_parse("--git-path", f"hooks/{name}")
+    if osp.isabs(hp):
+        return hp
+
+    base_dir = index.repo.working_dir or index.repo.git_dir
+    return osp.abspath(osp.join(base_dir, hp))
+
+
 def _has_file_extension(path: str) -> str:
     return osp.splitext(path)[1]
 
@@ -82,7 +92,7 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
 
     :raise git.exc.HookExecutionError:
     """
-    hp = hook_path(name, index.repo.git_dir)
+    hp = _commit_hook_path(name, index)
     if not os.access(hp, os.X_OK):
         return
 

--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -66,12 +66,13 @@ def hook_path(name: str, git_dir: PathLike) -> str:
 
 def _commit_hook_path(name: str, index: "IndexFile") -> str:
     """:return: path to the named commit hook, respecting Git's core.hooksPath."""
-    hp = index.repo.git.rev_parse("--git-path", f"hooks/{name}")
-    if osp.isabs(hp):
-        return hp
+    with index.repo.config_reader() as config:
+        hooks_dir = config.get("core", "hooksPath", fallback="")
 
-    base_dir = index.repo.working_dir or index.repo.git_dir
-    return osp.abspath(osp.join(base_dir, hp))
+    if not hooks_dir:
+        return hook_path(name, index.repo.git_dir)
+
+    return osp.abspath(osp.join(index.repo.working_dir, osp.expanduser(hooks_dir), name))
 
 
 def _has_file_extension(path: str) -> str:
@@ -104,8 +105,14 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
         if sys.platform == "win32" and not _has_file_extension(hp):
             # Windows only uses extensions to determine how to open files
             # (doesn't understand shebangs). Try using bash to run the hook.
-            relative_hp = Path(hp).relative_to(index.repo.working_dir).as_posix()
-            cmd = ["bash.exe", relative_hp]
+            try:
+                bash_hp = osp.relpath(hp, index.repo.working_dir)
+            except ValueError:
+                # Different drives have no relative path on Windows. Git Bash accepts
+                # an absolute path in this form, although a relative path is preferable
+                # because it also works with the Windows Subsystem for Linux wrapper.
+                bash_hp = hp
+            cmd = ["bash.exe", Path(bash_hp).as_posix()]
 
         process = safer_popen(
             cmd + list(args),

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1161,6 +1161,32 @@ class TestIndex(TestBase):
         index.commit("This should not fail")
 
     @pytest.mark.xfail(
+        type(_win_bash_status) is WinBashStatus.Absent,
+        reason="Can't run a hook on Windows without bash.exe.",
+        raises=HookExecutionError,
+    )
+    @pytest.mark.xfail(
+        type(_win_bash_status) is WinBashStatus.WslNoDistro,
+        reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
+        raises=HookExecutionError,
+    )
+    @with_rw_repo("HEAD", bare=True)
+    def test_pre_commit_hook_respects_core_hooks_path(self, rw_repo):
+        index = rw_repo.index
+        hooks_dir = Path(index.repo.git_dir, "custom-hooks")
+        hooks_dir.mkdir()
+        hp = hooks_dir / "pre-commit"
+        hp.write_text(HOOKS_SHEBANG + "echo 'ran custom hook' >custom-hook-output.txt", encoding="utf-8")
+        os.chmod(hp, 0o744)
+
+        with index.repo.config_writer() as writer:
+            writer.set_value("core", "hooksPath", "custom-hooks")
+
+        index.commit("This should run the custom hook")
+        output = Path(rw_repo.git_dir, "custom-hook-output.txt").read_text(encoding="utf-8")
+        self.assertEqual(output, "ran custom hook\n")
+
+    @pytest.mark.xfail(
         type(_win_bash_status) is WinBashStatus.WslNoDistro,
         reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=AssertionError,

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1099,9 +1099,35 @@ class TestIndex(TestBase):
     def test_run_commit_hook(self, rw_repo):
         index = rw_repo.index
         _make_hook(index.repo.git_dir, "fake-hook", "echo 'ran fake hook' >output.txt")
-        run_commit_hook("fake-hook", index)
-        output = Path(rw_repo.git_dir, "output.txt").read_text(encoding="utf-8")
-        self.assertEqual(output, "ran fake hook\n")
+        output = Path(rw_repo.git_dir, "output.txt")
+        with mock.patch.object(Repo, "config_level", ("repository",)):
+            with mock.patch.object(Git, "execute", side_effect=AssertionError("hook lookup must not run git")):
+                run_commit_hook("fake-hook", index)
+                self.assertEqual(output.read_text(encoding="utf-8"), "ran fake hook\n")
+
+                output.unlink()
+                with index.repo.config_writer() as writer:
+                    writer.set_value("core", "hooksPath", "")
+                run_commit_hook("fake-hook", index)
+
+        self.assertEqual(output.read_text(encoding="utf-8"), "ran fake hook\n")
+
+    @with_rw_directory
+    def test_run_commit_hook_outside_worktree_on_windows(self, rw_dir):
+        root = Path(rw_dir).resolve()
+        repo = Repo.init(root / "repo")
+        hooks_dir = root / "hooks"
+        _make_hook(root, "fake-hook", "exit 0")
+        with repo.config_writer() as writer:
+            writer.set_value("core", "hooksPath", str(hooks_dir))
+
+        with mock.patch("git.index.fun.sys.platform", "win32"):
+            with mock.patch("git.index.fun.safer_popen") as popen, mock.patch("git.index.fun.handle_process_output"):
+                popen.return_value.returncode = 0
+                run_commit_hook("fake-hook", repo.index)
+
+        command = popen.call_args[0][0]
+        self.assertEqual(command, ["bash.exe", "../hooks/fake-hook"])
 
     @ddt.data((False,), (True,))
     @with_rw_directory
@@ -1170,10 +1196,10 @@ class TestIndex(TestBase):
         reason="Currently uses the bash.exe of WSL, even with no WSL distro installed",
         raises=HookExecutionError,
     )
-    @with_rw_repo("HEAD", bare=True)
+    @with_rw_repo("HEAD")
     def test_pre_commit_hook_respects_core_hooks_path(self, rw_repo):
         index = rw_repo.index
-        hooks_dir = Path(index.repo.git_dir, "custom-hooks")
+        hooks_dir = Path(index.repo.working_dir, "custom-hooks")
         hooks_dir.mkdir()
         hp = hooks_dir / "pre-commit"
         hp.write_text(HOOKS_SHEBANG + "echo 'ran custom hook' >custom-hook-output.txt", encoding="utf-8")
@@ -1183,7 +1209,7 @@ class TestIndex(TestBase):
             writer.set_value("core", "hooksPath", "custom-hooks")
 
         index.commit("This should run the custom hook")
-        output = Path(rw_repo.git_dir, "custom-hook-output.txt").read_text(encoding="utf-8")
+        output = Path(rw_repo.working_dir, "custom-hook-output.txt").read_text(encoding="utf-8")
         self.assertEqual(output, "ran custom hook\n")
 
     @pytest.mark.xfail(


### PR DESCRIPTION
## Tasks

- [ ] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Read the effective core.hooksPath setting case-insensitively through GitPython configuration only when it is present and non-empty.
- Preserve the existing .git/hooks behavior—and avoid a Git subprocess—when core.hooksPath is unset or empty.
- Resolve configured relative hook directories from the directory where commit hooks run, while supporting absolute and home-relative paths.
- Keep the Windows Bash fallback working for hooks outside the repository worktree.
- Cover default lookup, mixed-case configuration, non-bare relative paths, and out-of-worktree Windows command construction.

Fixes #2083

## Test Plan

- 31 index tests passed locally.
- Ruff lint and format checks passed.
- mypy passed for git/index/fun.py.
- Full GitHub Actions matrix will be revalidated after the latest review fix.