### PR TITLE
Resolve Windows hook Bash through PATH

### DIFF
--- a/git/index/fun.py
+++ b/git/index/fun.py
@@ -79,6 +79,21 @@ def _has_file_extension(path: str) -> str:
     return osp.splitext(path)[1]
 
 
+def _which_from_path(command: str) -> Union[str, None]:
+    """Resolve an executable 'command' from PATH without considering the current directory."""
+    cwd = osp.normcase(osp.abspath(os.curdir))
+    for directory in os.get_exec_path():
+        if not directory:
+            continue
+        directory = osp.abspath(directory)
+        if osp.normcase(directory) == cwd:
+            continue
+        candidate = osp.join(directory, command)
+        if osp.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
     """Run the commit hook of the given name. Silently ignore hooks that do not exist.
 
@@ -112,7 +127,11 @@ def run_commit_hook(name: str, index: "IndexFile", *args: str) -> None:
                 # an absolute path in this form, although a relative path is preferable
                 # because it also works with the Windows Subsystem for Linux wrapper.
                 bash_hp = hp
-            cmd = ["bash.exe", Path(bash_hp).as_posix()]
+            # Resolve through PATH before spawning. On Windows, CreateProcess searches
+            # the current and system directories before PATH for a bare executable name,
+            # which can otherwise select an impostor or the WSL launcher instead of Git
+            # for Windows' Bash.
+            cmd = [_which_from_path("bash.exe") or "bash.exe", Path(bash_hp).as_posix()]
 
         process = safer_popen(
             cmd + list(args),

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1128,16 +1128,20 @@ class TestIndex(TestBase):
         repo = Repo.init(root / "repo")
         hooks_dir = root / "hooks"
         _make_hook(root, "fake-hook", "exit 0")
+        bash = root / "git" / "bin" / "bash.exe"
         with repo.config_writer() as writer:
             writer.set_value("core", "hooksPath", str(hooks_dir))
 
-        with mock.patch("git.index.fun.sys.platform", "win32"):
+        with mock.patch("git.index.fun.sys.platform", "win32"), mock.patch(
+            "git.index.fun._which_from_path", return_value=str(bash)
+        ) as which:
             with mock.patch("git.index.fun.safer_popen") as popen, mock.patch("git.index.fun.handle_process_output"):
                 popen.return_value.returncode = 0
                 run_commit_hook("fake-hook", repo.index)
 
+        which.assert_called_once_with("bash.exe")
         command = popen.call_args[0][0]
-        self.assertEqual(command, ["bash.exe", "../hooks/fake-hook"])
+        self.assertEqual(command, [str(bash), "../hooks/fake-hook"])
 
     @ddt.data((False,), (True,))
     @with_rw_directory


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Fixes #2198.

On Windows, resolve `bash.exe` from `PATH` before launching extensionless commit hooks. This prevents `CreateProcess` from selecting the WSL launcher in System32 ahead of Git for Windows Bash. The current directory is deliberately excluded from resolution so a repository-local executable cannot be selected. If no Bash is present on `PATH`, GitPython retains its existing bare-name fallback.

## Baselines

Git for Windows v2.55.0.windows.3 resolves its shell through PATH: `git var GIT_SHELL_PATH` returned `C:/Program Files/Git/usr/bin/sh.exe` in the reference checkout at `/c/Users/byron/Desktop/dev/git`.

The `gix-command` reference delegates default-shell selection to `gix_path::env::shell_command()`. On Windows, gix first locates a Git-associated shell from the selected Git installation (`bin`, then `usr/bin`) and falls back to bare `sh.exe`. This fix adopts the same key safety property—resolve before spawning and retain a bare fallback—while preserving GitPython's established Bash invocation.

## Validation

- `test/test_index.py`: 30 passed, 1 expected xfail, 1 xpass
- Focused hook tests: 7 passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
- `codex review --commit 531f5dc242efc2b4f76668f3d322d5fd3940f213`: no actionable findings