### PR TITLE
Render protected Traversable methods in the reference

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -91,6 +91,7 @@ Objects.Util
 .. automodule:: git.objects.util
    :members:
    :undoc-members:
+   :private-members: _get_intermediate_items, _list_traverse, _traverse
    :special-members:
 
 Index.Base


### PR DESCRIPTION
## Summary

- Explicitly include Traversable's protected extension-interface methods in Sphinx autodoc output.
- Render _get_intermediate_items, _list_traverse, and _traverse without exposing unrelated private members.

Addresses #1848.

## Validation

- LC_ALL=C LANG=C make SPHINXBUILD=.venv/bin/sphinx-build -C doc clean html
- Verified all three members are present in doc/build/html/reference.html.
- git diff --check

The local docs build completed successfully with existing Python 3.14 autodoc warnings.

## AI agent disclosure

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.