### PR TITLE
fix: reject unsafe output options in Commit.count

### DIFF
--- a/git/objects/commit.py
+++ b/git/objects/commit.py
@@ -269,12 +269,20 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         else:
             return self.message.split(b"\n", 1)[0]
 
-    def count(self, paths: Union[PathLike, Sequence[PathLike]] = "", **kwargs: Any) -> int:
+    def count(
+        self,
+        paths: Union[PathLike, Sequence[PathLike]] = "",
+        allow_unsafe_options: bool = False,
+        **kwargs: Any,
+    ) -> int:
         """Count the number of commits reachable from this commit.
 
         :param paths:
             An optional path or a list of paths restricting the return value to commits
             actually containing the paths.
+
+        :param allow_unsafe_options:
+            Allow unsafe options, like ``--output``.
 
         :param kwargs:
             Additional options to be passed to :manpage:`git-rev-list(1)`. They must not
@@ -284,6 +292,11 @@ class Commit(base.Object, TraversableIterableObj, Diffable, Serializable):
         :return:
             An int defining the number of reachable commits
         """
+        if not allow_unsafe_options:
+            Git.check_unsafe_options(
+                options=Git._option_candidates([], kwargs), unsafe_options=self.unsafe_git_rev_options
+            )
+
         # Yes, it makes a difference whether empty paths are given or not in our case as
         # the empty paths version will ignore merge commits for some reason.
         if paths:

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -301,6 +301,11 @@ class TestCommit(TestCommitSerialization):
             with self.assertRaises(UnsafeOptionError):
                 list(Commit.iter_items(self.rorepo, "HEAD", output=marker))
 
+    def test_count_rejects_unsafe_options(self):
+        with tempfile.NamedTemporaryFile() as marker:
+            with self.assertRaises(UnsafeOptionError):
+                self.rorepo.head.commit.count(output=marker.name)
+
     def test_rev_list_bisect_all(self):
         """
         'git rev-list --bisect-all' returns additional information


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Validate options forwarded by `Commit.count()` with the existing revision unsafe-option guard.
- Preserve the explicit `allow_unsafe_options=True` escape hatch for trusted callers.
- Audit internal `.git.*` calls that can accept Git’s `--output` option; revision iteration, diff/diff-tree, blame, and archive paths were already guarded, leaving `Commit.count()` as the missing high-level wrapper.

## Advisory summary

- Advisory: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-p538-c434-8v24
- GHSA: GHSA-p538-c434-8v24
- Severity: medium
- Package: GitPython (`pip`)
- Affected versions: <= 3.1.55
- Patched versions: not yet designated
- CVE: not assigned

The advisory is unpublished, so this public PR intentionally omits unnecessary exploitation detail.

## Git reference

Git baseline `a23bace963`: `diff.c` defines `--output` as a shared diff option consumed by `setup_revisions`; `t/t6000-rev-list-misc.sh` covers the option with `rev-list`.

## Validation

- Regression test failed before the fix and passes after it.
- Focused unsafe-option tests: 3 passed.
- `mypy git/objects/commit.py`: passed.
- Ruff check and format check: passed.
- Full `test/test_commit.py`: 33 passed; 2 unrelated local failures because this fixture checkout has no `master` ref.
- `codex review --commit 056e1f1474ca5d1c8817abe274633f7420c8104d`: no findings.