### PR TITLE
fix: validate checkout positional reference options

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -8,6 +8,7 @@ Changelog
 Security fixes for
 
 * https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-gq48-pqfc-9p58
+* https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-23mf-xhv8-69c2
 
 If you can, also try and provide feedback on the upcoming v4 branch
 https://github.com/gitpython-developers/GitPython/pull/2177 - patches welcome.

--- a/git/refs/head.py
+++ b/git/refs/head.py
@@ -283,7 +283,7 @@ class Head(Reference):
         """
         if not allow_unsafe_options:
             Git.check_unsafe_options(
-                options=Git._option_candidates([], kwargs),
+                options=Git._option_candidates([self], kwargs),
                 unsafe_options=Git.unsafe_git_pathspec_from_file_options,
             )
         kwargs["f"] = force

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -289,6 +289,25 @@ class TestRefs(TestBase):
                         pathspec_file_nul=True,
                         **{option_name: str(pathspecs)},
                     )
+            for option_name in ("--pathspec-from-file", "--pathspec-from"):
+                branch = Head(rw_repo, f"refs/heads/{option_name}={pathspecs}")
+                with self.assertRaises(UnsafeOptionError):
+                    branch.checkout()
+
+    def test_cloned_head_checkout_rejects_pathspec_from_file(self):
+        with tempfile.TemporaryDirectory() as tdir:
+            base_dir = Path(tdir)
+            with self._repo_with_initial_commit(base_dir) as source:
+                branch = source.create_head("--pathspec-from-file=pathspecs")
+                source.head.reference = branch
+                with Repo.clone_from(source.working_tree_dir, base_dir / "clone") as cloned:
+                    (base_dir / "clone" / "pathspecs").write_text("unmatched-private-content\n", encoding="utf-8")
+                    assert cloned.active_branch.name == branch.name
+                    with self.assertRaises(UnsafeOptionError):
+                        cloned.active_branch.checkout()
+                    with self.assertRaises(GitCommandError) as error:
+                        cloned.active_branch.checkout(allow_unsafe_options=True)
+                    assert "unmatched-private-content" in str(error.exception)
 
     @with_rw_repo("HEAD")
     def test_head_reset_rejects_pathspec_from_file(self, rw_repo):


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [ ] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

`Head.checkout()` now includes its positional reference in the existing unsafe-option validation. This keeps validation consistent for keyword arguments and reference names, including references obtained from a clone, while preserving explicit opt-in and normal branch switching.

## Advisory summary

[GHSA-23mf-xhv8-69c2](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-23mf-xhv8-69c2): severity high; affected package PyPI GitPython, reported range `<= 3.1.62`. No patched version or CVE is assigned in the advisory. The advisory is unpublished; this description omits its reproduction details.

## Validation

- Both new regression paths failed before the fix.
- All 30 tests in `test/test_refs.py` pass (Python 3.12.14, Apple Git 2.50.1), including explicit opt-in, ordinary checkout, and detached HEAD behavior.
- `git diff --check` passes.
- Git behavior reference: local Git checkout `1630431f326e15fcde608827b5ff38422528eb59`, `builtin/checkout.c` pathspec-file handling. A leading argument separator would change branch checkout into path checkout, so this change reuses the existing validation helper.
