### PR TITLE
fix: validate config section delimiters

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -897,6 +897,22 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
     def _assure_config_name_safe(self, name: "cp._SectionName", label: str) -> None:
         if isinstance(name, str) and UNSAFE_CONFIG_CHARS_RE.search(name):
             raise ValueError("Git config %s names must not contain CR, LF, or NUL" % label)
+        if label == "section" and isinstance(name, str):
+            in_quotes = False
+            escaped = False
+            for index, char in enumerate(name):
+                if escaped:
+                    escaped = False
+                elif in_quotes and char == "\\":
+                    escaped = True
+                elif char == '"':
+                    if not in_quotes and (index == 0 or name[index - 1] not in " \t"):
+                        raise ValueError("Git config quoted subsection names must begin after whitespace")
+                    in_quotes = not in_quotes
+                elif char == "]" and not in_quotes:
+                    raise ValueError("Git config section names must not contain an unquoted closing bracket")
+            if in_quotes:
+                raise ValueError("Git config section names must not contain an unterminated quote")
 
     @needs_values
     @set_dirty_and_flush_changes

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -195,6 +195,53 @@ class TestBase(TestCase):
             self.assertFalse(git_config.has_section("core"))
 
     @with_rw_directory
+    def test_writer_rejects_unquoted_section_terminators(self, rw_dir):
+        config_path = osp.join(rw_dir, "config")
+        bad_sections = (
+            "user] [other",
+            'user"] [other"',
+            'submodule "docs"] [other',
+            'submodule "docs] [other',
+            'submodule "docs] [other\\',
+        )
+        safe_section = 'submodule "docs]archive"'
+
+        with GitConfigParser(config_path, read_only=False) as git_config:
+            git_config.add_section("user")
+            for bad_section in bad_sections:
+                with pytest.raises(ValueError, match="section name"):
+                    git_config.add_section(bad_section)
+                with pytest.raises(ValueError, match="section name"):
+                    git_config.set(bad_section, "name", "value")
+                with pytest.raises(ValueError, match="section name"):
+                    git_config.set_value(bad_section, "name", "value")
+                with pytest.raises(ValueError, match="section name"):
+                    git_config.add_value(bad_section, "name", "value")
+                with pytest.raises(ValueError, match="section name"):
+                    git_config.rename_section("user", bad_section)
+
+            git_config.set_value("user", "name", "safe")
+            git_config.set_value(safe_section, "name", "safe")
+            self.assertEqual(git_config.get_value(safe_section, "name"), "safe")
+
+        # A closing bracket inside a quoted subsection name is data, not a section terminator.
+        with open(config_path, "rb") as config_file:
+            self.assertIn(
+                b'[submodule "docs]archive"]\n',
+                config_file.read(),
+                "a closing bracket within a quoted subsection name should be preserved",
+            )
+
+        # Reparse the file to verify that rejected names did not inject an [other] section.
+        with GitConfigParser(config_path, read_only=True) as git_config:
+            self.assertEqual(
+                git_config.get_value("user", "name"),
+                "safe",
+                "rejected section names corrupted the existing section",
+            )
+            self.assertFalse(git_config.has_section("other"), "an unsafe section name injected an [other] section")
+
+    @with_rw_directory
     def test_set_and_add_value_reject_unsafe_value_characters(self, rw_dir):
         config_path = osp.join(rw_dir, "config")
         bad_values = ("foo\rbar", "foo\nbar", "foo\x00bar", b"foo\nbar")


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-3rp5-jjmw-4wv2

GHSA-3rp5-jjmw-4wv2

## Advisory summary

- Severity: High
- Package: `gitpython` (`pip`)
- Affected versions: `<= 3.1.52`
- Patched versions: Not yet assigned
- CVE: Not yet assigned

## Summary

- Validate serialized configuration section boundaries at the shared writer entry points.
- Reject unquoted closing section delimiters while preserving delimiters inside valid quoted subsections.
- Cover plain and quoted-subsection-shaped unsafe inputs across the public writer APIs, plus a valid quoted-subsection compatibility case.

## Git baseline

Compared with Git at `a23bace963d508bd96983cc637131392d3face18`: basic section parsing terminates on an unquoted closing bracket, while the extended form permits brackets inside quoted subsection text and requires a final bracket after the closing quote.

## Validation

- `.venv/bin/pytest test/test_config.py -q` — 32 passed, 1 known skip
- `.venv/bin/ruff check git/config.py test/test_config.py`
- `.venv/bin/ruff format --check git/config.py test/test_config.py`
- `git diff --check`
- Codex commit review completed; its compatibility finding was addressed and the refreshed commit passed review.