### PR TITLE
Allow relative config paths with includes

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -634,6 +634,8 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
             files_to_read = list(self._file_or_files)
         # END ensure we have a copy of the paths to handle
 
+        files_to_read = [osp.abspath(path) if isinstance(path, (str, os.PathLike)) else path for path in files_to_read]
+
         seen = set(files_to_read)
         num_read_include_files = 0
         while files_to_read:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -311,6 +311,20 @@ class TestBase(TestCase):
             check_test_value(cr, tv)
 
     @with_rw_directory
+    def test_config_relative_path_include(self, rw_dir):
+        included_path = osp.join(rw_dir, "included")
+        with GitConfigParser(included_path, read_only=False) as cw:
+            cw.set_value("included", "value", "included")
+
+        config_path = osp.join(rw_dir, "config")
+        with GitConfigParser(config_path, read_only=False) as cw:
+            cw.set_value("include", "path", "included")
+
+        relative_config_path = osp.relpath(config_path)
+        with GitConfigParser(relative_config_path, read_only=True) as cr:
+            assert cr.get_value("included", "value") == "included"
+
+    @with_rw_directory
     def test_multiple_include_paths_with_same_key(self, rw_dir):
         """Test that multiple 'path' entries under [include] are all respected.
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

GitPython already supports relative include paths, but raised an `AssertionError` when the top-level configuration file was itself passed as a relative path. Normalize path-based parser inputs before reading so relative includes resolve against their containing config file and cycle detection uses consistent absolute paths.

Fixes #2103

## Git behavior reference

This matches Git documentation and the relative and chained-relative include cases in `t/t1305-config-include.sh`.

## Validation

- `uv run pytest -q test/test_config.py` (31 passed, 1 skipped)
- `uv run pre-commit run --files git/config.py test/test_config.py`
- `uv run mypy git/config.py`
- `git diff --check`
- Full suite: 631 passed, 75 skipped, 34 unrelated environment failures due to uninitialized nested submodules and a missing legacy `master` branch