### PR TITLE
fix: block joined short unsafe clone options

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -957,7 +957,10 @@ class Git(metaclass=_GitMeta):
         option_tokens = option_name.split(None, 1)
         if not option_tokens:
             return ""
-        return dashify(option_tokens[0])
+        option_token = option_tokens[0]
+        if option.startswith("-") and not option.startswith("--") and len(option_token) > 1:
+            option_token = option_token[:1]
+        return dashify(option_token)
 
     @classmethod
     def check_unsafe_options(cls, options: List[str], unsafe_options: List[str]) -> None:

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -118,8 +118,10 @@ class TestClone(TestBase):
             unsafe_options = [
                 f"--upload-pack='touch {tmp_file}'",
                 f"-u 'touch {tmp_file}'",
+                f"-u{tmp_file}",
                 "--config=protocol.ext.allow=always",
                 "-c protocol.ext.allow=always",
+                "-cprotocol.ext.allow=always",
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
@@ -207,8 +209,10 @@ class TestClone(TestBase):
             unsafe_options = [
                 f"--upload-pack='touch {tmp_file}'",
                 f"-u 'touch {tmp_file}'",
+                f"-u{tmp_file}",
                 "--config=protocol.ext.allow=always",
                 "-c protocol.ext.allow=always",
+                "-cprotocol.ext.allow=always",
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -162,6 +162,8 @@ class TestGit(TestBase):
             (["exec"], ["--exec"]),
             (["u"], ["-u"]),
             (["c"], ["-c"]),
+            (["-u/tmp/helper"], ["-u"]),
+            (["-cprotocol.ext.allow=always"], ["-c"]),
             (["--upload-pack=/tmp/helper"], ["--upload-pack"]),
             (["--config core.filemode=false"], ["--config"]),
         ]


### PR DESCRIPTION
## Tasks

- [x] refackiew 
- [ ] @EliahKagan review, and particularly to check if this would sufficiently resolve the advisory. To me it seems so.

----

## Advisory

- URL: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-v396-v7q4-x2qj
- GHSA ID: GHSA-v396-v7q4-x2qj
- Severity: high
- Affected package: GitPython
- Vulnerable range: = 3.1.50
- Patched versions: unreleased at time of writing

## Changes

- Normalize short-form clone options with attached values for unsafe-option checks in `Git._canonicalize_option_name`, so inputs like `-u/tmp/helper` and `-cprotocol.ext.allow=always` are correctly classified as `-u` and `-c`.
- Added regression coverage for joined short `-u...` and `-c...` bypass forms in `test_clone_unsafe_options` and `test_clone_from_unsafe_options`.
- Added explicit unsafe-option canonicalization assertions in `test_check_unsafe_options_normalizes_kwargs`.

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Validation

- `gh pr checks 2162 --watch` completed successfully (latest run on this PR head).
- Codex review run for commit `2568f2b7`.
