### PR TITLE
Read git's yes/no and on/off booleans in get_value

### DIFF
--- a/git/config.py
+++ b/git/config.py
@@ -956,11 +956,16 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 continue
         # END for each numeric type
 
-        # Try boolean values as git uses them.
+        # Try boolean values as git uses them. git accepts yes/no and on/off as
+        # well as true/false (git_parse_maybe_bool_text in parse.c), and so does
+        # ConfigParser.getboolean on this class, so only get_value lagged behind.
+        # Leaving them as strings was worse than merely inexact: "no" and "off"
+        # are non-empty, so a caller testing the result got True for a value git
+        # reads as false.
         vl = valuestr.lower()
-        if vl == "false":
+        if vl in ("false", "no", "off"):
             return False
-        if vl == "true":
+        if vl in ("true", "yes", "on"):
             return True
 
         if not isinstance(valuestr, str):

--- a/git/config.py
+++ b/git/config.py
@@ -10,36 +10,34 @@ __all__ = ["GitConfigParser", "SectionConstraint"]
 import abc
 import configparser as cp
 import fnmatch
-from functools import wraps
 import inspect
-from io import BufferedReader, IOBase
 import logging
 import os
 import os.path as osp
 import re
 import sys
-
-from git.compat import defenc, force_text
-from git.util import LockFile
+from functools import wraps
+from io import BufferedReader, IOBase
 
 # typing-------------------------------------------------------
-
 from typing import (
+    IO,
+    TYPE_CHECKING,
     Any,
     Callable,
-    Generic,
-    IO,
-    List,
     Dict,
+    Generic,
+    List,
     Sequence,
-    TYPE_CHECKING,
     Tuple,
     TypeVar,
     Union,
     cast,
 )
 
-from git.types import Lit_config_levels, ConfigLevels_Tup, PathLike, assert_never, _T
+from git.compat import defenc, force_text
+from git.types import _T, ConfigLevels_Tup, Lit_config_levels, PathLike, assert_never
+from git.util import LockFile
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -956,12 +954,7 @@ class GitConfigParser(cp.RawConfigParser, metaclass=MetaParserBuilder):
                 continue
         # END for each numeric type
 
-        # Try boolean values as git uses them. git accepts yes/no and on/off as
-        # well as true/false (git_parse_maybe_bool_text in parse.c), and so does
-        # ConfigParser.getboolean on this class, so only get_value lagged behind.
-        # Leaving them as strings was worse than merely inexact: "no" and "off"
-        # are non-empty, so a caller testing the result got True for a value git
-        # reads as false.
+        # Try boolean values as git uses them.
         vl = valuestr.lower()
         if vl in ("false", "no", "off"):
             return False

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -167,6 +167,38 @@ class TestBase(TestCase):
             key = "co" if section == "alias" else "k"
             self.assertEqual(config.get_value(section, key), expected)
 
+    def test_get_value_reads_git_boolean_spellings(self):
+        # git accepts yes/no and on/off as well as true/false, and getboolean on
+        # this class already did. get_value returned them as strings, so "no" and
+        # "off" arrived as non-empty (truthy) values for a caller testing them.
+        cases = [
+            (b"true", True),
+            (b"TRUE", True),
+            (b"yes", True),
+            (b"Yes", True),
+            (b"on", True),
+            (b"On", True),
+            (b"false", False),
+            (b"no", False),
+            (b"off", False),
+            (b"Off", False),
+        ]
+        for raw, expected in cases:
+            config_file = io.BytesIO(b"[core]\n\tflag = " + raw + b"\n")
+            config_file.name = "boolean_spellings.config"
+            config = GitConfigParser(config_file)
+            config.read()
+            self.assertIs(config.get_value("core", "flag"), expected, raw.decode())
+            # The two accessors must not disagree about the same value.
+            self.assertIs(config.getboolean("core", "flag"), expected, raw.decode())
+
+        # A value that is not a boolean at all still comes back untouched.
+        config_file = io.BytesIO(b"[core]\n\tflag = meld\n")
+        config_file.name = "boolean_spellings.config"
+        config = GitConfigParser(config_file)
+        config.read()
+        self.assertEqual(config.get_value("core", "flag"), "meld")
+
     @with_rw_directory
     def test_comment_backslash_does_not_continue_value(self, rw_dir):
         config_path = osp.join(rw_dir, "config")


### PR DESCRIPTION
> **This pull request was written by Claude Code (Claude Opus 5) working through @rawsun007's account**, identified here per CONTRIBUTING.md's "Prevent agent impersonation". The facts below were measured locally; @rawsun007 has not reviewed the diff line by line yet and will answer review comments himself.

`GitConfigParser` disagrees with itself about the same file. `getboolean` (from `ConfigParser`) accepts all of git's boolean spellings; `get_value` handled only `true`/`false`, under a comment saying it tries "boolean values as git uses them":

| value | `get_value()` | `getboolean()` | `git config --type=bool` |
| --- | --- | --- | --- |
| `yes` | `'yes'` | `True` | true |
| `no` | `'no'` | `False` | false |
| `on` | `'on'` | `True` | true |
| `off` | `'off'` | `False` | false |
| `true` / `false` | `True` / `False` | same | same |

Returning them as strings is worse than merely inexact: `"no"` and `"off"` are non-empty, so

```python
if repo.config_reader().get_value("core", "someflag"):
```

is **True** for a value git reads as false, and nothing raises.

`_string_to_value` now recognises the same spellings `getboolean` does. Non-boolean values are untouched (`"meld"` stays a string) and numeric values keep their current behaviour.

Deliberately not included: `get_value` also diverges on numeric bases and suffixes — `"0x10"` and `"1k"` come back as strings where git reads 16 and 1024, and `"010"` becomes 10 where git reads octal 8. Those change a value rather than its type, so they belong in their own commit; happy to send that separately.

Validation: `test_get_value_reads_git_boolean_spellings` covers the ten spellings and asserts the two accessors agree — it fails on the parent commit. `test/test_config.py` passes (40 passed, 2 skipped). `ruff check` and `ruff format --check` clean at the repo's line length. `test/test_repo.py` errors on my clone because `init-tests-after-clone.sh` has not been run; unchanged by this commit.
