### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os-type: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t", "3.15", "3.15t"]
         exclude:
         - os-type: macos
           python-version: "3.7"  # Not available for the ARM-based macOS runners.
@@ -25,14 +25,20 @@ jobs:
           python-version: "3.13t"
         - os-type: macos
           python-version: "3.14t"
+        - os-type: macos
+          python-version: "3.15t"
         - os-type: windows
-          python-version: "3.13"  # FIXME: Fix and enable Python 3.13 and 3.14 on Windows (#1955).
+          python-version: "3.13"  # FIXME: Fix and enable Python 3.13-3.15 on Windows (#1955).
         - os-type: windows
           python-version: "3.13t"
         - os-type: windows
           python-version: "3.14"
         - os-type: windows
           python-version: "3.14t"
+        - os-type: windows
+          python-version: "3.15"
+        - os-type: windows
+          python-version: "3.15t"
         include:
         - os-ver: latest
         - os-type: ubuntu
@@ -44,6 +50,10 @@ jobs:
         - python-version: "3.8"
           build-docs: false
         - experimental: false
+        - python-version: "3.15"
+          experimental: true
+        - python-version: "3.15t"
+          experimental: true
 
       fail-fast: false
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,20 +17,16 @@ jobs:
     strategy:
       matrix:
         os-type: [ubuntu, macos, windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t", "3.15", "3.15t"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
         exclude:
         - os-type: macos
           python-version: "3.7"  # Not available for the ARM-based macOS runners.
-        - os-type: macos
-          python-version: "3.13t"
         - os-type: macos
           python-version: "3.14t"
         - os-type: macos
           python-version: "3.15t"
         - os-type: windows
           python-version: "3.13"  # FIXME: Fix and enable Python 3.13-3.15 on Windows (#1955).
-        - os-type: windows
-          python-version: "3.13t"
         - os-type: windows
           python-version: "3.14"
         - os-type: windows

--- a/setup.py
+++ b/setup.py
@@ -108,5 +108,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -110,5 +110,6 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
     ],
 )


### PR DESCRIPTION
The Python 3.15 beta is out. 🚀 

The 3.15 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-15-0-beta-4-is-here/108208):

> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.15*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, removed up until the start of the release candidate phase (2026-08-04). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.15 as possible during the beta phase.
> 
> This includes creating pre-release wheels for 3.15, as it helps other projects to do their own testing. However, we recommend that your regular production releases wait until 3.15.0rc1, to avoid the risk of ABI breaks.

Also declare support for 3.13-3.15 with Trove classifiers.

And includes a suggestion: stop testing free-threaded 3.13t. It was experimental, 3.14t and up are properly supported and have better performance, and many other projects are stopping testing 3.13t, such as cibuildwheel and Pillow.