### PR TITLE
test: allow Python startup before timeout

### DIFF
--- a/test/test_git.py
+++ b/test/test_git.py
@@ -302,7 +302,7 @@ class TestGit(TestBase):
         status, _, stderr = self.git.execute(
             command,
             output_stream=output_stream,
-            kill_after_timeout=0.1,
+            kill_after_timeout=1,
             with_exceptions=False,
             with_extended_output=True,
         )


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [ ] refackiew

----

Everything below this line was generated by Codex.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

$issue-full-auto https://github.com/gitpython-developers/GitPython/actions/runs/30193022939/job/89769540615 fails as flake, and only that. Fix it one way or another, exluding it is also fine if there is no alternative.

## Change

Increase the timeout regression test deadline from 100 ms to one second so it tests GitPython timeout behavior instead of Python interpreter startup speed. Production code is unchanged.

## Validation

- Focused test passed five consecutive times on Python 3.8.
- Ruff check and format passed for test/test_git.py.
- Codex commit review found no actionable defects.