### PR TITLE
Handle invalid submodule names during recursive updates

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -492,14 +492,6 @@
                 }
             },
             {
-                "code": "reportPossiblyUnboundVariable",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 20,

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -747,9 +747,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             prefix = "DRY-RUN: "
         # END handle prefix
 
-        # To keep things plausible in dry-run mode.
-        if dry_run:
-            mrepo = None
+        mrepo = None
         # END init mrepo
 
         def fetch_remotes(module_repo: "Repo") -> None:

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -316,8 +316,9 @@ class Submodule(IndexObject, TraversableIterableObj):
 
     @classmethod
     def _module_abspath(cls, parent_repo: "Repo", path: PathLike, name: str) -> PathLike:
+        name = cls._validated_name(name)
         if cls._need_gitfile_submodules(parent_repo.git):
-            return osp.join(parent_repo.git_dir, "modules", cls._validated_name(name))
+            return osp.join(parent_repo.git_dir, "modules", name)
         if parent_repo.working_tree_dir:
             return osp.join(parent_repo.working_tree_dir, path)
         raise NotADirectoryError()

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -971,6 +971,10 @@ class TestSubmodule(TestBase):
             with pytest.raises(ValueError, match="submodule name"):
                 Submodule._module_abspath(clone, "module", name)
 
+        with mock.patch.object(Submodule, "_need_gitfile_submodules", return_value=False):
+            with pytest.raises(ValueError, match="submodule name"):
+                Submodule._module_abspath(clone, "module", "../module")
+
     @with_rw_directory
     @_patch_git_config("protocol.file.allow", "always")
     def test_root_update_keeps_going_after_invalid_submodule_name(self, rwdir):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -994,6 +994,8 @@ class TestSubmodule(TestBase):
         assert not clone.submodule("../invalid").module_exists()
         assert clone.submodule("valid").module_exists()
 
+        clone.submodule("../invalid").update(recursive=True, keep_going=True)
+
     @with_rw_directory
     @_patch_git_config("protocol.file.allow", "always")
     def test_list_only_valid_submodules(self, rwdir):


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Initialize mrepo before swallowing validation failures**

When an invalidly named submodule is updated directly with both `recursive=True` and `keep_going=True`, this validation error is swallowed, but execution then reaches the recursion block and reads `mrepo` before it has been assigned, raising `UnboundLocalError` instead of honoring `keep_going`. Fresh evidence in this revision is that the validation was moved inside the `try` without initializing `mrepo` on the non-dry-run path; initialize it before the `try` or skip recursion after the handled failure.

And in a separate stg commit: _module_abspath() only validates `name` when `_need_gitfile_submodules()` is true. This makes behavior depend on the installed git version and can allow invalid names to pass through this helper silently on older git versions (even though other code paths now expect invalid names to raise consistently). Consider validating `name` unconditionally at the start of the method and then using the validated value in the gitfile-submodules branch.

## Changes

- Initialize the module repository sentinel before validation so handled failures safely skip recursion.
- Validate submodule names before selecting the Git-version-dependent module path branch.
- Cover direct recursive `keep_going` updates and the legacy module-path branch.

## Git baseline

Git `submodule.c` at `883a47ef6496c96a5d6132ed8c87fcd44ebf8d1a` validates submodule paths before filesystem operations.

## Validation

- `test/test_submodule.py`: 40 passed, 1 skipped, 1 xfailed.
- `git diff --check`.
- One Codex review per commit hash; no substantive findings.
