### PR TITLE
Block separate git directories during clone

### DIFF
--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -9,6 +9,7 @@ import logging
 import ntpath
 import os
 import os.path as osp
+import shlex
 import stat
 import sys
 import uuid
@@ -363,6 +364,15 @@ class Submodule(IndexObject, TraversableIterableObj):
         module_abspath = cls._module_abspath(repo, path, name)
         module_checkout_path = module_abspath
         if cls._need_gitfile_submodules(repo.git):
+            if not allow_unsafe_options:
+                Git.check_unsafe_options(Git._option_candidates([], kwargs), repo.unsafe_git_clone_options)
+                multi_options = kwargs.get("multi_options")
+                if multi_options:
+                    Git.check_unsafe_options(
+                        shlex.split(" ".join(cast("Sequence[str]", multi_options))),
+                        repo.unsafe_git_clone_options,
+                    )
+            allow_unsafe_options = True
             kwargs["separate_git_dir"] = module_abspath
             module_abspath_dir = osp.dirname(module_abspath)
             if not osp.isdir(module_abspath_dir):

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -159,6 +159,8 @@ class Repo:
         "-c",
         # Can install hooks that execute during clone:
         "--template",
+        # Redirects the repository metadata to a caller-controlled path:
+        "--separate-git-dir",
         # Fetches from an additional caller-controlled URI:
         "--bundle-uri",
     ]

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -133,6 +133,7 @@ class TestClone(TestBase):
                 "-vcprotocol.ext.allow=always",
                 f"--template={tmp_dir}",
                 f"--bundle-uri=file://{tmp_dir}",
+                f"--separate-git-dir={tmp_dir / 'git-dir'}",
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
@@ -149,6 +150,7 @@ class TestClone(TestBase):
                 {"c": "protocol.ext.allow=always"},
                 {"template": tmp_dir},
                 {"bundle_uri": f"file://{tmp_dir}"},
+                {"separate_git_dir": tmp_dir / "git-dir"},
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
@@ -258,6 +260,7 @@ class TestClone(TestBase):
                 "-c protocol.ext.allow=always",
                 "-cprotocol.ext.allow=always",
                 "-vcprotocol.ext.allow=always",
+                f"--separate-git-dir={tmp_dir / 'git-dir'}",
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):
@@ -270,6 +273,7 @@ class TestClone(TestBase):
                 {"u": f"touch {tmp_file}"},
                 {"config": "protocol.ext.allow=always"},
                 {"c": "protocol.ext.allow=always"},
+                {"separate_git_dir": tmp_dir / "git-dir"},
             ]
             for unsafe_option in unsafe_options:
                 with self.assertRaises(UnsafeOptionError):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -954,6 +954,7 @@ class TestSubmodule(TestBase):
             source.working_tree_dir,
             osp.join(clone.working_tree_dir, "module"),
             separate_git_dir=osp.join(rwdir, "escaped", "module"),
+            allow_unsafe_options=True,
         )
         with pytest.raises(ValueError, match="submodule name"):
             clone.submodules[0].update(init=True)


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-8mcc-hrx5-hvxc

GHSA-8mcc-hrx5-hvxc reports that clone operations do not classify `--separate-git-dir` as unsafe. This change adds it to the existing clone option denylist, matching the init guard and the documented `allow_unsafe_options` contract.

## Advisory summary

- Severity: High
- Package: GitPython (pip)
- Affected versions: <= 3.1.58
- Patched version: not yet assigned
- CVE: not yet assigned

## Validation

- `test/test_clone.py`: 21 passed, 1 skipped
- Regression coverage includes both `Repo.clone()` and `Repo.clone_from()`, through keyword and multi-option inputs.
- Git baseline: `builtin/clone.c` registers the option and `t/t5601-clone.sh` verifies redirected metadata behavior.