### PR TITLE
Fix create_patch with mnemonic diff prefixes

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -253,17 +253,20 @@ class Diffable:
         if paths is not None and not isinstance(paths, (tuple, list)):
             paths = [paths]
 
-        diff_cmd = self.repo.git.diff
+        # Patch parsing relies on Git's standard "a/" and "b/" path prefixes.
+        # Override diff.mnemonicPrefix so a user's configuration cannot change them.
+        git = self.repo.git(c="diff.mnemonicPrefix=false")
+        diff_cmd = git.diff
         if other is INDEX:
             args.insert(0, "--cached")
         elif other is NULL_TREE:
             args.insert(0, "-r")  # Recursive diff-tree.
             args.insert(0, "--root")
-            diff_cmd = self.repo.git.diff_tree
+            diff_cmd = git.diff_tree
         elif other is not None:
             args.insert(0, "-r")  # Recursive diff-tree.
             args.insert(0, other)
-            diff_cmd = self.repo.git.diff_tree
+            diff_cmd = git.diff_tree
 
         args.insert(0, self)
 

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1539,7 +1539,9 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 args.extend(paths)
 
             kwargs["as_process"] = True
-            proc = self.repo.git.diff(*args, **kwargs)
+            # Patch parsing relies on Git's standard "a/" and "b/" path prefixes.
+            # Override diff.mnemonicPrefix so a user's configuration cannot change them.
+            proc = self.repo.git(c="diff.mnemonicPrefix=false").diff(*args, **kwargs)
 
             diff_method = (
                 git_diff.Diff._index_from_patch_format if create_patch else git_diff.Diff._index_from_raw_format

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -309,6 +309,35 @@ class TestDiff(TestBase):
         self.assertIsNone(diff_index[0].a_path, repr(diff_index[0].a_path))
         self.assertEqual(diff_index[0].b_path, "file with spaces", repr(diff_index[0].b_path))
 
+    @with_rw_directory
+    def test_diff_ignores_mnemonic_prefix_config(self, rw_dir):
+        repo = Repo.init(rw_dir)
+        file_path = osp.join(rw_dir, "file.txt")
+        with open(file_path, "w", encoding="utf-8") as stream:
+            stream.write("first\n")
+        repo.index.add([file_path])
+
+        with repo.config_writer() as writer:
+            writer.set_value("diff", "mnemonicPrefix", True)
+
+        # IndexFile has a separate implementation for diffs against the empty tree.
+        staged = repo.index.diff(NULL_TREE, create_patch=True)
+        self.assertEqual(len(staged), 1)
+        self.assertEqual(staged[0].b_path, "file.txt")
+
+        repo.index.commit("first")
+        with open(file_path, "w", encoding="utf-8") as stream:
+            stream.write("second\n")
+
+        # Both commit and index diffs use Diffable.diff for the working tree.
+        for diff_index in (
+            repo.head.commit.diff(None, create_patch=True),
+            repo.index.diff(None, create_patch=True),
+        ):
+            self.assertEqual(len(diff_index), 1)
+            self.assertEqual(diff_index[0].a_path, "file.txt")
+            self.assertEqual(diff_index[0].b_path, "file.txt")
+
     @pytest.mark.xfail(
         sys.platform == "win32",
         reason='"Access is denied" when tearDown calls shutil.rmtree',


### PR DESCRIPTION
## Summary

- override `diff.mnemonicPrefix` for Git commands whose output GitPython parses
- cover both the shared `Diffable.diff` path and the index-versus-empty-tree implementation
- add regression coverage for commit-to-working-tree, index-to-working-tree, and index-to-empty-tree patch parsing

Fixes #2013.

## Root cause

With `diff.mnemonicPrefix=true` in Git configuration, Git emits prefixes such as `c/`, `i/`, and `w/`. GitPython's patch parser expects the standard `a/` and `b/` prefixes, so `create_patch=True` silently returned an empty `DiffIndex`.

## User impact

Repository or global mnemonic-prefix preferences no longer change the machine-readable patch format used internally by GitPython. Patch-producing diff calls return the expected entries without requiring callers to override their Git configuration.

## Validation

- `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master .venv/bin/pytest test/test_diff.py --no-cov` (23 passed)
- `uvx ruff check git/diff.py git/index/base.py test/test_diff.py`
- `python -m compileall -q git test/test_diff.py`
- `git diff --check`

## AI disclosure

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor's GitHub account.
