### PR TITLE
Use standard prefixes for parsed patch diffs

### DIFF
--- a/git/diff.py
+++ b/git/diff.py
@@ -284,7 +284,10 @@ class Diffable:
         # END paths handling
 
         kwargs["as_process"] = True
-        proc = diff_cmd(*self._process_diff_args(args), **kwargs)
+        args = self._process_diff_args(args)
+        if create_patch:
+            self.repo.git(c="diff.mnemonicPrefix=false")
+        proc = diff_cmd(*args, **kwargs)
 
         diff_method = Diff._index_from_patch_format if create_patch else Diff._index_from_raw_format
         index = diff_method(self.repo, proc)

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1547,6 +1547,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
                 args.extend(paths)
 
             kwargs["as_process"] = True
+            if create_patch:
+                self.repo.git(c="diff.mnemonicPrefix=false")
             proc = self.repo.git.diff(*args, **kwargs)
 
             diff_method = (

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -92,6 +92,26 @@ class TestDiff(TestBase):
             "This should work, but doesn't right now ... it's OK",
         )
 
+    @with_rw_directory
+    def test_patch_diff_ignores_mnemonic_prefix(self, rw_dir):
+        repo = Repo.init(rw_dir)
+        filepath = osp.join(rw_dir, "file.txt")
+        with open(filepath, "w") as stream:
+            stream.write("initial\n")
+        repo.index.add([filepath])
+        repo.index.commit("initial")
+
+        with open(filepath, "w") as stream:
+            stream.write("changed\n")
+        repo.git.config("diff.mnemonicPrefix", "true")
+
+        self.assertEqual(len(repo.head.commit.diff(None, create_patch=True)), 1)
+        self.assertEqual(len(repo.index.diff(None, create_patch=True)), 1)
+
+        repo.index.add([filepath])
+        self.assertEqual(len(repo.index.diff(NULL_TREE, create_patch=True)), 1)
+        self.assertEqual(repo.git.config("--get", "diff.mnemonicPrefix"), "true")
+
     def test_list_from_string_new_mode(self):
         output = StringProcessAdapter(fixture("diff_new_mode"))
         diffs = Diff._index_from_patch_format(self.rorepo, output)


### PR DESCRIPTION
## Summary

- Force diff.mnemonicPrefix=false only for patch output parsed by GitPython.
- Cover the shared Diffable path and IndexFile's empty-tree path.
- Verify the temporary Git option does not affect a following command.

Fixes #2013.

## Validation

- .venv/bin/python -m pytest -o addopts= test/test_diff.py::TestDiff::test_patch_diff_ignores_mnemonic_prefix
- .venv/bin/python -m ruff check git/diff.py git/index/base.py test/test_diff.py
- .venv/bin/python -m ruff format --check git/diff.py git/index/base.py test/test_diff.py
- .venv/bin/python -m mypy git/diff.py git/index/base.py

Note: the complete test/test_diff.py run has one pre-existing failure in TestDiff.test_diff_with_staged_file on this local Git version; the focused regression passes.

## AI agent disclosure

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.