### PR TITLE
fix: prevent environment expansion in remote URLs

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -608,7 +608,7 @@ class Submodule(IndexObject, TraversableIterableObj):
         # END verify url
 
         ## See #525 for ensuring git URLs in config-files are valid under Windows.
-        url = Git.polish_url(url)
+        url = Git.polish_url(url, expand_vars=False)
 
         # It's important to add the URL to the parent config, to let `git submodule` know.
         # Otherwise there is a '-' character in front of the submodule listing:

--- a/git/remote.py
+++ b/git/remote.py
@@ -808,7 +808,7 @@ class Remote(LazyMixin, IterableObj):
         """
         scmd = "add"
         kwargs["insert_kwargs_after"] = scmd
-        url = Git.polish_url(url)
+        url = Git.polish_url(url, expand_vars=False)
         if not allow_unsafe_protocols:
             Git.check_unsafe_protocols(url)
         repo.git.remote(scmd, "--", name, url, **kwargs)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -4,6 +4,7 @@
 # 3-Clause BSD License: https://opensource.org/license/bsd-3-clause/
 
 import gc
+import os
 import os.path as osp
 from pathlib import Path
 import random
@@ -684,6 +685,14 @@ class TestRemote(TestBase):
         self.assertEqual(list(remote.urls), [test3])
         # Will raise fatal: Will not delete all non-push URLs.
         self.assertRaises(GitCommandError, remote.delete_url, test3)
+
+    @with_rw_repo("HEAD", bare=False)
+    def test_create_does_not_expand_environment_variables_in_url(self, rw_repo):
+        url = "https://example.com/${GITPYTHON_TEST_SECRET}/repo.git"
+        with mock.patch.dict(os.environ, {"GITPYTHON_TEST_SECRET": "sensitive-value"}):
+            remote = rw_repo.create_remote("untrusted", url)
+
+        assert remote.url == url
 
     def test_fetch_error(self):
         rem = self.rorepo.remote("origin")

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1355,6 +1355,20 @@ class TestSubmodule(TestBase):
         with self.assertRaises(cp.NoOptionError):
             sm_config.get_value("core", "eol")
 
+    @with_rw_directory
+    def test_add_does_not_expand_environment_variables_in_url(self, rwdir):
+        parent = git.Repo.init(osp.join(rwdir, "parent"))
+        url = osp.join(rwdir, "${GITPYTHON_TEST_SECRET}")
+        source = git.Repo.init(url)
+        Path(source.working_tree_dir, "file").write_text("content")
+        source.index.add(["file"])
+        source.index.commit("initial")
+
+        with mock.patch.dict(os.environ, {"GITPYTHON_TEST_SECRET": "sensitive-value"}):
+            sm = Submodule.add(parent, "new", "new", url)
+
+        assert sm.url == Git.polish_url(url, expand_vars=False)
+
     @with_rw_repo("HEAD")
     def test_submodule_add_unsafe_url(self, rw_repo):
         with tempfile.TemporaryDirectory() as tdir:


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Preserve caller-supplied environment-variable references literally when creating remotes and submodules. This closes the remaining sibling URL paths missed by the earlier clone hardening while retaining existing local-path normalization behavior.

## Advisory summary

- Advisory: GHSA-94p4-4cq8-9g67
- URL: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-94p4-4cq8-9g67
- Severity: High
- Package: GitPython (pip)
- Affected versions: <= 3.1.53
- Patched versions: not yet assigned
- CVE: not yet assigned

The advisory remains in triage, so reproduction and exploit details are intentionally omitted here.

## Validation

- Focused remote and submodule regression tests: 2 passed
- Changed-file pre-commit hooks: passed
- `git diff --check`: passed
- Full remote/submodule modules: 56 passed, 1 skipped; 14 fixture failures from unavailable nested test repositories and a historical `master`-branch fixture
- Codex commit review: no correctness findings