### PR TITLE
test: focus pytest summary on unexpected failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=git --cov-report=term -rfE"
+addopts = "--cov=git --cov-report=term -rfEX"
 filterwarnings = "ignore::DeprecationWarning"
 python_files = "test_*.py"
 tmp_path_retention_policy = "failed"
@@ -13,7 +13,7 @@ testpaths = "test"  # Space separated list of paths from root e.g test tests doc
 # --cov-report term-missing # to terminal with line numbers
 # --cov-report html:path  # html file at path
 # --maxfail  # number of errors before giving up
-# -rfE  # test summary: list failures and errors, omitting expected failures
+# -rfEX  # test summary: list failures, errors, and unexpected passes; omit expected failures
 # -ra   # test summary: list all non-passing (fail, error, skip, xfail, xpass)
 # --ignore-glob=**/gitdb/*  # ignore glob paths
 # filterwarnings ignore::WarningType  # ignores those warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=git --cov-report=term -ra"
+addopts = "--cov=git --cov-report=term -rfE"
 filterwarnings = "ignore::DeprecationWarning"
 python_files = "test_*.py"
 tmp_path_retention_policy = "failed"
@@ -13,7 +13,7 @@ testpaths = "test"  # Space separated list of paths from root e.g test tests doc
 # --cov-report term-missing # to terminal with line numbers
 # --cov-report html:path  # html file at path
 # --maxfail  # number of errors before giving up
-# -rfE  # default test summary: list fail and error
+# -rfE  # test summary: list failures and errors, omitting expected failures
 # -ra   # test summary: list all non-passing (fail, error, skip, xfail, xpass)
 # --ignore-glob=**/gitdb/*  # ignore glob paths
 # filterwarnings ignore::WarningType  # ignores those warnings


### PR DESCRIPTION
## Summary

- Use pytest failure/error summary modes instead of listing every expected failure.
- Keep aggregate failure, error, xfail, and skip counts available while making unexpected failures prominent.

Fixes #1891

## Validation

- Reproduced the baseline and candidate output with an isolated pytest fixture containing one expected failure and one unexpected failure.
- git diff --check

The full GitPython suite was not run because its setup script mutates repository branches, tags, and reflogs; the focused reporter fixture directly exercises this configuration change.

Assisted-by: OpenAI Codex. AI assistance was used for investigation and implementation; the submitted diff and validation were reviewed before publication.