### PR TITLE
Skip cross-drive relative config test on Windows

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -320,6 +320,9 @@ class TestBase(TestCase):
         with GitConfigParser(config_path, read_only=False) as cw:
             cw.set_value("include", "path", "included")
 
+        if osp.splitdrive(config_path)[0] != osp.splitdrive(os.getcwd())[0]:
+            pytest.skip("The temporary directory and checkout are on different drives")
+
         relative_config_path = osp.relpath(config_path)
         with GitConfigParser(relative_config_path, read_only=True) as cr:
             assert cr.get_value("included", "value") == "included"


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

```text
On Windows, this test is failing. Maybe fix by not running it there:

FAILED test/test_config.py::TestBase::test_config_relative_path_include - ValueError: path is on mount 'C:', start on mount 'D:'\n= 1 failed, 700 passed, 45 skipped, 13 xfailed, 1 xpassed, 3 warnings in 305.88s (0:05:05) =\n```\n\n## Change\n\nSkip `test_config_relative_path_include` only when the temporary config and current working directory are on different drives. Same-drive Windows environments retain coverage.\n\n## Validation\n\n- `pytest -q test/test_config.py` (31 passed, 1 existing skip)\n- `ruff check test/test_config.py`\n- `ruff format --check test/test_config.py`\n- Codex review of `67082d64` (no findings)