### PR TITLE
Reject unsafe submodule checkout paths

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+3.1.62
+======
+
+Security fixes for
+
+* https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-59cr-6r3x-644w
+
+If you can, also try and provide feedback on the upcoming v4 branch
+https://github.com/gitpython-developers/GitPython/pull/2177 - patches welcome.
+
+See the following for all changes.
+https://github.com/gitpython-developers/GitPython/releases/tag/3.1.62
+
 3.1.61
 ======
 

--- a/git/objects/submodule/base.py
+++ b/git/objects/submodule/base.py
@@ -414,6 +414,18 @@ class Submodule(IndexObject, TraversableIterableObj):
 
         return path
 
+    @property
+    def abspath(self) -> PathLike:
+        root = self.repo.working_tree_dir
+        if root is None:
+            return super().abspath
+        path = root
+        for component in os.fspath(self._to_relative_path(self.repo, self.path)).split("/"):
+            path = join_path_native(path, component)
+            if osp.islink(path):
+                raise ValueError("Submodule checkout path %r contains a symbolic link" % self.path)
+        return path
+
     @classmethod
     def _write_git_file_and_module_config(cls, working_tree_dir: PathLike, module_abspath: PathLike) -> None:
         """Write a ``.git`` file containing a (preferably) relative path to the actual

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -1369,6 +1369,46 @@ class TestSubmodule(TestBase):
             osp.join(Repo.working_tree_dir + "-other", "module"),
         )
 
+    @with_rw_directory
+    def test_update_rejects_checkout_path_outside_parent(self, rwdir):
+        parent = git.Repo.init(osp.join(rwdir, "parent"))
+        submodule = Submodule(
+            parent,
+            Submodule.NULL_BIN_SHA,
+            name="module",
+            path=osp.join("..", "outside"),
+            url="unused",
+        )
+
+        with mock.patch.object(Submodule, "_clone_repo", side_effect=AssertionError("clone attempted")):
+            with pytest.raises(ValueError, match="is not in repository"):
+                submodule.update(init=True)
+
+    @with_rw_directory
+    def test_update_rejects_checkout_path_through_symlink(self, rwdir):
+        parent = git.Repo.init(osp.join(rwdir, "parent"))
+        os.mkdir(osp.join(parent.working_tree_dir, "target"))
+        os.symlink("target", osp.join(parent.working_tree_dir, "link"))
+        submodule = Submodule(
+            parent,
+            Submodule.NULL_BIN_SHA,
+            name="module",
+            path=osp.join("link", "module"),
+            url="unused",
+        )
+
+        with mock.patch.object(Submodule, "_clone_repo", side_effect=AssertionError("clone attempted")):
+            with pytest.raises(ValueError, match="contains a symbolic link"):
+                submodule.update(init=True)
+
+    @with_rw_directory
+    def test_update_rejects_checkout_path_at_parent_root(self, rwdir):
+        parent = git.Repo.init(osp.join(rwdir, "parent"))
+        submodule = Submodule(parent, Submodule.NULL_BIN_SHA, name="module", path=".", url="unused")
+
+        with pytest.raises(ValueError, match="must not be the repository root"):
+            submodule.update(init=True)
+
     @skipUnless(sys.platform == "win32", "Specifically for Windows.")
     @with_rw_directory
     def test_to_relative_path_windows_path_kinds(self, rwdir):


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Confine submodule checkout paths to the parent repository before filesystem operations. The shared absolute-path accessor now rejects parent traversal, paths resolving through symlinks outside the worktree, and paths resolving to the worktree root.

## Advisory

https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-59cr-6r3x-644w

### Advisory summary

- GHSA: GHSA-59cr-6r3x-644w
- Severity: Medium
- Package: GitPython (pip)
- Affected versions: <= 3.1.61
- Patched version: not yet assigned
- CVE: not assigned

## Validation

- `python -m pytest test/test_submodule.py -q` — 45 passed, 3 skipped, 1 xfailed
- `pre-commit run --files git/objects/submodule/base.py test/test_submodule.py`
- `mypy git/objects/submodule/base.py`
- `git diff --check`

Git behavior reference: commit `e8d0608944`, `submodule.c::validate_submodule_path()`, and `t/t7423-submodule-symlinks.sh` reject every existing symlink component before submodule update. `read-cache.c::verify_path_internal()` rejects parent-traversing index paths.

## Commits

- `f67ab162` Reject submodule checkout paths outside the repository
- `07091717` Reject submodule paths through outside symlinks
- `914a4ae8` Keep submodule checkouts away from the worktree root
- `dcd956a6` Match Git submodule symlink validation
