### PR TITLE
Skip tests that need symlink privileges instead of erroring

### DIFF
--- a/test/lib/helper.py
+++ b/test/lib/helper.py
@@ -19,6 +19,8 @@ __all__ = [
     "GIT_REPO",
     "GIT_DAEMON_PORT",
     "xfail_if_raises",
+    "symlinks_supported",
+    "requires_symlinks",
 ]
 
 import contextlib
@@ -29,6 +31,7 @@ import io
 import logging
 import os
 import os.path as osp
+from stat import S_ISLNK, ST_MODE
 import subprocess
 import sys
 import tempfile
@@ -489,6 +492,28 @@ class VirtualEnvironment:
         if osp.isfile(path) or osp.islink(path):
             return path
         raise RuntimeError(f"no regular file or symlink {path!r}")
+
+
+def symlinks_supported() -> bool:
+    """Check whether this process can actually create a symlink.
+
+    On Windows the platform alone doesn't decide it: creating a symlink needs either
+    Developer Mode or SeCreateSymbolicLinkPrivilege, and an unprivileged process gets
+    OSError (WinError 1314) instead.
+    """
+    with tempfile.TemporaryDirectory(prefix="gitpython-symlink-check-") as temp_dir:
+        link_path = osp.join(temp_dir, "link")
+        try:
+            os.symlink("missing-target", link_path)
+        except (NotImplementedError, OSError):
+            return False
+        return S_ISLNK(os.lstat(link_path)[ST_MODE])
+
+
+requires_symlinks = pytest.mark.skipif(
+    not symlinks_supported(),
+    reason="symlinks are unavailable, or need privileges this process doesn't have",
+)
 
 
 @contextlib.contextmanager

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -40,7 +40,7 @@ from git.objects import Blob
 from git.util import Actor, cwd, hex_to_bin, rmtree
 
 from test.lib import TestBase, VirtualEnvironment, fixture, fixture_path, with_rw_directory, with_rw_repo, PathLikeMock
-from test.lib.helper import xfail_if_raises
+from test.lib.helper import symlinks_supported, xfail_if_raises
 
 HOOKS_SHEBANG = "#!/usr/bin/env sh\n"
 
@@ -173,19 +173,6 @@ class WinBashStatus:
 
 
 _win_bash_status = WinBashStatus.check()
-
-
-def _windows_supports_symlinks():
-    if sys.platform != "win32":
-        return False
-
-    with tempfile.TemporaryDirectory(prefix="gitpython-symlink-check-") as temp_dir:
-        link_path = osp.join(temp_dir, "link")
-        try:
-            os.symlink("missing-target", link_path)
-        except (NotImplementedError, OSError):
-            return False
-        return S_ISLNK(os.lstat(link_path)[ST_MODE])
 
 
 def _make_hook(git_dir, name, content, make_exec=True):
@@ -655,7 +642,7 @@ class TestIndex(TestBase):
     @with_rw_repo("0.1.6")
     def test_index_mutation(self, rw_repo):
         with xfail_if_raises(
-            sys.platform == "win32" and (Git().config("core.symlinks") == "true" or _windows_supports_symlinks()),
+            sys.platform == "win32" and (Git().config("core.symlinks") == "true" or symlinks_supported()),
             raises=(FileNotFoundError, GitCommandError),
             reason="Assumes symlinks are not created on Windows and opens a symlink to a nonexistent target.",
         ):

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -6,10 +6,11 @@ import functools
 import os
 import subprocess
 
-from test.lib import TestBase, VirtualEnvironment, with_rw_directory
+from test.lib import TestBase, VirtualEnvironment, requires_symlinks, with_rw_directory
 
 
 class TestInstallation(TestBase):
+    @requires_symlinks
     @with_rw_directory
     def test_installation(self, rw_dir):
         venv, run = self._set_up_venv(rw_dir)

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -28,7 +28,7 @@ from git.objects.tag import TagObject
 import git.refs as refs
 from git.util import Actor
 
-from test.lib import TestBase, with_rw_repo, PathLikeMock
+from test.lib import TestBase, requires_symlinks, with_rw_repo, PathLikeMock
 
 
 class TestRefs(TestBase):
@@ -780,6 +780,7 @@ class TestRefs(TestBase):
                 )
                 assert not outside_path.exists()
 
+    @requires_symlinks
     def test_symbolic_reference_set_reference_rejects_symlink_escape(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir)
@@ -791,10 +792,7 @@ class TestRefs(TestBase):
                 refs_heads_dir = Path(repo.common_dir) / "refs" / "heads"
                 refs_heads_dir.mkdir(parents=True, exist_ok=True)
                 symlink_path = refs_heads_dir / "link_out"
-                try:
-                    symlink_path.symlink_to(outside_dir, target_is_directory=True)
-                except (OSError, NotImplementedError) as ex:
-                    self.skipTest("symlinks unavailable on this platform: %s" % ex)
+                symlink_path.symlink_to(outside_dir, target_is_directory=True)
                 if osp.realpath(symlink_path / "escaped") == osp.abspath(symlink_path / "escaped"):
                     self.skipTest("realpath does not resolve directory symlinks on this platform")
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -43,7 +43,7 @@ from git.exc import BadObject
 from git.repo.fun import touch
 from git.util import bin_to_hex, cwd, cygpath, join_path_native, rmfile, rmtree
 
-from test.lib import TestBase, fixture, with_rw_directory, with_rw_repo, PathLikeMock
+from test.lib import TestBase, fixture, requires_symlinks, with_rw_directory, with_rw_repo, PathLikeMock
 
 
 def iter_flatten(lol):
@@ -1433,6 +1433,7 @@ class TestRepo(TestBase):
                 ["included_file.txt", "ignored_file.txt", "included_dir/file.txt", "ignored_dir/file.txt"]
             ) == ["ignored_file.txt", "ignored_dir/file.txt"]
 
+    @requires_symlinks
     def test_ignored_raises_error_w_symlink(self):
         with tempfile.TemporaryDirectory() as tdir:
             tmp_dir = pathlib.Path(tdir)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -40,7 +40,7 @@ from git.util import (
     rmtree,
 )
 
-from test.lib import TestBase, with_rw_repo
+from test.lib import TestBase, requires_symlinks, with_rw_repo
 
 
 @pytest.fixture
@@ -113,6 +113,7 @@ class TestRmtree:
         sys.platform == "cygwin",
         reason="Cygwin can't set the permissions that make the test meaningful.",
     )
+    @requires_symlinks
     def test_avoids_changing_permissions_outside_tree(self, tmp_path, request):
         # Automatically works on Windows, but on Unix requires either special handling
         # or refraining from attempting to fix PermissionError by making chmod calls.


### PR DESCRIPTION
## Summary

- Move the symlink capability probe out of `test/test_index.py` into `test/lib/helper.py` as `symlinks_supported()`, and add a `requires_symlinks` skip marker beside it.
- Apply the marker to the three tests that call `os.symlink` unguarded and error with `OSError: [WinError 1314]` on a Windows account without Developer Mode or `SeCreateSymbolicLinkPrivilege`.
- Drop the two existing copies of the check: the private probe in `test_index.py`, and the inline try/except plus `skipTest` in `test_refs.py`.

The tests that were erroring:

- `test_repo.py::TestRepo::test_ignored_raises_error_w_symlink`
- `test_util.py::TestRmtree::test_avoids_changing_permissions_outside_tree`
- `test_installation.py::TestInstallation::test_installation`

CI doesn't show this because the GitHub Windows runners hold the privilege, so the three run and pass there.

One behaviour note: the probe used to return early on non-Windows, so it never created anything. Now it always creates and removes a symlink in a temporary directory, on every platform.

## Validation

Windows 11, Python 3.13, after `./init-tests-after-clone.sh`:

- `python -m pytest --ignore=test/performance` — before: 6 failed, 711 passed, 47 skipped. After: 3 failed, 711 passed, 50 skipped.
- The three remaining failures are unrelated to symlinks: `test_commit_msg_hook_fail`, `test_pre_commit_hook_fail`, and `test_index_mutation`, which passes a POSIX absolute path to `git rm`.
- `python -m ruff check test/`
- `python -m ruff format --check test/`
