### PR TITLE
Block file-reading Git options

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -2,6 +2,20 @@
 Changelog
 =========
 
+3.1.59
+======
+
+Security fixes for
+
+* https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-5xxx-qhh7-9287
+* https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-3wxw-xv34-2frg
+
+If you can, also try and provide feedback on the upcoming v4 branch
+https://github.com/gitpython-developers/GitPython/pull/2177 - patches welcome.
+
+See the following for all changes.
+https://github.com/gitpython-developers/GitPython/releases/tag/3.1.59
+
 3.1.58
 ======
 

--- a/git/cmd.py
+++ b/git/cmd.py
@@ -652,6 +652,7 @@ class Git(metaclass=_GitMeta):
     unsafe_git_ls_remote_options = [
         # This option allows arbitrary command execution in git-ls-remote.
         "--upload-pack",
+        "--exec",
     ]
 
     unsafe_git_pathspec_from_file_options = [
@@ -976,7 +977,9 @@ class Git(metaclass=_GitMeta):
         return dashify(option_tokens[0])
 
     @classmethod
-    def check_unsafe_options(cls, options: List[str], unsafe_options: List[str]) -> None:
+    def check_unsafe_options(
+        cls, options: List[str], unsafe_options: List[str], clusterable_short_options: str = "46flnqsv"
+    ) -> None:
         """Raise :class:`~git.exc.UnsafeOptionError` for blocked option spellings.
 
         In addition to exact matches, this rejects abbreviated long options accepted
@@ -1011,7 +1014,7 @@ class Git(metaclass=_GitMeta):
         # These value-less Git flags can be clustered before another short option
         # (for example, ``-fuVALUE``). Stop at any other character because it may
         # begin an attached value, as ``o`` does in the safe option ``-oupstream``.
-        clusterable_short_options = frozenset("46flnqsv")
+        clusterable_short_options_set = frozenset(clusterable_short_options)
         options_are_kwargs = all(not option.startswith("-") for option in options)
         for option in options:
             candidate = cls._canonicalize_option_name(option)
@@ -1028,7 +1031,7 @@ class Git(metaclass=_GitMeta):
                         raise UnsafeOptionError(
                             f"{unsafe_option} is not allowed, use `allow_unsafe_options=True` to allow it."
                         )
-                    if option_char not in clusterable_short_options:
+                    if option_char not in clusterable_short_options_set:
                         break
             if not (option.startswith("--") or (options_are_kwargs and len(candidate) > 1)):
                 continue
@@ -1133,7 +1136,7 @@ class Git(metaclass=_GitMeta):
         """List references in a remote repository.
 
         :param allow_unsafe_options:
-            Allow unsafe options, like ``--upload-pack``.
+            Allow unsafe options, like ``--upload-pack`` or ``--exec``.
         """
         if not allow_unsafe_options:
             candidate_options = self._option_candidates(args, kwargs)

--- a/git/diff.py
+++ b/git/diff.py
@@ -220,8 +220,8 @@ class Diffable:
             to be read and diffed.
 
         :param allow_unsafe_options:
-            If ``True``, allow options such as ``--output`` that can write to arbitrary
-            filesystem paths.
+            If ``True``, allow options such as ``--output`` and ``-O`` that can write to
+            or read from arbitrary filesystem paths.
 
         :param kwargs:
             Additional arguments passed to :manpage:`git-diff(1)`, such as ``R=True`` to
@@ -238,7 +238,8 @@ class Diffable:
         if not allow_unsafe_options:
             Git.check_unsafe_options(
                 options=Git._option_candidates([other], kwargs),
-                unsafe_options=self.repo.unsafe_git_revision_options,
+                unsafe_options=self.repo.unsafe_git_diff_options,
+                clusterable_short_options="46abceflmnpqrstuvwzBCDMNRW",
             )
 
         args: List[Union[PathLike, Diffable]] = []

--- a/git/index/base.py
+++ b/git/index/base.py
@@ -1567,7 +1567,8 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
         if not allow_unsafe_options:
             Git.check_unsafe_options(
                 options=Git._option_candidates([other], kwargs),
-                unsafe_options=self.repo.unsafe_git_revision_options,
+                unsafe_options=self.repo.unsafe_git_diff_options,
+                clusterable_short_options="46abceflmnpqrstuvwzBCDMNRW",
             )
 
         # Only run if we are the default repository index.

--- a/git/refs/tag.py
+++ b/git/refs/tag.py
@@ -134,14 +134,16 @@ class TagReference(Reference):
         :return:
             A new :class:`TagReference`.
         """
+        legacy_ref = kwargs.pop("ref", None)
+        if legacy_ref:
+            reference = legacy_ref
+
         if not allow_unsafe_options:
             Git.check_unsafe_options(
-                options=Git._option_candidates([], kwargs),
+                options=Git._option_candidates([path, reference], kwargs),
                 unsafe_options=cls.unsafe_git_tag_options,
+                clusterable_short_options="46adefilnqsv",
             )
-
-        if "ref" in kwargs and kwargs["ref"]:
-            reference = kwargs["ref"]
 
         if "message" in kwargs and kwargs["message"]:
             kwargs["m"] = kwargs["message"]

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -199,6 +199,19 @@ class Repo:
         "-o",
     ]
 
+    unsafe_git_blame_options = unsafe_git_revision_options + [
+        # These options read from arbitrary files and expose their contents through blame output.
+        "--contents",
+        "-S",
+        "--ignore-revs-file",
+    ]
+
+    unsafe_git_diff_options = unsafe_git_revision_options + [
+        # Reads caller-controlled order patterns from an arbitrary file.
+        "-O",
+        "--orderfile",
+    ]
+
     # Invariants
     config_level: ConfigLevels_Tup = ("system", "user", "global", "repository")
     """Represents the configuration level of a configuration file."""
@@ -1149,7 +1162,7 @@ class Repo:
             :manpage:`git-rev-parse(1)` is a valid option.
 
         :param allow_unsafe_options:
-            Allow unsafe options in revision argument, like ``--output``.
+            Allow unsafe options in revision argument, like ``--output`` or ``--contents``.
 
         :return:
             Lazy iterator of :class:`BlameEntry` tuples, where the commit indicates the
@@ -1161,7 +1174,9 @@ class Repo:
         """
         if not allow_unsafe_options:
             Git.check_unsafe_options(
-                options=Git._option_candidates([rev], kwargs), unsafe_options=self.unsafe_git_revision_options
+                options=Git._option_candidates([rev], kwargs),
+                unsafe_options=self.unsafe_git_blame_options,
+                clusterable_short_options="46bceflnpqstvw",
             )
 
         data: bytes = self.git.blame(rev, "--", file, p=True, incremental=True, stdout_as_string=False, **kwargs)
@@ -1253,7 +1268,7 @@ class Repo:
             :manpage:`git-rev-parse(1)` is a valid option.
 
         :param allow_unsafe_options:
-            Allow unsafe options in revision argument, like ``--output``.
+            Allow unsafe options in revision argument, like ``--output`` or ``--contents``.
 
         :return:
             list: [git.Commit, list: [<line>]]
@@ -1269,7 +1284,8 @@ class Repo:
         if not allow_unsafe_options:
             Git.check_unsafe_options(
                 options=Git._option_candidates([rev, rev_opts_list], kwargs),
-                unsafe_options=self.unsafe_git_revision_options,
+                unsafe_options=self.unsafe_git_blame_options,
+                clusterable_short_options="46bceflnpqstvw",
             )
         data: bytes = self.git.blame(rev, *rev_opts_list, "--", file, p=True, stdout_as_string=False, **kwargs)
         commits: Dict[str, Commit] = {}

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -376,11 +376,25 @@ class TestDiff(TestBase):
     def test_diff_rejects_unsafe_output_options(self):
         commit = self.rorepo.head.commit
 
+        commit.diff(S="needle")
+
         calls = (
             lambda target: commit.diff(output=target),
             lambda target: commit.diff(other=f"--output={target}"),
+            lambda target: commit.diff(O=target),
+            lambda target: commit.diff(orderfile=target),
+            lambda target: commit.diff(other=f"--orderfile={target}"),
+            lambda target: commit.diff(other=f"-pO{target}"),
+            lambda target: commit.diff(other=f"-uO{target}"),
+            lambda target: commit.diff(other=f"-DO{target}"),
             lambda target: self.rorepo.index.diff(NULL_TREE, output=target),
             lambda target: self.rorepo.index.diff(f"--output={target}"),
+            lambda target: self.rorepo.index.diff(NULL_TREE, O=target),
+            lambda target: self.rorepo.index.diff(NULL_TREE, orderfile=target),
+            lambda target: self.rorepo.index.diff(f"--orderfile={target}"),
+            lambda target: self.rorepo.index.diff(f"-pO{target}"),
+            lambda target: self.rorepo.index.diff(f"-uO{target}"),
+            lambda target: self.rorepo.index.diff(f"-DO{target}"),
         )
         for index, call in enumerate(calls):
             target = osp.join(self.repo_dir, f"diff-output-{index}")

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -70,6 +70,21 @@ class TestRefs(TestBase):
                 with self.assertRaises(UnsafeOptionError):
                     TagReference.create(rw_repo, f"unsafe-{index}", **option)
 
+            for args in (
+                ("unsafe-reference", f"--file={message.name}"),
+                (f"--file={message.name}", "HEAD"),
+                (f"-eF{message.name}", "HEAD"),
+                (f"-iF{message.name}", "HEAD"),
+            ):
+                with self.assertRaises(UnsafeOptionError):
+                    TagReference.create(rw_repo, *args)
+
+            with self.assertRaises(UnsafeOptionError):
+                TagReference.create(rw_repo, "unsafe-ref-kwarg", ref=f"--file={message.name}")
+
+            tag = TagReference.create(rw_repo, "legacy-ref", ref="HEAD", allow_unsafe_options=True)
+            self.assertEqual(tag.commit, rw_repo.head.commit)
+
             tag = TagReference.create(rw_repo, "allowed-file", F=message.name, allow_unsafe_options=True)
             self.assertEqual(tag.tag.message, "private tag message")
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -1035,6 +1035,7 @@ class TestRemote(TestBase):
                 {"upload-pack": f"touch {tmp_file}"},
                 {"upload_pack": f"touch {tmp_file}"},
                 {"upl": f"touch {tmp_file}"},
+                {"exec": f"touch {tmp_file}"},
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
@@ -1047,6 +1048,8 @@ class TestRemote(TestBase):
                 rw_repo.git.ls_remote(f"--upload-pack={tmp_file}", ".")
             with self.assertRaises(UnsafeOptionError):
                 rw_repo.git.ls_remote(f"--upl={tmp_file}", ".")
+            with self.assertRaises(UnsafeOptionError):
+                rw_repo.git.ls_remote(f"--exec={tmp_file}", ".")
             with self.assertRaises(UnsafeOptionError):
                 rw_repo.git.ls_remote("--upload-pack", "touch", ".")
             with self.assertRaises(UnsafeOptionError):

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -590,8 +590,11 @@ class TestRepo(TestBase):
     def test_blame_rejects_unsafe_revision(self):
         with tempfile.TemporaryDirectory() as tdir:
             output_marker = osp.join(tdir, "pwn")
-            with self.assertRaises(UnsafeOptionError):
-                self.rorepo.blame(f"--output={output_marker}", "README.md")
+            for option in ("--output", "--contents", "-S", "-wS", "--ignore-revs-file"):
+                with self.assertRaises(UnsafeOptionError):
+                    self.rorepo.blame(f"{option}={output_marker}", "README.md")
+                with self.assertRaises(UnsafeOptionError):
+                    list(self.rorepo.blame_incremental(f"{option}={output_marker}", "README.md"))
             assert not osp.exists(output_marker)
 
     def test_blame_rejects_unsafe_options(self):


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Reject file-reading options passed to blame APIs, including equivalent short and clustered forms.
- Inspect positional tag path/reference inputs and the legacy `ref` alias for unsafe file options.
- Reject the adjacent diff order-file input, including clustered forms, while preserving safe `-S` pickaxe behavior.

## Advisories

- [GHSA-5xxx-qhh7-9287](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-5xxx-qhh7-9287)
- [GHSA-3wxw-xv34-2frg](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-3wxw-xv34-2frg)

## Advisory summary

Both advisories are medium severity and affect the pip package `GitPython` through version 3.1.58. No patched version or CVE has been assigned yet. The change prevents caller-controlled Git options from reading local files through high-level blame and tag APIs, and closes the same class of issue in diff order-file handling.

## Validation

- Focused regression tests: 4 passed
- `test_diff.py`: 23 passed; 1 unrelated local branch-fixture failure
- `test_repo.py` and `test_refs.py`: 108 passed, 2 skipped; 5 unrelated local environment/history failures
- Ruff on changed files
- `git diff --check`
- Codex commit review: no actionable findings after follow-up fixes

Git behavior reference: git.git `cf5497b14c`, including the documented file-input options for `git blame`, `git diff`, and `git tag`.