### PR TITLE
fix: harden config parsing boundaries

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -705,7 +705,11 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                     continue
 
                 for v in values:
-                    fp.write(("\t%s = %s\n" % (key, self._value_to_string(v).replace("\n", "\n\t"))).encode(defenc))
+                    value = self._value_to_string(v)
+                    if any(char in value for char in '\n\t\b\\"'):
+                        value = value.replace("\\", "\\\\").replace('"', '\\"')
+                        value = '"%s\\\n"' % value.replace("\n", "\\n").replace("\t", "\\t").replace("\b", "\\b")
+                    fp.write(("\t%s = %s\n" % (key, value)).encode(defenc))
                 # END if key is not __name__
 
         # END section writing

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -270,7 +270,7 @@ class Submodule(IndexObject, TraversableIterableObj):
             raise ValueError("Cannot write blobs of 'historical' submodule configurations")
         # END handle writes of historical submodules
 
-        return SubmoduleConfigParser(fp_module, read_only=read_only)
+        return SubmoduleConfigParser(fp_module, read_only=read_only, merge_includes=False)
 
     def _clear_cache(self) -> None:
         """Clear the possibly changed values."""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -7,6 +7,7 @@ import glob
 import io
 import os
 import os.path as osp
+import subprocess
 import sys
 from unittest import mock
 
@@ -15,7 +16,6 @@ import pytest
 from git import GitConfigParser
 from git.config import _OMD, cp
 from git.util import cwd, rmfile
-
 from test.lib import SkipTest, TestCase, fixture_path, with_rw_directory
 
 _tc_lock_fpaths = osp.join(osp.dirname(__file__), "fixtures/*.lock")
@@ -149,6 +149,46 @@ class TestBase(TestCase):
 
         git_config = GitConfigParser(config_file)
         git_config.read()  # This should not throw an exception
+
+    @with_rw_directory
+    def test_rewriting_multiline_value_does_not_create_option(self, rw_dir):
+        config_path = osp.join(rw_dir, "config")
+        with open(config_path, "wb") as config_file:
+            config_file.write(b'[core]\n\tzzz = "A\\nhooksPath = ../evil-hooks\\\n"\n')
+
+        with GitConfigParser(config_path, read_only=False) as git_config:
+            self.assertEqual(git_config.get_value("core", "zzz"), "A\nhooksPath = ../evil-hooks")
+            git_config.set_value("user", "name", "Test User")
+
+        with GitConfigParser(config_path, read_only=True) as git_config:
+            self.assertEqual(git_config.get_value("core", "zzz"), "A\nhooksPath = ../evil-hooks")
+            self.assertFalse(git_config.has_option("core", "hooksPath"))
+        self.assertEqual(
+            subprocess.run(["git", "config", "--file", config_path, "--get", "core.hooksPath"]).returncode, 1
+        )
+
+    @with_rw_directory
+    def test_writer_escapes_special_characters_without_newline(self, rw_dir):
+        config_path = osp.join(rw_dir, "config")
+        values = {"tab": "\tvalue\t", "backspace": "a\bb", "quote": 'a"b', "backslash": "a\\qb"}
+
+        with GitConfigParser(config_path, read_only=False) as git_config:
+            for key, value in values.items():
+                git_config.set_value("section", key, value)
+
+        with GitConfigParser(config_path, read_only=True) as git_config:
+            for key, value in values.items():
+                self.assertEqual(git_config.get_value("section", key), value)
+                self.assertEqual(
+                    subprocess.run(
+                        ["git", "config", "--file", config_path, "--get", "section.%s" % key],
+                        stdout=subprocess.PIPE,
+                        check=True,
+                    ).stdout,
+                    value.encode() + b"\n",
+                )
+        with open(config_path, "rb") as config_file:
+            self.assertNotIn(b"\x08", config_file.read())
 
     @with_rw_directory
     def test_set_value_rejects_config_injection(self, rw_dir):

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1208,6 +1208,22 @@ class TestSubmodule(TestBase):
         assert len(parent.submodules) == 0
 
     @with_rw_directory
+    def test_gitmodules_does_not_merge_includes(self, rwdir):
+        parent = git.Repo.init(rwdir)
+        secret_path = osp.join(rwdir, "secret")
+        with open(secret_path, "w", encoding="utf-8") as secret:
+            secret.write("not git config\n")
+        with open(osp.join(rwdir, ".gitmodules"), "w", encoding="utf-8") as modules:
+            modules.write('[submodule "module"]\n')
+            modules.write("\tpath = module\n")
+            modules.write("\turl = https://example.com/module.git\n")
+            modules.write("[include]\n")
+            modules.write("\tpath = %s\n" % secret_path)
+
+        parser = Submodule._config_parser(parent, None, read_only=True)
+        self.assertEqual(parser.get_value('submodule "module"', "path"), "module")
+
+    @with_rw_directory
     def test_remove_norefs(self, rwdir):
         parent = git.Repo.init(osp.join(rwdir, "parent"))
         sm_name = "mymodules/myname"


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Preserve parsed multiline Git config values when an unrelated write reserializes the file, keeping each value structurally intact.
- Disable include merging for `.gitmodules`, so repository-controlled submodule configuration cannot cause unrelated local files to be opened.

## Advisories

- https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-284h-m62q-gf8w (`GHSA-284h-m62q-gf8w`)
- https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-7833-fr7j-v32q (`GHSA-7833-fr7j-v32q`)

Both advisories remain private/under triage, so reproduction and exploit details are intentionally omitted here.

## Advisory summary

### GHSA-284h-m62q-gf8w

- Severity: High
- Package: `GitPython` (`pip`)
- Affected versions: `<= 3.1.58`
- Patched versions: not yet assigned
- CVE: not yet assigned

### GHSA-7833-fr7j-v32q

- Severity: High
- Package: `GitPython` (`pip`)
- Affected versions: `<= 3.1.58`
- Patched versions: not yet assigned
- CVE: not yet assigned

## Baselines

- Git `config.c` at `cf5497b14c5a` serializes embedded LF with an escape rather than as a physical config line.
- Existing GitPython hardening in `41ecc6a4` disables include merging for another write-sensitive config parser.

## Validation

- Focused regressions for both advisories
- `pytest -q test/test_config.py` (35 passed, 2 skipped)
- `pytest -q` (passed after each commit)
- Targeted Ruff lint and format checks
- `git diff --check`