### PR TITLE
Handle non-UTF-8 names in packed refs

### DIFF
--- a/git/refs/symbolic.py
+++ b/git/refs/symbolic.py
@@ -149,7 +149,7 @@ class SymbolicReference:
             The packed refs file will be kept open as long as we iterate.
         """
         try:
-            with open(cls._get_packed_refs_path(repo), "rt", encoding="UTF-8") as fp:
+            with open(cls._get_packed_refs_path(repo), "rt", encoding="UTF-8", errors="surrogateescape") as fp:
                 for line in fp:
                     line = line.strip()
                     if not line:

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -77,6 +77,19 @@ class TestRefs(TestBase):
         # Check remoteness
         assert Reference(self.rorepo, PathLikeMock("refs/remotes/origin")).is_remote()
 
+    def test_iter_packed_refs_with_non_utf8_name(self):
+        with tempfile.TemporaryDirectory() as tdir:
+            with self._repo_with_initial_commit(Path(tdir)) as repo:
+                packed_refs_path = Path(Reference._get_packed_refs_path(repo))
+                hexsha = repo.head.commit.hexsha
+                packed_refs_path.write_bytes(
+                    b"# pack-refs with: peeled\n" + hexsha.encode("ascii") + b" refs/tags/non-utf8-\xe9\n"
+                )
+
+                tag_data = [(tag.commit.hexsha, tag.path) for tag in repo.tags]
+
+        self.assertEqual(tag_data, [(hexsha, "refs/tags/non-utf8-\udce9")])
+
     def test_tag_base(self):
         tag_object_refs = []
         for tag in self.rorepo.tags:


### PR DESCRIPTION
## Summary

- Read packed-refs with Python surrogateescape handling.
- Preserve undecodable ref-name bytes instead of failing during decoding.
- Add a repo.tags regression test using a non-UTF-8 tag name.

Fixes #2064.

## Validation

- GIT_PYTHON_TEST_GIT_REPO_BASE=/tmp/gitpython-test-fixture.i7gtuO .venv/bin/python -m pytest -o addopts= test/test_refs.py
- .venv/bin/python -m ruff check git/refs/symbolic.py test/test_refs.py
- .venv/bin/python -m ruff format --check git/refs/symbolic.py test/test_refs.py
- .venv/bin/python -m mypy git/refs/symbolic.py

## AI agent disclosure

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.