### PR TITLE
Require explicit opt-in for filesystem diffs

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -8,6 +8,7 @@ Changelog
 Security fixes for
 
 * https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-g5vv-9gxw-82hx
+* https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-whh4-5q6c-9v3x
 
 If you can, also try and provide feedback on the upcoming v4 branch
 https://github.com/gitpython-developers/GitPython/pull/2177 - patches welcome.

--- a/git/diff.py
+++ b/git/diff.py
@@ -239,8 +239,8 @@ class Diffable:
             to be read and diffed.
 
         :param allow_unsafe_options:
-            If ``True``, allow options such as ``--output`` and ``-O`` that can write to
-            or read from arbitrary filesystem paths.
+            If ``True``, allow options such as ``--output``, ``--no-index``, and ``-O``
+            that can write to or read from arbitrary filesystem paths.
 
         :param kwargs:
             Additional arguments passed to :manpage:`git-diff(1)`, such as ``R=True`` to

--- a/git/repo/base.py
+++ b/git/repo/base.py
@@ -209,6 +209,8 @@ class Repo:
     ]
 
     unsafe_git_diff_options = unsafe_git_revision_options + [
+        # Treats path operands as arbitrary filesystem paths.
+        "--no-index",
         # Reads caller-controlled order patterns from an arbitrary file.
         "-O",
         "--orderfile",

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -412,6 +412,17 @@ class TestDiff(TestBase):
         commit.diff(output=allowed_target, allow_unsafe_options=True)
         self.assertTrue(osp.isfile(allowed_target))
 
+    def test_diff_rejects_no_index(self):
+        calls = (
+            lambda: self.rorepo.head.commit.diff(no_index=True),
+            lambda: self.rorepo.head.commit.diff(other="--no-index"),
+            lambda: self.rorepo.index.diff(None, no_index=True),
+            lambda: self.rorepo.index.diff("--no-index"),
+        )
+        for call in calls:
+            with self.assertRaises(UnsafeOptionError):
+                call()
+
     def test_diff_interface(self):
         """Test a few variations of the main diff routine."""
         assertion_map = {}


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-whh4-5q6c-9v3x

GHSA-whh4-5q6c-9v3x reports a repository-boundary bypass in the high-level diff API. This change requires callers to explicitly opt in before diff paths may use filesystem-wide semantics. Reproduction mechanics are intentionally omitted while the advisory is unpublished.

## Advisory summary

- Severity: medium
- Package: GitPython (pip)
- Affected range: `= 3.1.59`
- Patched versions: none published
- CVE: none assigned

## Changes

- Classify `--no-index` as an unsafe diff option.
- Cover keyword and raw-option spellings through commit and index APIs.
- Clarify the existing explicit opt-in documentation.

## Validation

- Focused diff security tests: 2 passed.
- Complete `test/test_diff.py`: 25 passed, 1 unrelated local-environment failure in staged conflict reporting.
- Ruff check and format checks passed.
- `git diff --check` passed.
- Git baseline: Git 2.50.1 documents filesystem operand behavior in `Documentation/git-diff.adoc` and implements it in `builtin/diff.c`.
- Post-commit Codex review was attempted once for `14200584` but the CLI usage allowance was exhausted before review began.